### PR TITLE
ci: restrict the workflow token to read-only in three workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,15 @@ name: CI
 # runs real work (the `integration` matrix interleaves a Rust lane and a
 # frontend lane; its job-level gate fires only when BOTH lanes are idle).
 
+# Least-privilege GITHUB_TOKEN. Without this block the token inherits the
+# repository or organisation default, which may grant write scopes these jobs
+# never use. Every job here only reads the repo and uploads artifacts, and
+# `actions/upload-artifact` needs no `contents: write` -- it writes to the
+# Actions artifact store, not to git. Mirrors release-gate.yml, which already
+# declares `contents: read` (astro-plan-j14r).
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,6 +19,15 @@ name: Coverage
 # here hard-fails the job. The workspace has no executable doctests to
 # measure either. Re-add it behind `cargo +nightly llvm-cov` if that changes.
 
+# Least-privilege GITHUB_TOKEN. Without this block the token inherits the
+# repository or organisation default, which may grant write scopes these jobs
+# never use. Every job here only reads the repo and uploads artifacts, and
+# `actions/upload-artifact` needs no `contents: write` -- it writes to the
+# Actions artifact store, not to git. Mirrors release-gate.yml, which already
+# declares `contents: read` (astro-plan-j14r).
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -120,6 +120,15 @@
 
 name: Real-UI E2E (thirtyfour + nextest + tauri-plugin-webdriver)
 
+# Least-privilege GITHUB_TOKEN. Without this block the token inherits the
+# repository or organisation default, which may grant write scopes these jobs
+# never use. Every job here only reads the repo and uploads artifacts, and
+# `actions/upload-artifact` needs no `contents: write` -- it writes to the
+# Actions artifact store, not to git. Mirrors release-gate.yml, which already
+# declares `contents: read` (astro-plan-j14r).
+permissions:
+  contents: read
+
 on:
   pull_request:
   # Runs the shards on every main push, not just PRs (issue #1203: before


### PR DESCRIPTION
## Summary

- `ci.yml`, `e2e.yml`, and `coverage.yml` declared no `permissions` block, so `GITHUB_TOKEN` inherited the repository or organisation default — potentially write scopes they never use. All three now declare `contents: read`, matching `release-gate.yml`.

## Why read-only is sufficient — verified, not assumed

The only write-shaped usage across all three is `actions/upload-artifact`: four sites in `e2e.yml`, one in `coverage.yml`, none in `ci.yml`. That writes to the **Actions artifact store, not to git**, so it needs no `contents: write`.

Also checked: **no job** in any of the three declares its own `permissions` block that a workflow-level default could conflict with, and **no step references `GITHUB_TOKEN`** at all.

## Verification

Each file was parsed with a real YAML parser afterwards rather than reviewed by eye — a malformed workflow fails at dispatch time, which is an expensive place to discover a typo. All three parse, with `permissions: {contents: read}` and job counts intact (8, 13, 2).

## Spec Context

Found by CodeRabbit on #1640 and confirmed pre-existing rather than introduced there.

Tracks-Bead: astro-plan-j14r
Merge-Bead: astro-plan-a6c7
