### PR TITLE
fix: settings panes reflect a value changed elsewhere in the app

### DIFF
--- a/apps/desktop/src/app/LogPanelContext.tsx
+++ b/apps/desktop/src/app/LogPanelContext.tsx
@@ -23,6 +23,7 @@ import {
 } from 'react';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
+import { updateSettings } from '@/data/settingsWrite';
 import type { LogLevel, LogEntrySource } from '@/data/logStore';
 import { startLogSubscription } from '@/data/logSubscription';
 import { createPersistedState } from '@/data/persisted-state';
@@ -154,10 +155,12 @@ export function LogPanelProvider({ children }: { children: ReactNode }) {
     // above) — from here on, the user owns it for this session.
     followTouchedRef.current = true;
     setFollowLogsState(v);
-    // Persist via settings.update (spec 018).
-    void commands
-      .settingsUpdate('advanced', { rememberFollowLogs: v })
-      .then(unwrap);
+    // Persist via settings.update (spec 018). The Advanced pane reads the
+    // `advanced` scope with `staleTime: Infinity`, so this must invalidate.
+    void updateSettings({
+      scope: 'advanced',
+      values: { rememberFollowLogs: v },
+    });
   }, []);
 
   return (

--- a/apps/desktop/src/data/locale.tsx
+++ b/apps/desktop/src/data/locale.tsx
@@ -168,15 +168,11 @@ function persistLocaleToSettings(locale: string): void {
       const { isTauri } = await importTauriCore();
       if (!isTauri()) return;
 
-      const [{ commands }, { unwrap }] = await Promise.all([
-        importBindings(),
-        importIpc(),
-      ]);
-      unwrap(
-        await commands.settingsUpdate(SETTINGS_SCOPE, {
-          [SETTINGS_KEY]: locale,
-        }),
-      );
+      const { updateSettings } = await import('@/data/settingsWrite');
+      await updateSettings({
+        scope: SETTINGS_SCOPE,
+        values: { [SETTINGS_KEY]: locale },
+      });
     } catch {
       // Best-effort — a DB write failure never blocks or reverts the UI change.
     }

--- a/apps/desktop/src/data/persisted-state.ts
+++ b/apps/desktop/src/data/persisted-state.ts
@@ -194,11 +194,8 @@ export function createPersistedState<T>(
         try {
           const { isTauri } = await importTauriCore();
           if (!isTauri()) return;
-          const [{ commands }, { unwrap }] = await Promise.all([
-            import('@/bindings/index'),
-            import('@/api/ipc'),
-          ]);
-          unwrap(await commands.settingsUpdate(scope, { [key]: value }));
+          const { updateSettings } = await import('@/data/settingsWrite');
+          await updateSettings({ scope, values: { [key]: value } });
         } catch {
           // Best-effort — a DB write failure never blocks or reverts the UI change.
         }

--- a/apps/desktop/src/data/settingsWrite.chokepoint.test.ts
+++ b/apps/desktop/src/data/settingsWrite.chokepoint.test.ts
@@ -1,0 +1,81 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * settingsWrite.chokepoint.test.ts — astro-plan-cia8.
+ *
+ * `settingsQueryOptions` caches every scope read with `staleTime: Infinity`, so
+ * a write that does not invalidate `queryKeys.settings.scope(scope)` leaves the
+ * reader on a value the user has already changed. Nine call sites called
+ * `commands.settingsUpdate` directly; two of them wrote scopes a `useQuery`
+ * caller already reads.
+ *
+ * The rule lived in the `settingsQueries.ts` docstring, which is why nine
+ * writers accumulated under it. This turns it into a gate: `data/settingsWrite.ts`
+ * is the only module allowed to name the raw command, and every scope with a
+ * reader must be written through it.
+ *
+ * It reads the sources rather than the module graph because the offending call
+ * is what matters, not whether a given test happened to exercise it. vitest runs
+ * with cwd = apps/desktop.
+ */
+
+/// <reference types="node" />
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const srcDir = join(process.cwd(), 'src');
+
+/** The chokepoint itself, and the generated binding that declares the command. */
+const ALLOWED = new Set(['data/settingsWrite.ts', 'bindings/index.ts']);
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...sourceFiles(full));
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Source with comments stripped, so a docstring naming the command is not a
+ *  call. Test files are excluded: a mock or an assertion legitimately names it. */
+function callSites(): string[] {
+  const offenders: string[] = [];
+  for (const file of sourceFiles(srcDir)) {
+    const rel = relative(srcDir, file).split(/[\\/]/).join('/');
+    if (ALLOWED.has(rel)) continue;
+    if (/\.(test|spec)\.tsx?$/.test(rel)) continue;
+
+    const code = readFileSync(file, 'utf-8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '');
+    // `.settingsUpdate(` covers both `commands.settingsUpdate(...)` and the
+    // `void commands\n  .settingsUpdate(...)` chained form.
+    if (/\.settingsUpdate\s*\(/.test(code)) offenders.push(rel);
+  }
+  return offenders;
+}
+
+describe('settings.update has one write path', () => {
+  it('no module outside data/settingsWrite.ts calls commands.settingsUpdate', () => {
+    expect(
+      callSites(),
+      'these modules write a settings scope without invalidating its cached read — call updateSettings from @/data/settingsWrite instead',
+    ).toEqual([]);
+  });
+
+  it('the chokepoint invalidates the scope it just wrote', () => {
+    const source = readFileSync(join(srcDir, 'data/settingsWrite.ts'), 'utf-8');
+
+    // Without this the guard above would pass while every write went stale:
+    // one unchecked write path is not better than nine.
+    expect(source).toMatch(/invalidateQueries/);
+    expect(source).toMatch(/queryKeys\.settings\.scope\(args\.scope\)/);
+  });
+});

--- a/apps/desktop/src/data/settingsWrite.ts
+++ b/apps/desktop/src/data/settingsWrite.ts
@@ -1,0 +1,37 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * The single write path for `settings.update`.
+ *
+ * `settingsQueryOptions` caches scope reads with `staleTime: Infinity`, so a
+ * scope that is written without invalidating `queryKeys.settings.scope(scope)`
+ * is read from cache for the rest of the session. Nine call sites wrote
+ * `commands.settingsUpdate` directly, two of them on scopes a `useQuery` caller
+ * already reads (`advanced` from the log panel, `cleanup` from the setup
+ * wizard), which left those panes showing a value the user had just changed.
+ *
+ * This module holds the invalidation so no caller can forget it, and
+ * `settingsWrite.chokepoint.test.ts` fails when a module outside it calls
+ * `commands.settingsUpdate`. It stays separate from `features/settings/
+ * settingsIpc.ts` so the lazy writers in `data/` can reach the chokepoint
+ * through a dynamic import without pulling the whole IPC surface into the boot
+ * bundle.
+ */
+
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import { queryClient } from '@/data/queryClient';
+import { queryKeys } from '@/data/queryKeys';
+
+/** Write one settings scope and invalidate its cached read. Throws on IPC or
+ *  validation failure; callers that treat the write as best-effort catch. */
+export async function updateSettings(args: {
+  scope: string;
+  values: Record<string, unknown>;
+}): Promise<void> {
+  unwrap(await commands.settingsUpdate(args.scope, args.values));
+  await queryClient.invalidateQueries({
+    queryKey: queryKeys.settings.scope(args.scope),
+  });
+}

--- a/apps/desktop/src/data/theme.persistence.test.ts
+++ b/apps/desktop/src/data/theme.persistence.test.ts
@@ -128,6 +128,14 @@ describe('hydrateThemeFromSettings — reconcile the boot cache from the setting
     expect(document.documentElement.getAttribute('data-theme')).toBe(
       'espresso-dark',
     );
+
+    // Adopting the DB value calls `setThemeChoice`, whose write-through is
+    // fire-and-forget. Settle it here: left in flight it lands in the next
+    // test, after its `mockReset`, and fails that test's assertion instead.
+    await waitForCall(settingsUpdateMock);
+    expect(settingsUpdateMock).toHaveBeenCalledWith('general', {
+      theme: 'espresso-dark',
+    });
   });
 
   it('leaves the cache untouched when the DB already agrees (no redundant write-back)', async () => {

--- a/apps/desktop/src/data/theme.ts
+++ b/apps/desktop/src/data/theme.ts
@@ -216,15 +216,11 @@ function persistThemeToSettings(choice: ThemeChoice): void {
       const { isTauri } = await importTauriCore();
       if (!isTauri()) return;
 
-      const [{ commands }, { unwrap }] = await Promise.all([
-        import('@/bindings/index'),
-        import('@/api/ipc'),
-      ]);
-      unwrap(
-        await commands.settingsUpdate(SETTINGS_SCOPE, {
-          [SETTINGS_KEY]: choice,
-        }),
-      );
+      const { updateSettings } = await import('@/data/settingsWrite');
+      await updateSettings({
+        scope: SETTINGS_SCOPE,
+        values: { [SETTINGS_KEY]: choice },
+      });
     } catch {
       // Best-effort — a DB write failure never blocks or reverts the UI change.
     }
@@ -442,15 +438,11 @@ function persistFontSizeToSettings(choice: FontSizeChoice): void {
       const { isTauri } = await importTauriCore();
       if (!isTauri()) return;
 
-      const [{ commands }, { unwrap }] = await Promise.all([
-        import('@/bindings/index'),
-        import('@/api/ipc'),
-      ]);
-      unwrap(
-        await commands.settingsUpdate(SETTINGS_SCOPE, {
-          [FONT_SIZE_SETTINGS_KEY]: choice,
-        }),
-      );
+      const { updateSettings } = await import('@/data/settingsWrite');
+      await updateSettings({
+        scope: SETTINGS_SCOPE,
+        values: { [FONT_SIZE_SETTINGS_KEY]: choice },
+      });
     } catch {
       // Best-effort — a DB write failure never blocks or reverts the UI change.
     }
@@ -552,15 +544,11 @@ function persistZoomToSettings(percent: ZoomPercent): void {
       const { isTauri } = await importTauriCore();
       if (!isTauri()) return;
 
-      const [{ commands }, { unwrap }] = await Promise.all([
-        import('@/bindings/index'),
-        import('@/api/ipc'),
-      ]);
-      unwrap(
-        await commands.settingsUpdate(SETTINGS_SCOPE, {
-          [ZOOM_SETTINGS_KEY]: percent,
-        }),
-      );
+      const { updateSettings } = await import('@/data/settingsWrite');
+      await updateSettings({
+        scope: SETTINGS_SCOPE,
+        values: { [ZOOM_SETTINGS_KEY]: percent },
+      });
     } catch {
       // Best-effort — a DB write failure never blocks or reverts the UI change.
     }

--- a/apps/desktop/src/features/settings/settingsIpc.ts
+++ b/apps/desktop/src/features/settings/settingsIpc.ts
@@ -188,15 +188,7 @@ export async function getSettingsTyped<T extends Record<string, unknown>>(
   return parseSettingsValues(data.values, schema);
 }
 
-export async function updateSettings(args: {
-  scope: string;
-  values: Record<string, unknown>;
-}): Promise<void> {
-  unwrap(await commands.settingsUpdate(args.scope, args.values));
-  await queryClient.invalidateQueries({
-    queryKey: queryKeys.settings.scope(args.scope),
-  });
-}
+export { updateSettings } from '@/data/settingsWrite';
 
 /**
  * `settings.restore-defaults` — restore named keys (or all keys when `keys`

--- a/apps/desktop/src/features/settings/settingsQueries.ts
+++ b/apps/desktop/src/features/settings/settingsQueries.ts
@@ -4,14 +4,10 @@
 /**
  * TanStack Query options for the generic `settings.get` scope reads.
  *
- * `staleTime: Infinity` is safe only because every write path through
- * `updateSettings` / `settingsRestoreDefaults` invalidates
- * `queryKeys.settings.all()`. A writer that calls `commands.settingsUpdate`
- * directly (see `data/theme.ts`, `data/locale.tsx`, `data/persisted-state.ts`,
- * `shared/observing-sites/site-store.ts`, `shared/planner/*-settings.ts`)
- * bypasses that invalidation — those modules own scopes no `useQuery` caller
- * reads, and a new caller for one of their scopes must add invalidation there
- * first.
+ * `staleTime: Infinity` is safe only because every write invalidates the scope
+ * it wrote: `data/settingsWrite.ts` is the one `settings.update` path, and
+ * `settingsRestoreDefaults` invalidates `queryKeys.settings.all()`.
+ * `data/settingsWrite.chokepoint.test.ts` is the gate on that.
  */
 
 import { queryOptions } from '@tanstack/react-query';

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
@@ -17,6 +17,7 @@ import { m } from '@/lib/i18n';
 import type { Density } from '@/bindings/types';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
+import { updateSettings } from '@/data/settingsWrite';
 import { selectBase } from '@/styles/select.css';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -85,10 +86,12 @@ function DefaultProtectionControl() {
     // above) — from here on the user owns it for this session.
     chosenRef.current = true;
     setValue(v);
-    void commands
-      .settingsUpdate('cleanup', { defaultProtection: v })
-      .then((r) => unwrap(r))
-      .catch(() => {});
+    // The Cleanup settings pane reads the `cleanup` scope with
+    // `staleTime: Infinity`, so this must invalidate.
+    void updateSettings({
+      scope: 'cleanup',
+      values: { defaultProtection: v },
+    }).catch(() => {});
   };
 
   return (

--- a/apps/desktop/src/shared/observing-sites/site-store.ts
+++ b/apps/desktop/src/shared/observing-sites/site-store.ts
@@ -24,6 +24,7 @@
 import { useSyncExternalStore } from 'react';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
+import { updateSettings } from '@/data/settingsWrite';
 import { type ObserverSite, coerceSites } from './observer-site';
 
 /** Settings scope + keys for the observing-site model. */
@@ -152,13 +153,14 @@ export async function saveSites(
     usableAltitudeDeg: current.usableAltitudeDeg,
   };
   writeGen += 1;
-  unwrap(
-    await commands.settingsUpdate(OBSERVING_SCOPE, {
+  await updateSettings({
+    scope: OBSERVING_SCOPE,
+    values: {
       [SITES_KEY]: next.sites,
       [DEFAULT_SITE_ID_KEY]: next.defaultSiteId,
       [ACTIVE_SITE_ID_KEY]: next.activeSiteId,
-    }),
-  );
+    },
+  });
   current = next;
   emit();
 }
@@ -190,11 +192,10 @@ export async function saveUsableAltitude(degrees: number): Promise<void> {
   current = { ...current, usableAltitudeDeg: clamped };
   emit();
   try {
-    unwrap(
-      await commands.settingsUpdate(OBSERVING_SCOPE, {
-        [USABLE_ALTITUDE_KEY]: clamped,
-      }),
-    );
+    await updateSettings({
+      scope: OBSERVING_SCOPE,
+      values: { [USABLE_ALTITUDE_KEY]: clamped },
+    });
   } catch (err) {
     if (writeGen === gen) {
       current = prev;

--- a/apps/desktop/src/shared/planner/catalogue-settings.ts
+++ b/apps/desktop/src/shared/planner/catalogue-settings.ts
@@ -16,6 +16,7 @@
 
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
+import { updateSettings } from '@/data/settingsWrite';
 import {
   PLANNER_CATALOGS,
   type CatalogueId,
@@ -72,7 +73,8 @@ export async function loadDefaultCatalogues(): Promise<CatalogueId[]> {
 export async function saveDefaultCatalogues(
   enabled: readonly CatalogueId[],
 ): Promise<void> {
-  unwrap(
-    await commands.settingsUpdate(CATALOGUES_SCOPE, { enabled: [...enabled] }),
-  );
+  await updateSettings({
+    scope: CATALOGUES_SCOPE,
+    values: { enabled: [...enabled] },
+  });
 }

--- a/apps/desktop/src/shared/planner/guidance-settings.ts
+++ b/apps/desktop/src/shared/planner/guidance-settings.ts
@@ -19,6 +19,7 @@
 import { useSyncExternalStore } from 'react';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
+import { updateSettings } from '@/data/settingsWrite';
 import {
   BANDS,
   DEFAULT_MOON_AVOIDANCE,
@@ -142,11 +143,10 @@ export async function saveGuidanceParams(
   current = clean;
   emit();
   try {
-    unwrap(
-      await commands.settingsUpdate(PLANNER_SCOPE, {
-        [MOON_AVOIDANCE_KEY]: clean,
-      }),
-    );
+    await updateSettings({
+      scope: PLANNER_SCOPE,
+      values: { [MOON_AVOIDANCE_KEY]: clean },
+    });
   } catch (err) {
     if (writeGen === gen) {
       current = prev;

--- a/scripts/eslint-alm-baseline.txt
+++ b/scripts/eslint-alm-baseline.txt
@@ -77,7 +77,7 @@ src/features/settings/SourceViewStrategy.tsx	60	alm/require-root-testid
 src/features/settings/SourceViews.tsx	97	alm/require-root-testid
 src/features/setup/SetupPage.tsx	48	alm/require-root-testid
 src/features/setup/SetupWizard.tsx	244	alm/require-root-testid
-src/features/setup/steps/StepCatalogs.tsx	168	alm/require-root-testid
+src/features/setup/steps/StepCatalogs.tsx	171	alm/require-root-testid
 src/features/setup/steps/StepConfirm.tsx	67	alm/require-root-testid
 src/features/setup/steps/StepLanguage.tsx	26	alm/require-root-testid
 src/features/setup/steps/StepSite.tsx	131	alm/require-root-testid


### PR DESCRIPTION
## Summary

- `settingsQueryOptions` caches each scope with `staleTime: Infinity`, sound only
  while every writer invalidates `queryKeys.settings.scope(scope)`. Nine sites
  called `commands.settingsUpdate` directly and skipped it.
- One of the nine writes a scope a `useQuery` caller already reads, so this is a
  live defect, not the latent one the bead describes: the first-run wizard writes
  `cleanup.defaultProtection` and `Cleanup.tsx` reads `cleanup` through
  `settingsQueryOptions`. Finish the wizard, open Settings > Cleanup: the pane
  shows the pre-wizard protection default for the rest of the session.
- The log panel's follow-tail write is not a second instance. `Advanced.tsx:4-8`
  states `rememberFollowLogs` is surfaced by the log panel rather than duplicated
  in the pane, and `LogPanelContext.tsx:117` seeds itself from a raw
  `commands.settingsGet('advanced')` in a `useEffect`, not from the query cache.
  Nothing that renders that key reads the cache, so invalidating its scope is
  correctness insurance for a future `useQuery` reader, not a fix a user can see.
- `data/settingsWrite.ts` now holds the write plus the invalidation; all nine
  sites call it. `settingsIpc.ts` re-exports it, so its existing callers are
  unchanged.
- It lives in `data/` so the lazy writers there keep reaching it through the
  dynamic import they already use, rather than pulling the whole IPC surface into
  the boot bundle.

## On the bead's two options

The bead recommended (b), a guard test, over (a), one write path, because
`theme`/`locale` write during boot and might have no `QueryClient`. `queryClient`
is a module singleton in `data/queryClient.ts`, not a context value, so that
concern does not hold and both options ship: one write path, and a gate on it.

## Verification

`pnpm vitest run` in `apps/desktop`: 268 files / 2378 tests pass. `tsc --noEmit`
clean; `check-circular.mjs` reports 0 new cycles.

Adding a module that calls `commands.settingsUpdate` makes the guard fail and
names the file. The second assertion covers the other direction: with the
`invalidateQueries` call deleted, a call-site-counting guard alone would still
pass while every write went stale.

`theme.persistence.test.ts` leaked a fire-and-forget write across a test
boundary and only passed because the old write path was slow enough to land
inside its own test. The write is now settled and asserted where it is made.

Tracks-Bead: astro-plan-cia8
Merge-Bead: astro-plan-qsjq
Closes-Bead: astro-plan-cia8

