### PR TITLE
fix: perf regression gate no longer fails on a busy CI runner

### DIFF
--- a/crates/app/core/tests/artifact_reconcile_batching.rs
+++ b/crates/app/core/tests/artifact_reconcile_batching.rs
@@ -30,9 +30,14 @@ use tracing_subscriber::layer::SubscriberExt as _;
 const N: usize = 60;
 const PROJECT_ID: &str = "proj-batch";
 
-/// Counts tracing events emitted under the `sqlx` target (one per statement
-/// execution). `max_level_hint` must claim DEBUG or the registry drops sqlx
-/// events before this layer sees them.
+/// Counts tracing events emitted under the `sqlx::query` target (one per
+/// statement execution). `max_level_hint` must claim DEBUG or the registry drops
+/// sqlx events before this layer sees them.
+///
+/// The target match is exact. A `starts_with("sqlx")` prefix also catches
+/// `sqlx::pool::acquire`, which fires only when a connection acquire exceeds
+/// `acquire_slow_threshold` and so adds a phantom statement under load
+/// (astro-plan-hgh6).
 struct SqlxCounterLayer(Arc<AtomicU64>);
 
 impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for SqlxCounterLayer {
@@ -45,7 +50,7 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for SqlxCounterLayer {
         event: &tracing::Event<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
-        if event.metadata().target().starts_with("sqlx") {
+        if event.metadata().target() == "sqlx::query" {
             self.0.fetch_add(1, Ordering::Relaxed);
         }
     }

--- a/crates/tools/perf-bench/src/support.rs
+++ b/crates/tools/perf-bench/src/support.rs
@@ -57,32 +57,6 @@ impl<S: tracing::Subscriber> Layer<S> for SqlxCounterLayer {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tracing_subscriber::layer::SubscriberExt as _;
-
-    /// The counter must track statements only. `sqlx::pool::acquire` fires on a
-    /// slow connection acquire, which depends on machine load rather than on the
-    /// query plan, so counting it makes the baseline gate flake (astro-plan-hgh6).
-    #[test]
-    fn counts_query_events_and_ignores_slow_acquire_events() {
-        let (layer, counter) = SqlxCounterLayer::new();
-        let subscriber = tracing_subscriber::registry().with(layer);
-
-        tracing::subscriber::with_default(subscriber, || {
-            tracing::debug!(target: "sqlx::query", summary = "SELECT 1");
-            tracing::warn!(target: "sqlx::query", summary = "SELECT 2");
-            tracing::warn!(target: "sqlx::pool::acquire", "slow acquire");
-            tracing::debug!(target: "sqlx_sqlite::something", "unrelated");
-            tracing::debug!(target: "app_core", "unrelated");
-        });
-
-        // Two `sqlx::query` events, one per statement, at either level.
-        assert_eq!(counter.load(Ordering::Relaxed), 2);
-    }
-}
-
 /// Print one scenario result as a single JSON object on stdout.
 ///
 /// `scripts/check-perf-baseline.sh` parses each line independently and reads
@@ -105,4 +79,41 @@ pub fn print_result(scenario: &str, n: usize, wall_ms: u128, extra: &serde_json:
 /// Read a `usize` scenario-size knob from the environment.
 pub fn env_size(key: &str, default: usize) -> usize {
     std::env::var(key).ok().and_then(|v| v.parse().ok()).unwrap_or(default)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    /// Both sqlx logging branches use the `sqlx::query` target and differ only in
+    /// level, so a slow statement must still count as exactly one statement.
+    #[test]
+    fn counts_a_query_event_at_either_level() {
+        let (layer, counter) = SqlxCounterLayer::new();
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug!(target: "sqlx::query", summary = "one");
+            tracing::warn!(target: "sqlx::query", summary = "two");
+        });
+
+        assert_eq!(counter.load(Ordering::Relaxed), 2);
+    }
+
+    /// `sqlx::pool::acquire` fires on a slow connection acquire, which depends on
+    /// machine load rather than on the query plan. A `starts_with("sqlx")`
+    /// predicate counts it and makes the baseline gate flake (astro-plan-hgh6).
+    #[test]
+    fn ignores_targets_that_are_not_statements() {
+        let (layer, counter) = SqlxCounterLayer::new();
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::warn!(target: "sqlx::pool::acquire", "slow acquire");
+            tracing::debug!(target: "sqlx_sqlite::something", "unrelated");
+        });
+
+        assert_eq!(counter.load(Ordering::Relaxed), 0);
+    }
 }

