### PR TITLE
fix: calibration matching finds no masters for any session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "metadata_core",
  "metadata_fits",
  "metadata_xisf",
+ "persistence_calibration",
  "persistence_core",
  "persistence_lifecycle",
  "persistence_plans",

--- a/crates/app/core/tests/ingest_sessions_integration.rs
+++ b/crates/app/core/tests/ingest_sessions_integration.rs
@@ -14,6 +14,10 @@ use std::path::Path;
 
 use audit::bus::EventBus;
 use audit::event_bus::{PlanApplyingCompleted, Source, TOPIC_PLAN_APPLYING_COMPLETED};
+use contracts_core::calibration_match::{
+    CalibrationMatchSuggestRequest, CalibrationType, SUGGEST_CONTRACT_VERSION,
+};
+use persistence_inbox::repositories::q_inbox;
 use persistence_plans::repositories::plans as plans_repo;
 use targeting_resolver::cache::upsert_resolved;
 use targeting_resolver::{
@@ -73,6 +77,11 @@ fn write_fits(
     write_card(&format!("{:<80}", "GAIN    = 100"));
     write_card(&format!("{:<80}", "XBINNING= 1"));
     write_card(&format!("{:<80}", "YBINNING= 1"));
+    // Remaining calibration-matching dimensions: `OFFSET` is a dark/bias
+    // hard rule, `EXPTIME`/`SET-TEMP` the soft ones (astro-plan-siyk).
+    write_card(&format!("{:<80}", "OFFSET  = 50"));
+    write_card(&format!("{:<80}", "EXPTIME = 300.0"));
+    write_card(&format!("{:<80}", "SET-TEMP= -10.0"));
     block[idx * 80..idx * 80 + 3].copy_from_slice(b"END");
     let mut f = std::fs::File::create(path).unwrap();
     f.write_all(&block).unwrap();
@@ -518,5 +527,113 @@ async fn ingested_session_total_size_is_sum_of_real_frame_sizes() {
     assert_eq!(
         detail.total_size_bytes, expected_total,
         "detail total must match the same real sum"
+    );
+}
+
+// ── astro-plan-siyk: real ingest populates the calibration-matching fingerprint ──
+
+/// The real ingest path must record the session's calibration-matching
+/// dimensions, and `calibration.match.suggest` must then return candidates.
+///
+/// This drives the production writer end to end — a plan-apply event through
+/// the real plan listener over a real FITS file — rather than seeding
+/// `acquisition_fingerprint` directly. A fixture that inserted the row itself
+/// (or a `SessionInfo` built in memory) passed for 2.5 months while no
+/// production writer existed at all: `load_session` returned an all-`None`
+/// `SessionInfo` and `hard_rule_numeric` excluded every master.
+#[tokio::test]
+async fn ingested_session_matches_a_calibration_master() {
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+    let tmp = tempfile::tempdir().unwrap();
+    let root_id = "src-raw";
+    register_source(pool, root_id, tmp.path().to_str().unwrap()).await;
+    upsert_resolved(pool, &m31()).await.unwrap();
+
+    // `write_fits` emits GAIN=100 / OFFSET=50 / EXPTIME=300 / SET-TEMP=-10.
+    write_fits(
+        tmp.path(),
+        "light.fits",
+        "Light Frame",
+        Some("M 31"),
+        Some("Ha"),
+        Some("2026-06-21T22:00:00"),
+    );
+    build_applied_plan(pool, "plan-siyk", root_id, &[("light.fits", "move", true)]).await;
+
+    app_core::inbox::plan_listener::start_inbox_plan_listener(
+        pool.clone(),
+        &bus,
+        targeting_resolver::simbad::ResolveCache::in_memory().unwrap(),
+    );
+    publish_applied(&bus, "plan-siyk").await;
+
+    let session_id = support::poll_until(
+        || async {
+            sqlx::query_scalar::<_, String>("SELECT id FROM acquisition_fingerprint")
+                .fetch_optional(pool)
+                .await
+                .unwrap()
+        },
+        "acquisition_fingerprint row never appeared after plan-siyk apply-completed event",
+    )
+    .await;
+
+    // The dimensions the dark hard rules read must be present, not NULL.
+    let dims: (Option<f64>, Option<f64>, Option<f64>, Option<f64>) =
+        sqlx::query_as("SELECT gain, offset_val, exposure_s, temp_c FROM acquisition_fingerprint")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(dims.0, Some(100.0), "GAIN must reach the fingerprint (hard rule, every kind)");
+    assert_eq!(dims.1, Some(50.0), "OFFSET must reach the fingerprint (dark hard rule)");
+    assert_eq!(dims.2, Some(300.0), "EXPTIME must reach the fingerprint");
+    assert_eq!(dims.3, Some(-10.0), "SET-TEMP must reach the fingerprint");
+
+    // A dark master with the same gain/offset, seeded through the same
+    // production insert the master-registration path uses.
+    let master_id = "master-siyk";
+    sqlx::query(
+        "INSERT INTO calibration_session (id, session_key, frame_ids, kind, created_at)
+         VALUES (?, 'dark-dark', '[]', 'dark', '2026-06-20T00:00:00Z')",
+    )
+    .bind(master_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    q_inbox::insert_calibration_fingerprint(
+        pool,
+        &q_inbox::InsertCalibrationFingerprint {
+            calibration_session_id: master_id,
+            calibration_type: "dark",
+            exposure_s: Some(300.0),
+            filter_name: None,
+            gain: Some(100.0),
+            offset_val: Some(50.0),
+            temp_c: Some(-10.0),
+            binning: Some("1x1"),
+            optic_train: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let resp = app_core::calibration::suggest(
+        pool,
+        CalibrationMatchSuggestRequest {
+            contract_version: SUGGEST_CONTRACT_VERSION.to_owned(),
+            request_id: "req-siyk".to_owned(),
+            session_id: session_id.clone(),
+            calibration_types: Some(vec![CalibrationType::Dark]),
+        },
+    )
+    .await
+    .expect("suggest must not error");
+
+    assert_eq!(resp.status, "success", "suggest failed: {:?}", resp.error);
+    let matches = resp.matches.expect("suggest must return a matches list");
+    assert!(
+        matches.iter().any(|m| m.master_id == master_id),
+        "a production-shaped ingested session must match a compatible dark master; got {matches:?}"
     );
 }

--- a/crates/app/inbox/src/plan_listener.rs
+++ b/crates/app/inbox/src/plan_listener.rs
@@ -352,9 +352,11 @@ async fn register_master_if_applicable(pool: &SqlitePool, plan_id: &str) -> Resu
     // real calibration master's `root_id` stayed `NULL` (silently decoded as
     // `""` by sqlx-sqlite, masking the gap from a plain string comparison).
     let mut resolved_root_id: Option<String> = None;
+    let mut dims = MasterFingerprintDims::default();
     let frame_id = match resolve_applied_frame_path(pool, plan_id).await {
         Ok(Some((root_id, relative_path))) => {
             let outcome = write_calibration_frame_record(pool, &root_id, &relative_path).await;
+            dims = read_master_fingerprint_dims(pool, &root_id, &relative_path).await;
             resolved_root_id = Some(root_id);
             match outcome {
                 Ok(id) => Some(id),
@@ -399,17 +401,7 @@ async fn register_master_if_applicable(pool: &SqlitePool, plan_id: &str) -> Resu
     .await
     .map_err(|e| format!("insert calibration_session: {e}"))?;
 
-    q_inbox::insert_calibration_fingerprint(
-        pool,
-        &InsertCalibrationFingerprint {
-            calibration_session_id: &session_id,
-            calibration_type: cal_kind,
-            exposure_s: item.master_exposure_s,
-            filter_name: item.master_filter.as_deref(),
-        },
-    )
-    .await
-    .map_err(|e| format!("insert calibration_fingerprint: {e}"))?;
+    write_master_fingerprint(pool, &session_id, cal_kind, &item, &dims).await?;
 
     // F0 invalidate-after-commit contract (crates/app/cache/src/lib.rs): both
     // inserts above have committed (sqlx pool auto-commits per statement; no
@@ -456,6 +448,87 @@ async fn resolve_applied_frame_path(
         (_, Some(r)) => Some((r, row.from_relative_path)),
         _ => None,
     })
+}
+
+/// Write the master's `calibration_fingerprint` row from the detector's
+/// findings plus the frame's own header dimensions.
+async fn write_master_fingerprint(
+    pool: &SqlitePool,
+    session_id: &str,
+    cal_kind: &str,
+    item: &inbox_repo::InboxItemRow,
+    dims: &MasterFingerprintDims,
+) -> Result<(), String> {
+    q_inbox::insert_calibration_fingerprint(
+        pool,
+        &InsertCalibrationFingerprint {
+            calibration_session_id: session_id,
+            calibration_type: cal_kind,
+            // The detector's exposure wins when present (it already reconciled
+            // filename and header evidence); the header supplies it otherwise.
+            exposure_s: item.master_exposure_s.or(dims.exposure_s),
+            filter_name: item.master_filter.as_deref(),
+            gain: dims.gain,
+            offset_val: dims.offset_val,
+            temp_c: dims.temp_c,
+            binning: dims.binning.as_deref(),
+            optic_train: dims.optic_train.as_deref(),
+        },
+    )
+    .await
+    .map_err(|e| format!("insert calibration_fingerprint: {e}"))
+}
+
+/// Calibration-matching dimensions read from a master frame's own header.
+#[derive(Debug, Default)]
+struct MasterFingerprintDims {
+    gain: Option<f64>,
+    offset_val: Option<f64>,
+    exposure_s: Option<f64>,
+    temp_c: Option<f64>,
+    binning: Option<String>,
+    optic_train: Option<String>,
+}
+
+/// Read the applied master frame's header for the dimensions
+/// `calibration_fingerprint` matches on (astro-plan-siyk).
+///
+/// An unreadable file yields all-`None` rather than an error: master
+/// registration must still record the session, and the resulting fingerprint
+/// simply matches nothing until re-derived.
+async fn read_master_fingerprint_dims(
+    pool: &SqlitePool,
+    root_id: &str,
+    relative_path: &str,
+) -> MasterFingerprintDims {
+    let Ok(Some(root_path)) =
+        app_core_targets::ingest_sessions::ensure_library_root(pool, root_id).await
+    else {
+        return MasterFingerprintDims::default();
+    };
+    let abs_path = std::path::Path::new(&root_path).join(relative_path);
+    let Ok(meta) = app_core_targets::metadata_cache::cached_extract(&abs_path) else {
+        return MasterFingerprintDims::default();
+    };
+
+    let binning = match (meta.x_binning.as_deref(), meta.y_binning.as_deref()) {
+        (Some(x), Some(y)) => Some(format!("{}x{}", x.trim(), y.trim())),
+        (Some(x), None) => Some(x.trim().to_owned()),
+        _ => None,
+    };
+
+    MasterFingerprintDims {
+        gain: meta.gain.as_deref().and_then(metadata_core::parse_f64),
+        offset_val: meta.offset.and_then(|o| i32::try_from(o).ok()).map(f64::from),
+        exposure_s: meta.exposure.as_deref().and_then(metadata_core::parse_f64),
+        temp_c: meta.set_temp_c.or(meta.ccd_temp_c),
+        binning,
+        optic_train: sessions::optic_train_key(
+            meta.telescop.as_deref(),
+            meta.instrume.as_deref(),
+            meta.focal_length_mm,
+        ),
+    }
 }
 
 /// Write the calibration master's `file_record` with its real on-disk size

--- a/crates/app/targets/Cargo.toml
+++ b/crates/app/targets/Cargo.toml
@@ -16,6 +16,7 @@ domain_core = { path = "../../domain/core" }
 metadata_core = { path = "../../metadata/core" }
 metadata_fits = { path = "../../metadata/fits" }
 metadata_xisf = { path = "../../metadata/xisf" }
+persistence_calibration = { path = "../../persistence/calibration" }
 persistence_core = { path = "../../persistence/core", features = ["test-fixture"] }
 persistence_lifecycle = { path = "../../persistence/lifecycle" }
 persistence_plans = { path = "../../persistence/plans" }

--- a/crates/app/targets/src/ingest_sessions.rs
+++ b/crates/app/targets/src/ingest_sessions.rs
@@ -66,6 +66,7 @@ use std::sync::Arc;
 
 use audit::EventBus;
 use metadata_core::RawFileMetadata;
+use persistence_calibration::repositories::q_calibration;
 use persistence_lifecycle::repositories::first_run;
 use persistence_plans::repositories::plans as plans_repo;
 use persistence_plans::repositories::projects as repo_projects;
@@ -262,6 +263,13 @@ async fn ingest_light_frame(
         tracing::warn!(session_id, "ingest: failed to backfill session geometry: {e:?}");
     }
 
+    // Record this frame's calibration-matching dimensions on the session
+    // (astro-plan-siyk). Same error posture and null semantics as the
+    // geometry backfill above.
+    if let Err(e) = backfill_session_fingerprint(pool, &session_id, &meta).await {
+        tracing::warn!(session_id, "ingest: failed to backfill session fingerprint: {e:?}");
+    }
+
     // F-Framing-10: bind this session to the attribution pick recorded on
     // the confirming plan, if any — the earliest point a real session id
     // exists to add as a framing member. Logged, never propagated (same
@@ -325,6 +333,70 @@ async fn backfill_session_geometry(
         pointing_dec_deg,
         rotation_deg,
         optic_train_key.as_deref(),
+    )
+    .await
+    .map_err(db_err)
+}
+
+/// Record this frame's calibration-matching dimensions on the session's
+/// `acquisition_fingerprint` row (astro-plan-siyk).
+///
+/// Without this row `load_session` yields an all-`None` `SessionInfo`, and
+/// `calibration_core::rules::hard_rule_numeric` excludes every master because
+/// it requires both sides present — so calibration matching returned
+/// `no_match` for every ingested session.
+///
+/// The row is keyed by session id and accumulated across the session's frames.
+/// Conflict resolution is first-non-null-wins, delegated to the repository's
+/// `COALESCE` upsert: it mirrors `backfill_session_geometry` and
+/// `upsert_session`'s `root_id`, and matches the fact that `session_key`
+/// already partitions sessions by gain/filter/binning, so a frame that
+/// disagrees on a hard dimension normally lands in a different session.
+async fn backfill_session_fingerprint(
+    pool: &SqlitePool,
+    session_id: &str,
+    meta: &RawFileMetadata,
+) -> Result<(), ContractError> {
+    let binning = binning_of(meta);
+    let filter = meta.filter.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    let optic_train = sessions::optic_train_key(
+        meta.telescop.as_deref(),
+        meta.instrume.as_deref(),
+        meta.focal_length_mm,
+    );
+
+    // Sensor set-point first: it is the temperature a calibration master is
+    // matched on, with the measured CCD reading as the fallback.
+    let temp_c = meta.set_temp_c.or(meta.ccd_temp_c);
+
+    let has_exposure_start_utc = meta.date_obs.as_deref().is_some_and(|d| !d.trim().is_empty());
+    let observing_night_date = sessions::observing_night(
+        parse_date_obs(meta.date_obs.as_deref()),
+        Some(&ObserverContext { utc_offset: UtcOffset::UTC }),
+    )
+    .ok();
+
+    q_calibration::upsert_acquisition_fingerprint(
+        pool,
+        &q_calibration::UpsertAcquisitionFingerprint {
+            session_id,
+            gain: meta.gain.as_deref().and_then(metadata_core::parse_f64),
+            // Sensor offsets are small integers; a value beyond f64 exactness is
+            // not a real header, so it is dropped rather than rounded.
+            offset_val: meta.offset.and_then(|o| i32::try_from(o).ok()).map(f64::from),
+            exposure_s: meta.exposure.as_deref().and_then(metadata_core::parse_f64),
+            temp_c,
+            filter_name: filter,
+            rotation_deg: meta.rotator_angle_deg,
+            binning: (!binning.is_empty()).then_some(binning.as_str()),
+            optic_train: optic_train.as_deref(),
+            observing_night_date: observing_night_date.as_deref(),
+            // R11: ingest always uses the UTC observing-night fallback, so no
+            // frame can assert a real observer location (mirrors
+            // `derive_session_key`'s `has_observer_location = false`).
+            has_observer_location: false,
+            has_exposure_start_utc,
+        },
     )
     .await
     .map_err(db_err)

--- a/crates/calibration/core/src/lib.rs
+++ b/crates/calibration/core/src/lib.rs
@@ -378,10 +378,16 @@ mod tests {
     }
 
     #[test]
-    fn suggest_finds_matches_without_acquisition_fingerprint() {
-        // #867 regression: a session with no fingerprint row at all (both
-        // guard fields false/default) must still surface candidate matches,
-        // not observer_location_missing for every session.
+    fn suggest_finds_matches_without_observer_location() {
+        // #867 regression: an unset observer location must not turn into
+        // observer_location_missing for every session.
+        //
+        // This clears the guard flag only; the session keeps its dimensions.
+        // A session with NO `acquisition_fingerprint` row at all is a
+        // different shape, and no unit fixture can prove the production path
+        // writes one — `ingested_session_matches_a_calibration_master` in
+        // `app_core`'s `ingest_sessions_integration` covers that
+        // (astro-plan-siyk).
         let session = SessionInfo { has_observer_location: false, ..default_session() };
         let master = dark_master("m-001", 100.0, 50.0, 300.0, -10.0);
         let matches = suggest(&session, &[master], &[], &MatchingRuleConfig::default()).unwrap();

--- a/crates/persistence/calibration/src/repositories/q_calibration.rs
+++ b/crates/persistence/calibration/src/repositories/q_calibration.rs
@@ -148,6 +148,80 @@ pub async fn get_acquisition_fingerprint(
     Ok(row)
 }
 
+/// Dimensions written to one `acquisition_fingerprint` row.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UpsertAcquisitionFingerprint<'a> {
+    pub session_id: &'a str,
+    pub gain: Option<f64>,
+    pub offset_val: Option<f64>,
+    pub exposure_s: Option<f64>,
+    pub temp_c: Option<f64>,
+    pub filter_name: Option<&'a str>,
+    pub rotation_deg: Option<f64>,
+    pub binning: Option<&'a str>,
+    pub optic_train: Option<&'a str>,
+    pub observing_night_date: Option<&'a str>,
+    pub has_observer_location: bool,
+    pub has_exposure_start_utc: bool,
+}
+
+/// Write the `acquisition_fingerprint` row for a session, filling only the
+/// dimensions that are still NULL.
+///
+/// The primary key is `acquisition_session(id)`, so the row is accumulated
+/// across a session's frames: every `COALESCE` keeps the stored value and a
+/// later frame contributes only where nothing is recorded yet. A frame whose
+/// header omits a dimension therefore cannot regress a known value to NULL,
+/// and disagreeing frames leave the first non-NULL reading in place.
+///
+/// The two `has_*` flags are OR-accumulated for the same reason: they assert
+/// that some frame in the session supplied the evidence, so a later frame
+/// without it must not clear them.
+///
+/// # Errors
+/// Returns `persistence_core::DbError::Database` on query failure.
+pub async fn upsert_acquisition_fingerprint(
+    pool: &SqlitePool,
+    fp: &UpsertAcquisitionFingerprint<'_>,
+) -> DbResult<()> {
+    sqlx::query(
+        "
+        INSERT INTO acquisition_fingerprint
+            (id, session_type, gain, offset_val, exposure_s, temp_c, filter_name,
+             rotation_deg, binning, optic_train, observing_night_date,
+             has_observer_location, has_exposure_start_utc)
+        VALUES (?, 'light', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+            gain                   = COALESCE(gain, excluded.gain),
+            offset_val             = COALESCE(offset_val, excluded.offset_val),
+            exposure_s             = COALESCE(exposure_s, excluded.exposure_s),
+            temp_c                 = COALESCE(temp_c, excluded.temp_c),
+            filter_name            = COALESCE(filter_name, excluded.filter_name),
+            rotation_deg           = COALESCE(rotation_deg, excluded.rotation_deg),
+            binning                = COALESCE(binning, excluded.binning),
+            optic_train            = COALESCE(optic_train, excluded.optic_train),
+            observing_night_date   = COALESCE(observing_night_date, excluded.observing_night_date),
+            has_observer_location  = MAX(has_observer_location, excluded.has_observer_location),
+            has_exposure_start_utc = MAX(has_exposure_start_utc, excluded.has_exposure_start_utc)
+        ",
+    )
+    .bind(fp.session_id)
+    .bind(fp.gain)
+    .bind(fp.offset_val)
+    .bind(fp.exposure_s)
+    .bind(fp.temp_c)
+    .bind(fp.filter_name)
+    .bind(fp.rotation_deg)
+    .bind(fp.binning)
+    .bind(fp.optic_train)
+    .bind(fp.observing_night_date)
+    .bind(i64::from(fp.has_observer_location))
+    .bind(i64::from(fp.has_exposure_start_utc))
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 /// List `acquisition_fingerprint` rows for `light` sessions (candidates for
 /// a calibration master's "compatible sessions" list — #868).
 ///

--- a/crates/persistence/inbox/src/repositories/q_inbox.rs
+++ b/crates/persistence/inbox/src/repositories/q_inbox.rs
@@ -96,6 +96,17 @@ pub struct InsertCalibrationFingerprint<'a> {
     pub calibration_type: &'a str,
     pub exposure_s: Option<f64>,
     pub filter_name: Option<&'a str>,
+    /// Hard-rule dimension for every calibration kind: a master with a NULL
+    /// `gain` is excluded from every candidate list, because
+    /// `calibration_core::rules::hard_rule_numeric` requires both sides to be
+    /// present (astro-plan-siyk).
+    pub gain: Option<f64>,
+    pub offset_val: Option<f64>,
+    pub temp_c: Option<f64>,
+    /// Hard-rule dimension for flat matching.
+    pub binning: Option<&'a str>,
+    /// Hard-rule dimension for flat matching.
+    pub optic_train: Option<&'a str>,
 }
 
 /// Idempotency guard for master registration: does a `calibration_session`
@@ -150,13 +161,19 @@ pub async fn insert_calibration_fingerprint(
 ) -> DbResult<()> {
     sqlx::query(
         "INSERT INTO calibration_fingerprint
-            (id, calibration_type, exposure_s, filter_name)
-         VALUES (?, ?, ?, ?)",
+            (id, calibration_type, exposure_s, filter_name, gain, offset_val,
+             temp_c, binning, optic_train)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(fp.calibration_session_id)
     .bind(fp.calibration_type)
     .bind(fp.exposure_s)
     .bind(fp.filter_name)
+    .bind(fp.gain)
+    .bind(fp.offset_val)
+    .bind(fp.temp_c)
+    .bind(fp.binning)
+    .bind(fp.optic_train)
     .execute(pool)
     .await?;
     Ok(())


### PR DESCRIPTION
## Summary

- Calibration matching now returns candidate masters for ingested sessions.
  It previously reported no match for every session, because the capture
  dimensions it compares on were never recorded.

## The defect

Calibration matching returned `no_match` for every real session. No production
code wrote `acquisition_fingerprint`, so `load_session`
(`crates/app/calibration/src/matching/loaders.rs:59`) built a `SessionInfo` with
gain, offset, exposure, and temperature all `None`. `hard_rule_numeric`
(`crates/calibration/core/src/rules/mod.rs:20`) matches only
`(Some(s), Some(m))`, and its doc says "Missing either side always excludes".
The gain hard rule at `rules/dark.rs:33` therefore rejected every master.

A history bisect recorded on the bead found no regression. The writer never
existed. The origin commit `6c91e8941` says so in its body.

## Second gap, found while fixing the first

The master side was equally broken one level down. Its live writer,
`insert_calibration_fingerprint` (`crates/persistence/inbox/src/repositories/q_inbox.rs:158`),
bound only `exposure_s` and `filter_name`, leaving `gain` NULL. Because the hard
rule needs both sides, writing the session half alone would still have produced
zero candidates.

## The change

| Path | Change |
| --- | --- |
| `crates/persistence/calibration/src/repositories/q_calibration.rs` | `upsert_acquisition_fingerprint`, one row per session, `COALESCE` merge |
| `crates/app/targets/src/ingest_sessions.rs` | `backfill_session_fingerprint`, on the per-frame hook beside `backfill_session_geometry` |
| `crates/app/inbox/src/plan_listener.rs` | `read_master_fingerprint_dims` + `write_master_fingerprint` |
| `crates/persistence/inbox/src/repositories/q_inbox.rs` | insert now binds gain, offset, temp, binning, optic_train |

The row's primary key is `acquisition_session(id)`, so it accumulates across a
session's frames as an UPSERT. The two `has_*` flags are OR-accumulated: they
assert that some frame supplied the evidence, so a later frame without it must
not clear them.

## Disagreement semantics: first-non-null-wins

When frames in a session disagree on a dimension, the first non-NULL reading is
kept, implemented as `COALESCE` in the upsert.

Rejected alternatives:

- **Last-wins.** `session_key` already partitions sessions by target, filter,
  binning, gain, and observing night. Frames that disagree on a hard dimension
  are routed to *different* sessions, so the collapse `astro-plan-qgyu`
  describes is not reachable through the hard rules that gate matching.
- **An explicit "mixed" marker.** Needs a schema change and a new hard-rule
  state for a case the key already separates.

First-wins also matches `backfill_session_geometry` and `upsert_session`'s
`root_id`, so a session row and its fingerprint cannot disagree about which
frame won.

## Verification

`ingested_session_matches_a_calibration_master`
(`crates/app/core/tests/ingest_sessions_integration.rs`) drives the production
path: a plan-apply event through the real plan listener over a real FITS file,
then the real `app_core::calibration::suggest`. It asserts a candidate comes
back. Fixtures that seed `acquisition_fingerprint` directly pass against total
failure, so this test seeds only an `acquisition_session`.

Mutation-verified in both directions:

- Session writer removed: `poll_until timed out after 10 s:
  acquisition_fingerprint row never appeared after plan-siyk apply-completed
  event`
- Master `gain` bound to NULL: `a production-shaped ingested session must match
  a compatible dark master; got []`

`suggest_finds_matches_without_acquisition_fingerprint`
(`crates/calibration/core/src/lib.rs:381`) does not test the shape its name
claims. Its `default_session()` fixture populates every dimension, and the test
clears only the observer-location flag. Renamed to
`suggest_finds_matches_without_observer_location`.

`cargo clippy --workspace --all-targets -- -D warnings` is clean. All 191 Rust
test suites pass. One contract suite
(`spec062_portable_contracts::relative_path_schema_and_serde_share_utf8_byte_boundaries`)
fails on `Cannot find module 'ajv/dist/2020'` because the worktree has no
`node_modules`. That failure is unrelated to this change.

## Downstream readers

Both consumers that now receive rows hold:

- `masters.rs:174` (`list_light_acquisition_fingerprints`) computes a master's
  compatible-session list through the same domain matcher, which is the feature
  this fixes.
- `app_core::sessions:91` (`get_fingerprints_batch`) passes the row to
  `parse_session_key`, which uses it only to fill session-key segments the key
  itself left empty.


## Spec Context

Tracks-Bead: astro-plan-siyk
