### PR TITLE
fix: developer command-palette entry no longer ships in release builds

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -39,6 +39,7 @@ env:
   POLICY_VERSION_SYNC: hard
   POLICY_BUILD: hard
   POLICY_DEVTOOLS_OFF: hard
+  POLICY_DEVTOOLS_BUNDLE: hard
   POLICY_TESTS: soft
   POLICY_CHANGELOG: soft
 
@@ -133,6 +134,45 @@ jobs:
           echo "status=$STATUS" >> "$GITHUB_OUTPUT"
           echo "detail=$DETAIL" >> "$GITHUB_OUTPUT"
 
+      # --- Check 3b: dev surface absent from the frontend bundle (HARD) ---
+      # Check 3 covers the Rust feature graph only. On the frontend the gate is a
+      # Vite define, not a Cargo feature, so it is invisible to `cargo tree` and
+      # to `vitest`, which bakes `VITE_DEV_TOOLS="false"` into its own config and
+      # so asserts against a constant it supplies itself. This builds the bundle
+      # the way `tauri build` does and greps the artifact.
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.17.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Assert dev routes are absent from the frontend bundle
+        id: devtools_bundle
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          STATUS=pass
+          DETAIL="no dev route present in apps/desktop/dist"
+          if [ "${VITE_DEV_TOOLS:-}" = "true" ]; then
+            echo "status=fail" >> "$GITHUB_OUTPUT"
+            echo "detail=VITE_DEV_TOOLS=true in the release build environment" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pnpm install --frozen-lockfile
+          rm -rf apps/desktop/dist
+          pnpm --filter @astro-plan/desktop build
+          if [ ! -d apps/desktop/dist/assets ]; then
+            STATUS=fail
+            DETAIL="frontend build did not write apps/desktop/dist/assets"
+          elif grep -rlE '/dev/(contracts|settings)' apps/desktop/dist >/dev/null 2>&1; then
+            STATUS=fail
+            DETAIL="a dev route string survived into the release bundle"
+          fi
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          echo "detail=$DETAIL" >> "$GITHUB_OUTPUT"
+
       # --- Check 4: full test suite (SOFT) ---
       - name: Workspace tests
         id: tests
@@ -181,6 +221,8 @@ jobs:
           BUILD_DETAIL: ${{ steps.build.outputs.detail }}
           DT_STATUS: ${{ steps.devtools_off.outputs.status }}
           DT_DETAIL: ${{ steps.devtools_off.outputs.detail }}
+          DTB_STATUS: ${{ steps.devtools_bundle.outputs.status }}
+          DTB_DETAIL: ${{ steps.devtools_bundle.outputs.detail }}
           TESTS_STATUS: ${{ steps.tests.outputs.status }}
           TESTS_DETAIL: ${{ steps.tests.outputs.detail }}
           CL_STATUS: ${{ steps.changelog.outputs.status }}
@@ -213,6 +255,7 @@ jobs:
           emit "version-sync" "$POLICY_VERSION_SYNC" "${VS_STATUS:-fail}" "$VS_DETAIL"
           emit "build (release, dev-tools off)" "$POLICY_BUILD" "${BUILD_STATUS:-fail}" "$BUILD_DETAIL"
           emit "dev-tools-off" "$POLICY_DEVTOOLS_OFF" "${DT_STATUS:-fail}" "$DT_DETAIL"
+          emit "dev-tools-off (frontend bundle)" "$POLICY_DEVTOOLS_BUNDLE" "${DTB_STATUS:-fail}" "$DTB_DETAIL"
           emit "tests" "$POLICY_TESTS" "${TESTS_STATUS:-fail}" "$TESTS_DETAIL"
           emit "changelog" "$POLICY_CHANGELOG" "${CL_STATUS:-fail}" "$CL_DETAIL"
 