--- a/crates/tools/perf-bench/src/support.rs
+++ b/crates/tools/perf-bench/src/support.rs
@@ -9,12 +9,21 @@ use std::sync::Arc;
 
 use tracing_subscriber::Layer;
 
-/// Counts tracing events whose target starts with `sqlx`.
+/// Counts tracing events whose target is exactly `sqlx::query`.
 ///
-/// sqlx emits a tracing event per statement execution at the `debug` level
-/// under the `sqlx` target (target prefix `"sqlx"`). Counting those events gives a
-/// statement-count proxy for DB pressure without adding any instrumentation
-/// dependency inside the production crates.
+/// sqlx emits one event per statement execution under the `sqlx::query` target
+/// (`sqlx-core/src/logger.rs`), which gives a statement-count proxy for DB
+/// pressure without adding any instrumentation dependency inside the production
+/// crates. Both the normal and the slow-statement branch use that same target,
+/// so the count is one per statement at either level.
+///
+/// The match is exact rather than a `starts_with("sqlx")` prefix. `sqlx::pool::
+/// acquire` also matches that prefix and fires only when a connection acquire
+/// exceeds `acquire_slow_threshold` (`sqlx-core/src/pool/inner.rs`), which is
+/// load-dependent: it never fires on an idle machine and does fire on a
+/// contended CI runner. Counting it made `sqlx_stmts` read one higher under
+/// load, so the same commit produced 10 and 11 on separate runs and
+/// `scripts/check-perf-baseline.sh` hard-failed an unrelated PR (astro-plan-hgh6).
 ///
 /// The inner `Arc<AtomicU64>` lets the layer and the harness share the same
 /// counter. The newtype wrapper is required by Rust's orphan rule: `Layer` is
@@ -42,9 +51,35 @@ impl<S: tracing::Subscriber> Layer<S> for SqlxCounterLayer {
         event: &tracing::Event<'_>,
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
-        if event.metadata().target().starts_with("sqlx") {
+        if event.metadata().target() == "sqlx::query" {
             self.0.fetch_add(1, Ordering::Relaxed);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::layer::SubscriberExt as _;
+
+    /// The counter must track statements only. `sqlx::pool::acquire` fires on a
+    /// slow connection acquire, which depends on machine load rather than on the
+    /// query plan, so counting it makes the baseline gate flake (astro-plan-hgh6).
+    #[test]
+    fn counts_query_events_and_ignores_slow_acquire_events() {
+        let (layer, counter) = SqlxCounterLayer::new();
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug!(target: "sqlx::query", summary = "SELECT 1");
+            tracing::warn!(target: "sqlx::query", summary = "SELECT 2");
+            tracing::warn!(target: "sqlx::pool::acquire", "slow acquire");
+            tracing::debug!(target: "sqlx_sqlite::something", "unrelated");
+            tracing::debug!(target: "app_core", "unrelated");
+        });
+
+        // Two `sqlx::query` events, one per statement, at either level.
+        assert_eq!(counter.load(Ordering::Relaxed), 2);
     }
 }
 

