### PR TITLE
fix: onboarding spotlight no longer gives up on a control that is still loading

### DIFF
--- a/apps/desktop/src/features/onboarding/FindSpotlight.arrival.test.tsx
+++ b/apps/desktop/src/features/onboarding/FindSpotlight.arrival.test.tsx
@@ -2,18 +2,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * Which signal starts the spotlight's short anchor deadline (spec 056 FR-022).
+ * Which signal starts the spotlight's anchor deadline (spec 056 FR-022).
  *
  * Two budgets share one resolve loop: a 3s pre-arrival navigation grace, and a
- * 1.5s post-arrival anchor wait restarted from the moment the target route is on
+ * 4s post-arrival anchor wait restarted from the moment the target route is on
  * screen. Recording arrival on the wrong signal silently converts legitimate
- * navigation time into anchor-wait time and shows the unavailable callout while
- * the app is still navigating, so each case below pins WHICH deadline governs by
- * checking whether the callout has appeared at 2s — past the short deadline,
- * short of the long one.
+ * navigation time into anchor-wait time, so each case below pins WHICH deadline
+ * governs by probing at a time that only one of them has passed.
  *
- * The anchor never exists in these runs (nothing renders a `data-guide-anchor`),
- * so the loop always ends in the callout; only its timing is under test.
+ * Except where a case inserts one, the anchor never exists in these runs, so the
+ * loop always ends in the callout; only its timing is under test.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -135,8 +133,12 @@ describe('FindSpotlight arrival tracking', () => {
     const navigate = await mountFind(item('sessions.add_note', 'sessions'));
     await navigate('/sessions/session-1');
 
-    await advance(2000);
+    // Past the pre-arrival grace, short of the post-arrival deadline: still
+    // waiting proves the clock restarted on arrival.
+    await advance(3200);
+    expect(unavailable()).toBeNull();
 
+    await advance(1200);
     expect(unavailable()).not.toBeNull();
   });
 
