### PR TITLE
fix(ci): stop hiding the primary CI workflow from every scanner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,6 +523,10 @@ jobs:
             # zero runnable tests (e.g. an e2e_tests-only change — all its
             # tests are #[ignore]d for the Layer-2 e2e.yml job), and nextest
             # otherwise exits 4 ("no tests to run", run 28751553778).
+            #
+            # $args is a word list of `-p <crate>` flags and has to split, so the
+            # SC2086 quote would collapse it into one bad argument.
+            # shellcheck disable=SC2086
             cargo nextest run --profile ci --no-tests=pass $args
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "changes: rust=$rust frontend=$frontend frontend_full=$frontend_full docs_only=$docs_only scripts=${{ steps.filter.outputs.scripts }}"
 
+      # This job is the only one with no gate, which is what the guard needs: a
+      # PR that reintroduces an ignore rule for `.github/` may touch nothing
+      # else, and every other job would skip it. The check is a `git ls-files`
+      # plus one `git check-ignore`, so it costs nothing here.
+      - name: Workflows visible to ignore-respecting scanners
+        run: bash scripts/check-github-not-ignored.sh
+
   # Three lanes share this matrix (Rust, frontend, scripts), each with its own
   # step-level gate, so it is NOT split into separate jobs. The job-level gate
   # below fires only when ALL lanes are idle -- the case where the job had

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,7 @@
 __MACOSX/
 .AppleDouble
 .LSOverride
-Icon[
-]
+Icon[]
 
 # Resource forks
 ._*
@@ -30,8 +29,7 @@ Icon[
 .file
 .disk_label*
 lost+found
-.HFS+ Private Directory Data[
-]
+.HFS+ Private Directory Data[]
 
 # Directories potentially created on remote AFP share
 .AppleDB

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 __MACOSX/
 .AppleDouble
 .LSOverride
-Icon[]
+Icon[
+]
 
 # Resource forks
 ._*
@@ -29,7 +30,8 @@ Icon[]
 .file
 .disk_label*
 lost+found
-.HFS+ Private Directory Data[]
+.HFS+ Private Directory Data[
+]
 
 # Directories potentially created on remote AFP share
 .AppleDB
@@ -354,8 +356,6 @@ apps/desktop/playwright-report/
 /.idea/
 .idea
 
-# parked: needs workflow-scoped push (content in docs/development/ci/)
-.github/workflows/ci.yml
 
 
 # Headroom live runtime state — never version-controlled

--- a/justfile
+++ b/justfile
@@ -28,6 +28,9 @@ lint:
     pnpm -r --if-present lint
     pnpm run lint:tests
     pre-commit run --all-files
+    # A tracked file under .github/ that a gitignore rule also matches stays in
+    # git and disappears from every ignore-respecting scanner. Sealed at zero.
+    bash scripts/check-github-not-ignored.sh
 
 # Build the Rust workspace and package workspaces when present.
 build:

--- a/scripts/check-github-not-ignored.sh
+++ b/scripts/check-github-not-ignored.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright (C) 2024-2026 Sjors Robroek
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Fail when a tracked file under .github/ is also matched by a gitignore rule
+# (astro-plan-o1om). Sealed at zero.
+#
+# Why this exists: git keeps honouring a tracked file, so an ignore rule over one
+# changes nothing about commits or CI and produces no warning. Every
+# ignore-respecting scanner drops it. `.github/workflows/ci.yml` was ignored as
+# `# parked: needs workflow-scoped push`, and for as long as that entry stood,
+# ripgrep, opengrep, gitleaks, trivy, zizmor, actionlint, osv-scanner, and
+# ast-grep all reported a clean primary CI workflow they never opened. Measured at
+# the time: `rg -n 'run: just ' .github/workflows/` returned 0 and `--no-ignore`
+# returned 5.
+#
+# The failure mode is a clean report, not an error, which is why it needs a guard
+# rather than a convention.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT"
+
+hidden="$(git ls-files -i -c --exclude-standard -- .github)"
+
+if [ -z "$hidden" ]; then
+  echo "OK: no tracked file under .github/ is hidden by a gitignore rule."
+  exit 0
+fi
+
+echo "FAIL: tracked files under .github/ are matched by a gitignore rule:" >&2
+printf '    %s\n' "$hidden" >&2
+cat >&2 <<'EOF'
+
+git still tracks these, so the ignore rule changes nothing about what gets
+committed. What it changes is that every ignore-respecting scanner skips them and
+reports the surface clean. Drop the rule, or untrack the file if it genuinely
+should not be in the repo.
+
+To find which rule matches:
+  git check-ignore -v <path>
+EOF
+exit 1


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml` was tracked and also listed in `.gitignore` as `# parked: needs workflow-scoped push`. git keeps honouring a tracked file, so the entry changed nothing about commits or CI and did not warn. What it changed is that every ignore-respecting traversal skipped the primary workflow.
- Measured on `main`: `rg -n 'run: just ' .github/workflows/` returned 0; `rg --no-ignore -n ...` returned 5. ripgrep, opengrep, gitleaks, trivy, zizmor, actionlint, osv-scanner, and ast-grep were all reporting a clean surface they never opened.

## Changes

- The `.gitignore` entry is gone.
- `scripts/check-github-not-ignored.sh` seals it at zero and runs from `just lint`. It fails when `git ls-files -i -c --exclude-standard -- .github` returns anything. Verified in both directions: clean after the fix, and it names `ci.yml` when run against the pre-fix `.gitignore`.
- ci.yml:518 carried the one actionlint shellcheck issue the invisibility hid. `$args` holds a `-p <crate>` word list that has to split, so the SC2086 quote would collapse it into one bad argument. A disable directive and a reason sit above it. `actionlint .github/workflows/ci.yml` is now clean.

## Out of scope

- zizmor reports 10 `unpinned-uses` and 6 `artipacked` against ci.yml. That is the same unpinned-action posture as the workflows that were never hidden (`e2e.yml` reports 23 and 9), so it is a repo-wide policy question rather than something this entry concealed.
- Other tracked-but-ignored paths exist outside `.github/` (`.claude/settings.local.json`, seven review screenshots). The guard is scoped to `.github/` because that is where an invisible file changes what CI enforces.

## Spec Context

Tracks-Bead: astro-plan-o1om
Merge-Bead: astro-plan-6t6y