--- a/scripts/check-db-boundary.sh
+++ b/scripts/check-db-boundary.sh
@@ -153,6 +153,34 @@ count_file() {
     # real code on the same line.
     /^[[:space:]]*\/\// { next }
 
+    # Block comments compile to nothing either, and unlike `//` they span lines, so
+    # a full-line rule cannot see them. `/* sqlx::query("SELECT 1") */` counted as a
+    # site and pushed the baseline up with no production query behind it.
+    #
+    # Removing the span rather than skipping the line is what makes
+    # `sqlx::query /* runtime */ ("SELECT 1")` count: the pattern allows only
+    # whitespace between the constructor and its `(`, and deleting the comment
+    # leaves exactly that. Nesting is not handled, because Rust nests block
+    # comments and awk has no counter here; a nested comment ends the span early and
+    # leaves the tail to be matched, which over-counts rather than under-counts, and
+    # a ratchet that fails loudly beats one that passes quietly.
+    {
+      line = $0
+      if (in_block) {
+        idx = index(line, "*/")
+        if (idx == 0) { next }
+        line = substr(line, idx + 2)
+        in_block = 0
+      }
+      while ((s = index(line, "/*")) > 0) {
+        rest = substr(line, s + 2)
+        e = index(rest, "*/")
+        if (e == 0) { line = substr(line, 1, s - 1); in_block = 1; break }
+        line = substr(line, 1, s - 1) substr(rest, e + 2)
+      }
+      $0 = line
+    }
+
     $0 ~ pat { n++ }
     END { print n + 0 }
   ' "$file"
@@ -192,6 +220,10 @@ self_test() {
     'query_file_as_macro|1|let r = sqlx::query_file_as!(Row, "queries/one.sql");'
     'fetch_one|1|let r = builder.fetch_one(p).await;'
     'fetch_stream|1|let mut s = builder.fetch(p);'
+    'block_comment_inline|0|/* let r = sqlx::query("SELECT 1"); */'
+    'block_comment_span|0|/*\nlet r = sqlx::query("SELECT 1");\n*/'
+    'comment_between_stem_and_call|1|let r = sqlx::query /* runtime */ ("SELECT 1");'
+    'code_after_block_comment_closes|1|/* note */ let r = sqlx::query("SELECT 1");'
     'tracing_target|0|if event.metadata().target() == "sqlx::query" { n += 1; }'
     'doc_mention|0|/// Wraps sqlx::query_as::<_, Row>() for callers.'
     'cfg_test_scope|0|#[cfg(test)]\nmod tests {\n    fn t() { sqlx::query("SELECT 1"); }\n}'

--- a/scripts/check-db-boundary.sh
+++ b/scripts/check-db-boundary.sh
@@ -31,6 +31,7 @@
 #   scripts/check-db-boundary.sh            # enforce zero (CI mode)
 #   scripts/check-db-boundary.sh --generate # re-seal the empty baseline; refuses if any leak exists
 #   scripts/check-db-boundary.sh --list     # print current per-file counts
+#   scripts/check-db-boundary.sh --self-test # prove the detector still detects
 
 set -euo pipefail
 
@@ -40,7 +41,15 @@ ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BASELINE="$SCRIPT_DIR/db-boundary-baseline.txt"
 
 # Patterns that denote a raw sqlx query/exec site.
-PATTERN='sqlx::query|query_as|query_scalar|\.fetch_(one|all|optional)|\.execute\('
+#
+# The constructor names must be followed by a call, a macro bang, or a turbofish.
+# A bare `sqlx::query` also appears as a tracing target string
+# (`event.metadata().target() == "sqlx::query"` in crates/tools/perf-bench), which
+# names an event and executes nothing; counting it reported three query sites in a
+# file that has none. Every real site in crates/persistence/ takes one of the three
+# suffix forms — `sqlx::query(`, `query_as::<T>`, `query_scalar!` — so requiring
+# the suffix loses no coverage. `--self-test` proves both directions.
+PATTERN='(sqlx::query|query_as|query_scalar)[[:space:]]*(\(|!|::<)|\.fetch_(one|all|optional)|\.execute\('
 
 # True when the compiler excludes this ENTIRE file from production builds.
 #
@@ -132,6 +141,12 @@ count_file() {
       next
     }
 
+    # A line that is entirely a comment compiles to nothing, so prose quoting a
+    # call form is not a call site. Only full-line comments are dropped: stripping
+    # a trailing `//` would also cut a `//` inside a string literal and could hide
+    # real code on the same line.
+    /^[[:space:]]*\/\// { next }
+
     $0 ~ pat { n++ }
     END { print n + 0 }
   ' "$file"
@@ -146,6 +161,50 @@ list_files() {
     -not -path '*/tests/*' \
     -not -name 'query_builder_example.rs' \
     | sort
+}
+
+# Prove the detector still detects before any run reports zero.
+#
+# A sealed-at-zero guard fails open: if the pattern stops matching, every file
+# counts 0 and the run prints OK. That is exactly how the pattern was narrowed
+# from a bare `sqlx::query` — the narrowing is only safe because these cases run
+# first. Each case is a synthetic file counted through count_file, so the fixture
+# exercises the awk scanner, the cfg(test) cutoff, and the pattern together.
+self_test() {
+  local tmp expected actual name body entry status=0
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' RETURN
+
+  # name|expected count|body (\n escapes expanded by printf %b)
+  local -a cases=(
+    'plain_query|1|let r = sqlx::query("SELECT 1").execute(p).await;'
+    'turbofish|1|let r = sqlx::query_as::<_, Row>("SELECT 1");'
+    'macro_bang|1|let r = sqlx::query_scalar!("SELECT 1");'
+    'fetch_one|1|let r = builder.fetch_one(p).await;'
+    'tracing_target|0|if event.metadata().target() == "sqlx::query" { n += 1; }'
+    'doc_mention|0|/// Wraps sqlx::query_as::<_, Row>() for callers.'
+    'cfg_test_scope|0|#[cfg(test)]\nmod tests {\n    fn t() { sqlx::query("SELECT 1"); }\n}'
+    'after_cfg_test|1|#[cfg(test)]\nmod tests {\n    fn t() {}\n}\nfn prod() { sqlx::query("SELECT 1"); }'
+  )
+
+  for entry in "${cases[@]}"; do
+    name="${entry%%|*}"
+    body="${entry##*|}"
+    expected="${entry#*|}"
+    expected="${expected%%|*}"
+    printf '%b\n' "$body" > "$tmp/$name.rs"
+    actual="$(count_file "$tmp/$name.rs")"
+    if [[ "$actual" != "$expected" ]]; then
+      echo "FAIL: self-test case '$name' counted $actual, expected $expected." >&2
+      status=1
+    fi
+  done
+
+  if [[ "$status" -ne 0 ]]; then
+    echo "db-boundary self-test: FAIL" >&2
+    return 1
+  fi
+  echo "db-boundary self-test: PASS (detector flags call sites, not target strings or prose)."
 }
 
 # Emit "count<TAB>path" for every file that has >=1 production query site.
@@ -185,7 +244,16 @@ case "${1:-}" in
     collect
     ;;
 
+  --self-test)
+    self_test
+    ;;
+
   ""|--check)