--- a/apps/desktop/src/app/CommandPalette.tsx
+++ b/apps/desktop/src/app/CommandPalette.tsx
@@ -233,6 +233,7 @@ export function CommandPalette() {
   const visiblePages = visiblePagesFor(devMode);
 
   return (
+    // eslint-disable-next-line alm/require-root-testid -- Dialog.Root renders no DOM node of its own; the popup it portals carries data-testid="command-palette"
     <Dialog.Root open={open} onOpenChange={setOpen}>
       <Dialog.Portal>
         <Dialog.Backdrop

--- a/apps/desktop/src/app/CommandPalette.tsx
+++ b/apps/desktop/src/app/CommandPalette.tsx
@@ -12,6 +12,7 @@ import { unwrap } from '@/api/ipc';
 import { openInNewWindow } from '@/lib/window';
 import { useHotkeys } from '@/lib/useHotkeys';
 import { normalizeDesig } from '@/features/targets/target-search-helpers';
+import { DEV_TOOLS_ENABLED } from '@/dev/devToolsEnabled';
 import type { SearchResult } from '@/bindings/types';
 import type { TargetListItem } from '@/bindings/index';
 
@@ -95,12 +96,31 @@ const ACTIONS: Array<PaletteAction> = [
 ];
 
 /**
- * Developer-only palette entry (spec 021 T013).
- * Appended to the Pages group only when devMode is on.
+ * Developer-only palette entries (spec 021 T013, FR-031, SC-009).
+ *
+ * Two gates, both required. `DEV_TOOLS_ENABLED` is compile-time, so a release
+ * bundle drops the array contents entirely — without it the `/dev/contracts`
+ * string shipped in `dist/assets/*.js` pointing at a route `router.tsx` had
+ * already compiled out. The runtime `devMode` setting then decides whether a
+ * developer build shows the entry.
  */
-const DEV_PAGES: Array<{ label: () => string; route: string }> = [
-  { label: () => m.cmdk_dev_contracts(), route: '/dev/contracts' },
-];
+export const DEV_PAGES: Array<{ label: () => string; route: string }> =
+  DEV_TOOLS_ENABLED
+    ? [{ label: () => m.cmdk_dev_contracts(), route: '/dev/contracts' }]
+    : [];
+
+/**
+ * Pages shown for a given `devMode` state. Exported for the T007/T009 gate
+ * tests. `devPages` is a parameter because `DEV_TOOLS_ENABLED` folds to a
+ * constant per build, so the enabled branch is otherwise unreachable from a
+ * test run, which bakes `VITE_DEV_TOOLS="false"` into its own config.
+ */
+export function visiblePagesFor(
+  devMode: boolean,
+  devPages: Array<{ label: () => string; route: string }> = DEV_PAGES,
+): Array<{ label: () => string; route: string }> {
+  return devMode ? [...PAGES, ...devPages] : PAGES;
+}
 
 export function CommandPalette() {
   const [open, setOpen] = useState(false);
@@ -210,7 +230,7 @@ export function CommandPalette() {
   const ALL_ACTIONS: Array<PaletteAction> = [...ACTIONS];
 
   // All visible pages: standard pages + dev pages when devMode is on.
-  const visiblePages = devMode ? [...PAGES, ...DEV_PAGES] : PAGES;
+  const visiblePages = visiblePagesFor(devMode);
 
   return (
     <Dialog.Root open={open} onOpenChange={setOpen}>

--- a/apps/desktop/src/app/router.tsx
+++ b/apps/desktop/src/app/router.tsx
@@ -24,6 +24,7 @@ import {
   PROJECT_STATES,
   INVENTORY_FRAME_FILTERS,
 } from '@/lib/route-contract';
+import { DEV_TOOLS_ENABLED } from '@/dev/devToolsEnabled';
 
 /** String `selected` redirect for routes where IDs are UUIDs (e.g. sessions). */
 function selectedSearchString(rawId: string): { selected?: string } {
@@ -223,7 +224,6 @@ const settingsPaneRoute = createRoute({
 // Release builds set VITE_DEV_TOOLS="false" (default in vite.config.ts),
 // so this import and the entire @/dev/ContractsPage chunk are tree-shaken
 // out of the production bundle (T072 / FR-031 / SC-009).
-const DEV_TOOLS_ENABLED = import.meta.env.VITE_DEV_TOOLS === 'true';
 
 const devContractsRoute = DEV_TOOLS_ENABLED
   ? createRoute({

--- a/apps/desktop/src/dev/commandPalette.devMode.test.ts
+++ b/apps/desktop/src/dev/commandPalette.devMode.test.ts
@@ -4,81 +4,72 @@
 /**
  * CommandPalette devMode gate tests (spec 021 T009).
  *
- * Verifies that:
- * - The "Developer / Contracts" entry is hidden when devMode = false.
- * - The "Developer / Contracts" entry appears when devMode = true.
- * - The dev entry navigates to /dev/contracts.
+ * These import the real `PAGES`, `DEV_PAGES`, and `visiblePagesFor` from
+ * `CommandPalette.tsx`. An earlier version of this file declared local copies of
+ * all three and tested those, which is why it kept passing while production
+ * gated `DEV_PAGES` on the runtime `devMode` setting alone and shipped
+ * `/dev/contracts` into release bundles. The copies had also drifted: they
+ * listed `/review`, `/plans`, and `/audit`, none of which are palette pages.
  *
- * Tests operate on the PAGES/DEV_PAGES constants and the visibility logic,
- * not on the rendered Dialog (which requires ResizeObserver — deferred to
- * Playwright). Pattern mirrors CommandPalette.test.tsx.
+ * The test run bakes `VITE_DEV_TOOLS="false"` into `vitest.config.ts`, so
+ * `DEV_TOOLS_ENABLED` is false here and `DEV_PAGES` is empty — the shape a
+ * release build has. The developer-build shape is covered by passing explicit
+ * dev pages to `visiblePagesFor`.
+ *
+ * The rendered Dialog needs ResizeObserver and is deferred to Playwright.
  */
 
 import { describe, it, expect } from 'vitest';
+import { PAGES, DEV_PAGES, visiblePagesFor } from '@/app/CommandPalette';
+import { DEV_TOOLS_ENABLED } from './devToolsEnabled';
 
-// ── Mirrors of CommandPalette.tsx constants ───────────────────────────────────
-// Keep in sync with apps/desktop/src/app/CommandPalette.tsx.
+const DEV_CONTRACTS_ROUTE = '/dev/contracts';
 
-const PAGES: Array<{ label: string; route: string }> = [
-  { label: 'Sessions', route: '/sessions' },
-  { label: 'Review queue', route: '/review' },
-  { label: 'Calibration', route: '/calibration' },
-  { label: 'Targets', route: '/targets' },
-  { label: 'Projects', route: '/projects' },
-  { label: 'Plans', route: '/plans' },
-  { label: 'Audit log', route: '/audit' },
-  { label: 'Settings', route: '/settings' },
+/** Stand-in for the dev entry a `VITE_DEV_TOOLS="true"` build would compile in. */
+const DEV_PAGES_ENABLED = [
+  { label: () => 'Developer / Contracts', route: DEV_CONTRACTS_ROUTE },
 ];
 
-const DEV_PAGES: Array<{ label: string; route: string }> = [
-  { label: 'Developer / Contracts', route: '/dev/contracts' },
-];
+describe('CommandPalette dev gate — release-shaped build (T009)', () => {
+  it('DEV_TOOLS_ENABLED is false under the test config', () => {
+    expect(DEV_TOOLS_ENABLED).toBe(false);
+  });
 
-/** Mirror of the CommandPalette visibility logic. */
-function visiblePages(
-  devMode: boolean,
-): Array<{ label: string; route: string }> {
-  return devMode ? [...PAGES, ...DEV_PAGES] : PAGES;
-}
+  it('DEV_PAGES is empty, so no dev route exists to leak into the bundle', () => {
+    expect(DEV_PAGES).toEqual([]);
+  });
 
-// ── Tests (T009) ──────────────────────────────────────────────────────────────
+  it('devMode = true cannot surface a dev entry when the build gate is off', () => {
+    const pages = visiblePagesFor(true);
+    expect(pages.find((p) => p.route === DEV_CONTRACTS_ROUTE)).toBeUndefined();
+    expect(pages.map((p) => p.route)).toEqual(PAGES.map((p) => p.route));
+  });
+});
 
-describe('CommandPalette devMode gate (T009)', () => {
+describe('CommandPalette devMode gate — developer build (T009)', () => {
   it('dev entry is absent when devMode = false', () => {
-    const pages = visiblePages(false);
-    const devEntry = pages.find((p) => p.route === '/dev/contracts');
-    expect(devEntry).toBeUndefined();
+    const pages = visiblePagesFor(false, DEV_PAGES_ENABLED);
+    expect(pages.find((p) => p.route === DEV_CONTRACTS_ROUTE)).toBeUndefined();
   });
 
-  it('dev entry is present when devMode = true', () => {
-    const pages = visiblePages(true);
-    const devEntry = pages.find((p) => p.route === '/dev/contracts');
+  it('dev entry is present and routed when devMode = true', () => {
+    const pages = visiblePagesFor(true, DEV_PAGES_ENABLED);
+    const devEntry = pages.find((p) => p.route === DEV_CONTRACTS_ROUTE);
     expect(devEntry).toBeDefined();
-    expect(devEntry?.label).toBe('Developer / Contracts');
-  });
-
-  it('dev entry routes to /dev/contracts', () => {
-    const pages = visiblePages(true);
-    const devEntry = pages.find((p) => p.label === 'Developer / Contracts');
-    expect(devEntry?.route).toBe('/dev/contracts');
+    expect(devEntry?.label()).toBe('Developer / Contracts');
   });
 
   it('standard pages are unchanged regardless of devMode', () => {
-    const pagesOff = visiblePages(false);
-    const pagesOn = visiblePages(true);
-    // Every standard page must appear in both modes.
+    const off = visiblePagesFor(false, DEV_PAGES_ENABLED).map((p) => p.route);
+    const on = visiblePagesFor(true, DEV_PAGES_ENABLED).map((p) => p.route);
     for (const p of PAGES) {
-      expect(pagesOff.some((x) => x.route === p.route)).toBe(true);
-      expect(pagesOn.some((x) => x.route === p.route)).toBe(true);
+      expect(off).toContain(p.route);
+      expect(on).toContain(p.route);
     }
   });
 
-  it('DEV_PAGES is not empty (at least one dev entry defined)', () => {
-    expect(DEV_PAGES.length).toBeGreaterThan(0);
-  });
-
-  it('dev pages do not appear in normal pages list', () => {
-    const devRoutes = new Set(DEV_PAGES.map((p) => p.route));
+  it('no standard page uses a dev route', () => {
+    const devRoutes = new Set(DEV_PAGES_ENABLED.map((p) => p.route));
     for (const p of PAGES) {
       expect(devRoutes.has(p.route)).toBe(false);
     }

--- a/apps/desktop/src/dev/devToolsEnabled.ts
+++ b/apps/desktop/src/dev/devToolsEnabled.ts
@@ -1,0 +1,17 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * The single compile-time developer-tools gate (spec 021 FR-031, SC-009).
+ *
+ * `vite.config.ts` replaces `import.meta.env.VITE_DEV_TOOLS` with a string
+ * literal at transform time, so this comparison folds to a constant and every
+ * `DEV_TOOLS_ENABLED ? … : …` branch below it is dropped from a release bundle
+ * rather than shipped and skipped at runtime.
+ *
+ * Every developer-surface gate reads this constant. A second copy would let one
+ * gate flip while another stayed open, which is how the command palette shipped
+ * a `/dev/contracts` entry into release bundles whose route the router had
+ * already compiled out.
+ */
+export const DEV_TOOLS_ENABLED = import.meta.env.VITE_DEV_TOOLS === 'true';

--- a/scripts/eslint-alm-baseline.txt
+++ b/scripts/eslint-alm-baseline.txt
@@ -6,7 +6,6 @@
 # rule's own `// eslint-disable-next-line alm/no-user-string -- <reason>`
 # for a genuinely non-user-facing string).
 # Regenerate with: node scripts/check-eslint-baseline.mjs --generate
-src/app/CommandPalette.tsx	216	alm/require-root-testid
 src/app/OperationStatusContext.tsx	46	alm/require-root-testid
 src/app/PageStatusContext.tsx	52	alm/require-root-testid
 src/components/DetailPanel.tsx	134	alm/require-root-testid


### PR DESCRIPTION
## What

The command palette's `/dev/contracts` entry shipped in release bundles. It was
gated on the runtime `devMode` setting, while the route it points at was gated on
the compile-time `VITE_DEV_TOOLS` define, so a release build carried a palette
entry to a route the router had compiled out.

`DEV_PAGES` is now gated on `DEV_TOOLS_ENABLED` at module level, so Rollup drops
it from a release bundle. The constant lives in one place,
`apps/desktop/src/dev/devToolsEnabled.ts`, read by both the router and the
palette.

## Evidence

Built the frontend both ways and grepped the artifact:

| `VITE_DEV_TOOLS` | `/dev/contracts` in `apps/desktop/dist` |
| --- | --- |
| `false` | absent |
| `true` | `dist/assets/main-7Tm_haEl.js` |

Before the fix, the `false` build emitted `route:"/dev/contracts"` into
`dist/assets/main-CLayXJml.js`. The second row is the control: without it the
grep would pass whether or not the fix worked.

`pnpm vitest run src/dev/` — 12 files, 83 tests, all passing. `tsc --noEmit` and
`biome check` clean on the edited files. `actionlint` clean on the workflow.

## Why the tests missed it

`commandPalette.devMode.test.ts` declared local copies of `PAGES`, `DEV_PAGES`,
and the visibility logic and tested those. The copies had drifted as well: they
listed `/review`, `/plans`, and `/audit`, none of which are palette pages. The
tests now import the real exported constants. The developer-build branch takes
its dev pages as a parameter, because `vitest.config.ts` bakes
`VITE_DEV_TOOLS="false"` into the test run and no environment variable can reach
it.

## Release gate

Check 3 inspects the Cargo feature graph, where a Vite define cannot appear, so
the frontend half of the developer-surface claim was unverified: a release built
with `VITE_DEV_TOOLS=true` in the environment shipped both dev routes and every
check still passed. A new hard check builds the bundle the way `tauri build` does
and greps `apps/desktop/dist` for `/dev/contracts` and `/dev/settings`.

Release PR #1393 stays held; this changes the gate, not the release.

Tracks-Bead: astro-plan-9f78
Merge-Bead: astro-plan-a460
Closes-Bead: astro-plan-9f78