@@ -144,9 +146,33 @@ describe('FindSpotlight arrival tracking', () => {
     pathname = '/projects';
     await mountFind(item('projects.create_first', 'projects'));
 
-    await advance(2000);
+    await advance(3200);
+    expect(unavailable()).toBeNull();
 
+    await advance(1200);
     expect(unavailable()).not.toBeNull();
+  });
+
+  it('still finds a data-gated anchor that renders 2.5s after arrival', async () => {
+    // The post-arrival phase waits on an IPC query and a render, not on the
+    // route: with the budgets ordered the other way round (1.5s post-arrival)
+    // this anchor is reported missing before it ever mounts, and that verdict is
+    // terminal.
+    pathname = '/projects';
+    await mountFind(item('projects.create_first', 'projects'));
+
+    await advance(2500);
+    const anchor = document.createElement('button');
+    anchor.dataset.guideAnchor = 'projects.create-cta';
+    document.body.append(anchor);
+    await advance(200);
+
+    // Total elapsed now exceeds the post-arrival deadline: had the loop given up
+    // before the anchor mounted, the callout would be latched on.
+    await advance(2000);
+    expect(unavailable()).toBeNull();
+
+    anchor.remove();
   });
 
   it('dismisses on navigation away from the page even when the deep link never resolved', async () => {

--- a/apps/desktop/src/features/onboarding/FindSpotlight.tsx
+++ b/apps/desktop/src/features/onboarding/FindSpotlight.tsx
@@ -152,13 +152,17 @@ export function useActiveFindItem(): OnboardingItemDto | null {
 // ── Spotlight ─────────────────────────────────────────────────────────────────
 
 const PULSE_MS = 2500;
-// Two budgets, because waiting for a route to land and waiting for an anchor on
-// the page already shown are different problems. Cross-page navigation plus
-// React hydration under full-suite Playwright load can take ~2s, so the
-// pre-arrival budget is generous; once the target page is on screen an absent
-// anchor is absent, and the user should not wait 3s for the explanation.
+// Two budgets, because the two phases wait on different things. No route in
+// `router.tsx` has a loader, so a route commit waits only on a lazy chunk plus
+// the optional pre-navigation lookup here (`fetchFirstSessionId` for a deep
+// link) — page DATA is fetched after the commit, in the mounted component. The
+// post-arrival phase is therefore the one that waits on an IPC query and a
+// render: data-gated anchors (inbox rows, sessions rows, master rows) do not
+// exist until their query resolves, and a large library makes that slow. A
+// premature `missing` is terminal — the resolve effect re-runs only on
+// `[selector]` — so the post-arrival budget gets the larger allowance.
 const NAVIGATION_GRACE_MS = 3000;
-const ARRIVED_TIMEOUT_MS = 1500;
+const ARRIVED_TIMEOUT_MS = 4000;
 const RESOLVE_POLL_MS = 60;
 
 // react-joyride wire strings (enum imports stay in the adapter — mirrored here).
@@ -261,8 +265,8 @@ function SpotlightFor({
         return;
       }
       // Before arrival the navigation grace applies; arrival restarts the clock
-      // on the shorter anchor wait, so a genuinely absent control is reported
-      // ~1.5s after the page is visible instead of ~3s after activation.
+      // on the anchor wait, so the query that renders a data-gated anchor gets
+      // its full allowance measured from when its page came on screen.
       const arrivedAt = arrivedAtRef.current;
       const deadline =
         arrivedAt === null

--- a/scripts/eslint-alm-baseline.txt
+++ b/scripts/eslint-alm-baseline.txt
@@ -33,7 +33,7 @@ src/features/inbox/InboxDetail.tsx	366	alm/require-root-testid
 src/features/inbox/InboxNeedsReview.tsx	113	alm/require-root-testid
 src/features/inbox/PlanDestructiveControl.tsx	33	alm/require-root-testid
 src/features/onboarding/ChecklistPopover.tsx	110	alm/require-root-testid
-src/features/onboarding/FindSpotlight.tsx	173	alm/require-root-testid
+src/features/onboarding/FindSpotlight.tsx	177	alm/require-root-testid
 src/features/onboarding/OrientationWalk.tsx	161	alm/require-root-testid
 src/features/onboarding/joyrideAdapter.tsx	209	alm/require-root-testid
 src/features/plans/PlanProtectionGate.tsx	116	alm/require-root-testid


### PR DESCRIPTION
## Summary

- The onboarding spotlight gave up on controls that were about to render. `FindSpotlight` split its resolve budget as 3000 ms before arrival and 1500 ms after, on the rationale that navigation is the slow phase.
- No route in `router.tsx` declares a loader or `ensureQueryData`, so a route commit waits only on a lazy chunk and page data is fetched after the commit inside the mounted component. The waiting therefore happens after arrival, and the data-gated anchors (inbox rows, sessions rows, master rows) are exactly the ones that mount late. A premature `missing` is terminal, because the resolve effect re-runs only on `[selector]`, so the callout persisted even once the anchor appeared.
- Post-arrival goes to 4000 ms. The pre-arrival grace stays at 3000 ms rather than shrinking, because it also covers the deep-link `fetchFirstSessionId` lookup that precedes navigation. Worst-case total rises from 4.5 s to 7 s: a slightly longer successful wait beats a spotlight that abandons a control that was about to render.

## Test plan

`pnpm test` in `apps/desktop`. The arrival test probes were pinned at 2 s, which no longer distinguishes the phases; they now bracket each deadline, and a new case renders the anchor 2.5 s after arrival. Three of the six cases fail under the old split. The line number in the alm baseline shifts with the longer comment.

## Spec Context

Tracks-Bead: astro-plan-l3tl
Closes-Bead: astro-plan-l3tl
Merge-Bead: astro-plan-bafl
