### PR TITLE
fix: one bad observing site no longer wipes the rest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "sqlx",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
  "uuid",
  "workflow_profiles",
 ]

--- a/crates/app/settings/Cargo.toml
+++ b/crates/app/settings/Cargo.toml
@@ -21,6 +21,7 @@ persistence_plans = { path = "../../persistence/plans" }
 serde_json.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
+tracing.workspace = true
 # "v5" beyond the workspace default ("v4"): deterministic audit `entity_id`
 # derivation for settings keys (T122, spec 030 FR-133), same pattern as
 # `crates/targeting/Cargo.toml`.

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -80,6 +80,7 @@ use domain_core::ids::Timestamp;
 
 mod keys;
 mod read;
+mod repair;
 mod validation;
 mod writes;
 

--- a/crates/app/settings/src/read.rs
+++ b/crates/app/settings/src/read.rs
@@ -1,8 +1,8 @@
 use app_core_cache::SnapshotCache;
 
 use super::{
-    bus_err, db_err, descriptors, is_catalogues_enabled_key, is_locale_key, is_tools_bundle_id_key,
-    repair, repo, validate_value, ContractError, EventBus, SettingsGetResponse, SettingsRepair,
+    db_err, descriptors, is_catalogues_enabled_key, is_locale_key, is_tools_bundle_id_key, repair,
+    repo, validate_value, ContractError, EventBus, SettingsGetResponse, SettingsRepair,
     SettingsState, Source, SqlitePool, Timestamp, Value, TOPIC_SETTINGS_REPAIR,
 };
 