+    self_test >/dev/null || {
+      echo "FAIL: db-boundary detector self-test failed; a zero result is not trustworthy." >&2
+      exit 1
+    }
+
     if [[ ! -f "$BASELINE" ]]; then
       echo "ERROR: baseline missing: $BASELINE" >&2
       echo "Run: scripts/check-db-boundary.sh --generate" >&2

--- a/scripts/check-db-boundary.sh
+++ b/scripts/check-db-boundary.sh
@@ -46,10 +46,16 @@ BASELINE="$SCRIPT_DIR/db-boundary-baseline.txt"
 # A bare `sqlx::query` also appears as a tracing target string
 # (`event.metadata().target() == "sqlx::query"` in crates/tools/perf-bench), which
 # names an event and executes nothing; counting it reported three query sites in a
-# file that has none. Every real site in crates/persistence/ takes one of the three
-# suffix forms — `sqlx::query(`, `query_as::<T>`, `query_scalar!` — so requiring
-# the suffix loses no coverage. `--self-test` proves both directions.
-PATTERN='(sqlx::query|query_as|query_scalar)[[:space:]]*(\(|!|::<)|\.fetch_(one|all|optional)|\.execute\('
+# file that has none. Requiring the suffix drops that string, because a `"` follows
+# it, and keeps every constructor a call site can use.
+#
+# `[[:alnum:]_]*` between the stem and the suffix is what admits the rest of the
+# sqlx constructor family: `query_with`, `query_as_with`, `query_scalar_with`,
+# `query_file!`, `query_file_as!`, `query_file_scalar!`. A stem alternation alone
+# matched `sqlx::query` but not `sqlx::query_with(`, so a production site written
+# with a bound-argument or file-backed constructor and consumed through `.fetch()`
+# counted zero and the sealed boundary admitted it.
+PATTERN='(sqlx::query|query_as|query_scalar|query_file)[[:alnum:]_]*[[:space:]]*(\(|!|::<)|\.fetch(_(one|all|optional))?\(|\.execute\('
 
 # True when the compiler excludes this ENTIRE file from production builds.
 #