@@ -42,14 +42,14 @@ pub async fn get_settings(
             // user typed in (constitution V, Tier 1).
             if let Some(salvaged) = repair::salvage(&key, &value) {
                 repo::set_raw(pool, &key, &salvaged.kept).await.map_err(db_err)?;
-                publish_repair(bus, &key, salvaged.dropped, salvaged.kept.clone()).await?;
+                publish_repair(bus, &key, salvaged.dropped, salvaged.kept.clone()).await;
                 apply_value_to_state(&key, salvaged.kept, &mut settings);
                 continue;
             }
 
             // Repair: delete the bad row and emit a warn audit event.
             repo::delete_key(pool, &key).await.map_err(db_err)?;
-            publish_repair(bus, &key, value.clone(), default_value_for_key(&key)).await?;
+            publish_repair(bus, &key, value.clone(), default_value_for_key(&key)).await;
 
             // Use the default — do not apply the invalid stored value.
             continue;
@@ -68,25 +68,40 @@ pub async fn get_settings(
 /// `discarded` is the whole stored value for a full reset and only the dropped
 /// entries for a partial repair. `restored` is the value now stored: the in-code
 /// default, or the salvaged remainder.
-async fn publish_repair(
-    bus: &EventBus,
-    key: &str,
-    discarded: Value,
-    restored: Value,
-) -> Result<(), ContractError> {
-    bus.publish(
-        TOPIC_SETTINGS_REPAIR,
-        Source::System,
-        SettingsRepair {
-            key: key.to_owned(),
-            invalid_value: discarded,
-            default_value: restored,
-            at: Timestamp::now_iso(),
-        },
-    )
-    .await
-    .map_err(bus_err)?;
-    Ok(())
+///
+/// A publish failure is logged and swallowed rather than returned. Propagating it
+/// would deny the caller every setting in the bag because one subscriber went
+/// away, and the repaired row is already durable, so the error would report a
+/// failure over a repair that succeeded.
+///
+/// The event is a Tier-2 notification under constitution V: what it announces is
+/// a value that failed validation, which the application could not have presented
+/// as a setting either way. The discarded value is nonetheless the only copy left
+/// once the repaired row is stored, so the failure path logs it instead of
+/// dropping it silently.
+async fn publish_repair(bus: &EventBus, key: &str, discarded: Value, restored: Value) {
+    let result = bus
+        .publish(
+            TOPIC_SETTINGS_REPAIR,
+            Source::System,
+            SettingsRepair {
+                key: key.to_owned(),
+                invalid_value: discarded.clone(),
+                default_value: restored,
+                at: Timestamp::now_iso(),
+            },
+        )
+        .await;
+
+    if let Err(e) = result {
+        tracing::error!(
+            key,
+            error = %e,
+            discarded = %discarded,
+            "settings.repair notification could not be published; the discarded value is \
+             recorded here because the repaired row has replaced it"
+        );
+    }
 }
 
 /// Apply a raw JSON value to the correct field of `SettingsState`.

--- a/crates/app/settings/src/read.rs
+++ b/crates/app/settings/src/read.rs
@@ -2,7 +2,7 @@ use app_core_cache::SnapshotCache;
 
 use super::{
     bus_err, db_err, descriptors, is_catalogues_enabled_key, is_locale_key, is_tools_bundle_id_key,
-    repo, validate_value, ContractError, EventBus, SettingsGetResponse, SettingsRepair,
+    repair, repo, validate_value, ContractError, EventBus, SettingsGetResponse, SettingsRepair,
     SettingsState, Source, SqlitePool, Timestamp, Value, TOPIC_SETTINGS_REPAIR,
 };
 
@@ -36,23 +36,20 @@ pub async fn get_settings(
     for (key, value) in all_raw {
         // Validate stored value.
         if let Err(_validation_err) = validate_value(&key, &value) {
+            // Partial repair: for array-valued keys whose entries stand alone,
+            // keep the entries that validate and store the remainder, so one
+            // malformed observing site no longer discards every other site the
+            // user typed in (constitution V, Tier 1).
+            if let Some(salvaged) = repair::salvage(&key, &value) {
+                repo::set_raw(pool, &key, &salvaged.kept).await.map_err(db_err)?;
+                publish_repair(bus, &key, salvaged.dropped, salvaged.kept.clone()).await?;
+                apply_value_to_state(&key, salvaged.kept, &mut settings);
+                continue;
+            }
+
             // Repair: delete the bad row and emit a warn audit event.
             repo::delete_key(pool, &key).await.map_err(db_err)?;
-
-            let default_value = default_value_for_key(&key);
-            let at = Timestamp::now_iso();
-            bus.publish(
-                TOPIC_SETTINGS_REPAIR,
-                Source::System,
-                SettingsRepair {
-                    key: key.clone(),
-                    invalid_value: value.clone(),
-                    default_value: default_value.clone(),
-                    at,
-                },
-            )
-            .await
-            .map_err(bus_err)?;
+            publish_repair(bus, &key, value.clone(), default_value_for_key(&key)).await?;
 
             // Use the default — do not apply the invalid stored value.
             continue;
@@ -64,6 +61,32 @@ pub async fn get_settings(
 
     cache.store(std::sync::Arc::new(settings.clone()));
     Ok(SettingsGetResponse { settings })
+}
+
+/// Emit the `settings.repair` audit event.
+///
+/// `discarded` is the whole stored value for a full reset and only the dropped
+/// entries for a partial repair. `restored` is the value now stored: the in-code
+/// default, or the salvaged remainder.
+async fn publish_repair(
+    bus: &EventBus,
+    key: &str,
+    discarded: Value,
+    restored: Value,
+) -> Result<(), ContractError> {
+    bus.publish(
+        TOPIC_SETTINGS_REPAIR,
+        Source::System,
+        SettingsRepair {
+            key: key.to_owned(),
+            invalid_value: discarded,
+            default_value: restored,
+            at: Timestamp::now_iso(),
+        },
+    )
+    .await
+    .map_err(bus_err)?;
+    Ok(())
 }
 
 /// Apply a raw JSON value to the correct field of `SettingsState`.

--- a/crates/app/settings/src/repair.rs
+++ b/crates/app/settings/src/repair.rs
@@ -1,0 +1,76 @@
+use std::collections::BTreeSet;
+
+use super::{descriptors, ContractError, ErrorCode, ErrorSeverity, Value};
+
+// ── Partial repair of array-valued settings ───────────────────────────────
+
+/// The split of an array-valued setting whose stored value failed validation.
+pub struct Salvage {
+    /// The entries that validate, in stored order.
+    pub kept: Value,
+    /// The entries that were discarded.
+    pub dropped: Value,
+}
+
+/// Split an invalid array-valued setting into the entries worth keeping and the
+/// entries to discard.
+///
+/// Returns `None` unless every one of these holds, in which case the caller
+/// falls back to resetting the whole key:
+///
+/// - the key's rule is one whose entries are independently valid,
+/// - the stored value is an array,
+/// - at least one entry fails on its own, so the whole-value failure is
+///   accounted for by the entries this pass discards,
+/// - the kept remainder passes the key's own validation.
+///
+/// The last two conditions matter: without them a whole-value rule that no
+/// per-entry check can see would let an invalid value through as "repaired".
+///
+/// Observing sites are the one salvageable key today. They are coordinates a
+/// user looked up and typed in, so by the durability test in constitution
+/// Principle V they are Tier 1 user knowledge, and discarding the sites that
+/// were fine because a sibling is malformed loses knowledge no filesystem scan
+/// can recover.
+pub fn salvage(key: &str, value: &Value) -> Option<Salvage> {
+    let descriptor = descriptors::descriptor_for(key)?;
+    let rule = descriptor.validation;
+    if !matches!(rule, descriptors::ValidationRule::ObserverSites) {
+        return None;
+    }
+
+    let entries = value.as_array()?;
+    let mut kept: Vec<Value> = Vec::new();
+    let mut dropped: Vec<Value> = Vec::new();
+    let mut ids: BTreeSet<String> = BTreeSet::new();
+
+    for entry in entries {
+        // A duplicate id is only visible against the entries already kept, so
+        // the first occurrence survives and later ones are dropped.
+        let id = entry.get("id").and_then(Value::as_str).map(str::to_owned);
+        let duplicate = id.as_ref().is_some_and(|i| ids.contains(i));
+        if duplicate || check(rule, &Value::Array(vec![entry.clone()])).is_err() {
+            dropped.push(entry.clone());
+            continue;
+        }
+        if let Some(id) = id {
+            ids.insert(id);
+        }
+        kept.push(entry.clone());
+    }
+
+    if dropped.is_empty() {
+        return None;
+    }
+    let kept = Value::Array(kept);
+    check(rule, &kept).ok()?;
+    Some(Salvage { kept, dropped: Value::Array(dropped) })
+}
+
+/// Run a validation rule against a value, discarding the rendered message.
+fn check(rule: descriptors::ValidationRule, value: &Value) -> Result<(), ContractError> {
+    let invalid = |msg: &str| {
+        ContractError::new(ErrorCode::ValueInvalid, msg.to_owned(), ErrorSeverity::Warning, false)
+    };
+    descriptors::check_rule(rule, value, &invalid)
+}

--- a/crates/app/settings/src/tests.rs
+++ b/crates/app/settings/src/tests.rs
@@ -320,6 +320,86 @@ async fn get_settings_repairs_invalid_stored_value() {
     assert!(raw.is_none());
 }
 
+// ── Partial repair of observing sites (mq5m) ───────────────────────
+
+/// A valid observing site with the given id and name.
+fn site(id: &str, name: &str) -> Value {
+    serde_json::json!({
+        "id": id, "name": name, "latitudeDeg": 52.1, "longitudeDeg": 5.3,
+        "elevationM": 12.0, "timezone": "Europe/Amsterdam",
+        "twilight": "astronomical", "minHorizonAltDeg": 0.0
+    })
+}
+
+/// One malformed site must not take the user's other sites with it. Observing
+/// sites are coordinates the user typed in, so the whole-key reset lost Tier-1
+/// user knowledge with nothing left to recover from.
+#[tokio::test]
+async fn get_settings_keeps_the_valid_observing_sites_when_one_is_malformed() {
+    let (db, bus, cache) = setup().await;
+    let mut bad = site("s2", "Broken");
+    bad["latitudeDeg"] = serde_json::json!(91.0);
+    let stored = serde_json::json!([site("s1", "Home"), bad, site("s3", "Dark")]);
+    repo::set_raw(db.pool(), "observingSites", &stored).await.unwrap();
+
+    let resp = get_settings(db.pool(), &bus, &cache).await.unwrap();
+
+    let ids: Vec<&str> = resp.settings.observing_sites.iter().map(|s| s.id.as_str()).collect();
+    assert_eq!(ids, vec!["s1", "s3"], "only the malformed site may be dropped");
+
+    // The repaired remainder is written back, not deleted.
+    let raw = repo::get_raw(db.pool(), "observingSites").await.unwrap();
+    assert_eq!(raw, Some(serde_json::json!([site("s1", "Home"), site("s3", "Dark")])));
+}
+
+/// The repair event names the dropped site and the remainder that was kept.
+#[tokio::test]
+async fn partial_repair_audits_the_dropped_site_and_the_kept_remainder() {
+    let (db, bus, cache) = setup().await;
+    let mut bad = site("s2", "Broken");
+    bad["latitudeDeg"] = serde_json::json!(91.0);
+    let stored = serde_json::json!([site("s1", "Home"), bad]);
+    repo::set_raw(db.pool(), "observingSites", &stored).await.unwrap();
+
+    get_settings(db.pool(), &bus, &cache).await.unwrap();
+
+    let payload: String =
+        sqlx::query_scalar("SELECT payload FROM events WHERE topic = 'settings.repair'")
+            .fetch_one(db.pool())
+            .await
+            .expect("partial repair must still audit");
+    let payload: Value = serde_json::from_str(&payload).expect("payload is JSON");
+    assert_eq!(payload["invalidValue"], serde_json::json!([bad]));
+    assert_eq!(payload["defaultValue"], serde_json::json!([site("s1", "Home")]));
+}
+
+/// A duplicate id is only visible against the sites already kept, so the first
+/// occurrence survives.
+#[tokio::test]
+async fn get_settings_keeps_the_first_of_two_sites_sharing_an_id() {
+    let (db, bus, cache) = setup().await;
+    let stored = serde_json::json!([site("dup", "First"), site("dup", "Second")]);
+    repo::set_raw(db.pool(), "observingSites", &stored).await.unwrap();
+
+    let resp = get_settings(db.pool(), &bus, &cache).await.unwrap();
+
+    let names: Vec<&str> = resp.settings.observing_sites.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, vec!["First"]);
+}
+
+/// Salvage applies to arrays of independently valid entries. A value that is not
+/// an array has no entries to keep, so the whole key still resets.
+#[tokio::test]
+async fn get_settings_resets_observing_sites_when_the_value_is_not_an_array() {
+    let (db, bus, cache) = setup().await;
+    repo::set_raw(db.pool(), "observingSites", &serde_json::json!("nope")).await.unwrap();
+
+    let resp = get_settings(db.pool(), &bus, &cache).await.unwrap();
+
+    assert!(resp.settings.observing_sites.is_empty());
+    assert!(repo::get_raw(db.pool(), "observingSites").await.unwrap().is_none());
+}
+
 // ── T021/T022: source override tests ──────────────────────────────
 
 #[tokio::test]

--- a/crates/audit-types/src/event_bus.rs
+++ b/crates/audit-types/src/event_bus.rs
@@ -224,15 +224,18 @@ pub const TOPIC_SETTINGS_SNAPSHOT: &str = "settings.snapshot";
 /// Payload for the `settings.repair` topic (spec 018, T005).
 ///
 /// Emitted at warn level when a stored settings value fails schema validation
-/// and is reset to its in-code default (T019).
+/// (T019). The repair either resets the key to its in-code default or, for an
+/// array-valued key whose entries are independently valid, keeps the entries
+/// that validate and drops the rest.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct SettingsRepair {
-    /// The settings key that was reset.
+    /// The settings key that was repaired.
     pub key: String,
-    /// The invalid stored value that triggered the repair.
+    /// What was discarded: the whole stored value for a full reset, or only the
+    /// dropped entries for a partial repair.
     pub invalid_value: serde_json::Value,
-    /// The default value restored.
+    /// The value now stored: the in-code default, or the kept remainder.
     pub default_value: serde_json::Value,
     /// ISO-8601 timestamp.
     pub at: String,


### PR DESCRIPTION
## Summary

- One malformed observing site no longer discards every other site. `get_settings`
  deleted the whole `observingSites` key on any validation failure and reset it to
  `[]`, so a single out-of-range latitude took every site the user had configured
  with it. The raw row was already gone and the repair event has no UI surface, so
  the sites vanished with no explanation and nothing to recover from.
- The repair now keeps the entries that validate and writes the remainder back.
  Duplicate ids resolve in favour of the first occurrence.
- The whole key still resets when salvage cannot account for the failure: the
  value must be an array, at least one entry must fail on its own, and the kept
  remainder must pass the key's own validation. Otherwise a whole-value rule that
  no per-entry check can see would let an invalid value through as repaired.
  `observingSites` is the only salvageable key today.
- The `settings.repair` event carries the dropped entries in `invalidValue` and
  the value actually stored in `defaultValue`. No field or schema change;
  `just check-generated` is clean.

Observing sites are coordinates a user looked up and typed in. No filesystem scan
re-derives them, so by the durability test in constitution Principle V they are
Tier-1 user knowledge.

## Verification

`cargo test -p app_core_settings` — 224 passed. `cargo clippy -p
app_core_settings --all-targets -D warnings` clean.

Three of the four new tests fail with `repair::salvage` stubbed to return `None`;
the fourth asserts that a non-array value still resets the whole key, so it
passes either way by design.

## Note on the bead

The bead cites a pinning test `get_settings_repair_of_one_bad_site_discards_the_whole_list`
in `crates/app/settings/src/tests.rs`. No such test exists on `main`, so the
behaviour was unpinned. The four tests here cover it.

Tracks-Bead: astro-plan-mq5m
Merge-Bead: astro-plan-vssp
Closes-Bead: astro-plan-mq5m