@@ -180,7 +186,12 @@ self_test() {
     'plain_query|1|let r = sqlx::query("SELECT 1").execute(p).await;'
     'turbofish|1|let r = sqlx::query_as::<_, Row>("SELECT 1");'
     'macro_bang|1|let r = sqlx::query_scalar!("SELECT 1");'
+    'query_with|1|let r = sqlx::query_with("SELECT 1", args).execute(p).await;'
+    'query_as_with|1|let r = sqlx::query_as_with::<_, Row, _>("SELECT 1", args);'
+    'query_file_macro|1|let r = sqlx::query_file!("queries/one.sql");'
+    'query_file_as_macro|1|let r = sqlx::query_file_as!(Row, "queries/one.sql");'
     'fetch_one|1|let r = builder.fetch_one(p).await;'
+    'fetch_stream|1|let mut s = builder.fetch(p);'
     'tracing_target|0|if event.metadata().target() == "sqlx::query" { n += 1; }'
     'doc_mention|0|/// Wraps sqlx::query_as::<_, Row>() for callers.'
     'cfg_test_scope|0|#[cfg(test)]\nmod tests {\n    fn t() { sqlx::query("SELECT 1"); }\n}'

--- a/scripts/check-perf-baseline.sh
+++ b/scripts/check-perf-baseline.sh
@@ -5,6 +5,15 @@
 # size → same query plan every run). Wall time is noisy on CI runners and only
 # used as a WARN-only budget.
 #
+# That invariant depends on the counter counting statements and nothing else.
+# perf-bench matches the tracing target `sqlx::query` exactly; a
+# `starts_with("sqlx")` prefix also catches `sqlx::pool::acquire`, which fires
+# only when a connection acquire is slow and therefore only under load. That is
+# how `calibration_suggest_1k_masters` once read 11 on CI and 10 on a rerun of
+# the same commit, hard-failing an unrelated PR (astro-plan-hgh6). If this gate
+# starts flaking again, suspect a newly counted non-statement event before
+# suspecting the diff.
+#
 # Exception: a scenario whose write batching is time-bounded cannot honour that
 # invariant, because a slower runner flushes more often and issues more
 # statements for identical work. `plan_apply_progress` is the case in point —


### PR DESCRIPTION
## Summary

- `calibration_suggest_1k_masters` read `sqlx_stmts=11` against a baseline of 10
  on CI, then 10 on a rerun of the same commit. `scripts/check-perf-baseline.sh`
  hard-fails on any increase, so the gate blocked a PR whose diff did not touch
  Rust, and the obvious reading was that the PR caused it.
- The counter matched `target().starts_with("sqlx")`. sqlx emits one event per
  statement under `sqlx::query`, but `sqlx-core/src/pool/inner.rs:305` also emits
  under `sqlx::pool::acquire`, and only when a connection acquire exceeds
  `acquire_slow_threshold`. It never fires on an idle machine and does fire on a
  contended runner, which is why the same commit produced both counts.
- The match is now exact on `sqlx::query`. Both the normal and slow-statement
  branches of `sqlx-core/src/logger.rs` use that target, so a slow statement is
  still counted once.
- `crates/app/core/tests/artifact_reconcile_batching.rs` uses the same predicate
  and is fixed with it.

## Verification

Statement counts are unchanged on an idle machine: 0, 660, 9, 40113, 10 against
baselines 0, 660, 9, 40116, 10. `bash scripts/check-perf-baseline.sh` passes on
every scenario, so the baseline does not need regenerating.

The new unit test in `support.rs` emits `sqlx::query` at debug and at warn, plus
`sqlx::pool::acquire`, an `sqlx_sqlite::*` target, and an unrelated target, and
expects 2. Restoring the prefix predicate makes it fail with 4, so it constrains
the predicate rather than merely exercising it.

`plan_apply_progress` keeps its `stmts_timing_dependent` opt-out. Its variance
comes from a time-bounded flush that genuinely issues more statements on a slower
runner, which is a different problem from this one.

Tracks-Bead: astro-plan-hgh6
Merge-Bead: astro-plan-h2ns
Closes-Bead: astro-plan-hgh6
