### PR TITLE
fix: keep clippy passing when the toolchain moves forward

### DIFF
--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -221,6 +221,11 @@ struct ResolvedToolConfig {
 /// Load project and validate tool configuration (profile exists, enabled, path set).
 ///
 /// Returns `Err(ToolLaunchResponse)` for user-facing validation failures.
+// The `Err` variant is the contract response DTO, not an error type: `launch`
+// receives it and returns it as `Ok`. Boxing to satisfy the 128-byte threshold
+// would add an allocation and an unbox at the one call site, on a path that is
+// about to spawn a process, and buy nothing.
+#[allow(clippy::result_large_err)]
 async fn resolve_tool_config(
     pool: &SqlitePool,
     bus: &EventBus,
@@ -262,6 +267,8 @@ async fn resolve_tool_config(
 ///
 /// Returns the canonical working-directory string, or `Err(ToolLaunchResponse)`
 /// when the resolved path falls outside all registered library roots.
+// See `resolve_tool_config` above for why the large `Err` variant stays unboxed.
+#[allow(clippy::result_large_err)]
 async fn resolve_and_check_working_dir(
     pool: &SqlitePool,
     project_path: &str,

--- a/crates/metadata/fits/src/lib.rs
+++ b/crates/metadata/fits/src/lib.rs
@@ -100,7 +100,9 @@ fn read_header_bytes(mut reader: impl Read) -> io::Result<Vec<u8>> {
         }
 
         let has_end = block
-            .chunks_exact(CARD_SIZE)
+            .as_chunks::<CARD_SIZE>()
+            .0
+            .iter()
             .any(|c| c.starts_with(b"END     ") || c.starts_with(b"END\x00"));
         bytes.extend_from_slice(&block);
         if has_end {

--- a/crates/persistence/core/src/operation_state.rs
+++ b/crates/persistence/core/src/operation_state.rs
@@ -136,6 +136,15 @@ pub struct InMemoryOperationStateRepository {
     states: std::collections::BTreeMap<String, OperationState>,
 }
 
+// `async` here is the trait's contract, not this double's need: the real SQLite
+// implementation awaits, a `BTreeMap` has nothing to await. Returning
+// `std::future::ready` instead, as the lint suggests, would run each body at call
+// time rather than at poll time, which is a behaviour change for a test double.
+//
+// `allow` rather than `expect`, and paired with `unknown_lints`, because clippy
+// added `unused_async_trait_impl` in 1.98: an expectation would go unfulfilled on
+// older toolchains, and naming the lint at all is itself unknown to them.
+#[allow(unknown_lints, clippy::unused_async_trait_impl)]
 impl OperationStateRepository for InMemoryOperationStateRepository {
     async fn insert_operation_state(&mut self, state: &OperationState) -> DbResult<()> {
         self.states.insert(state.id.clone(), state.clone());

--- a/crates/persistence/lifecycle/src/repositories/lifecycle.rs
+++ b/crates/persistence/lifecycle/src/repositories/lifecycle.rs
@@ -659,6 +659,15 @@ fn parse_entity_type(s: &str) -> EntityType {
 #[derive(Default)]
 pub struct InMemoryLifecycleRepository;
 
+// `async` here is the trait's contract, not this stub's need: the sqlx
+// implementation awaits, a stub that returns a constant has nothing to await.
+// Returning `std::future::ready` instead, as the lint suggests, would run each
+// body at call time rather than at poll time.
+//
+// `allow` rather than `expect`, and paired with `unknown_lints`, because clippy
+// added `unused_async_trait_impl` in 1.98: an expectation would go unfulfilled on
+// older toolchains, and naming the lint at all is itself unknown to them.
+#[allow(unknown_lints, clippy::unused_async_trait_impl)]
 impl LifecycleRepository for InMemoryLifecycleRepository {
     async fn load_asset_detail(
         &self,


### PR DESCRIPTION
## Summary

- CI's toolchain is unpinned `stable`, so it moved to clippy 1.98 while local
  toolchains are on 1.95. `chunks_exact_to_as_chunks`, `unused_async_trait_impl`,
  and `result_large_err` fail the `Unit + integration (L1+L2)` job on **every** open
  PR, including ones whose diff is only YAML. Clippy 1.95 has none of them, so
  `just lint` passes locally, which is why nobody saw it.
- `chunks_exact_to_as_chunks` in `metadata_fits`: `read_header_bytes` now walks the
  2880-byte header block with `as_chunks::<CARD_SIZE>()`. 2880 is 36 cards exactly,
  so the remainder slice is empty and the scan covers the same bytes as before.
- `unused_async_trait_impl` on the in-memory `OperationStateRepository` and
  `LifecycleRepository` doubles: allowed, not rewritten. The suggested
  `std::future::ready` would run each body at call time instead of at poll time,
  which changes the semantics of a test double to satisfy a lint. Each `allow` is
  paired with `unknown_lints` so clippy 1.95 does not warn on the unknown name.
- `result_large_err` on the two `tool_launch` helpers: their `Err` variant is the
  contract response DTO, which `launch` receives and returns as `Ok`. Boxing it to
  reach the 128-byte threshold adds an allocation and an unbox at the one call site.
- Verified against both toolchains: clippy 1.98 over the workspace, all targets,
  warnings denied, reports nothing, and so does clippy 1.95 over the four crates
  touched here. Tests pass for `metadata_fits`, `persistence_core`, and
  `persistence_lifecycle`.

Not fixed here: `rust-toolchain.toml` is still `channel = "stable"` with no
version, which is the underlying cause. Pinning it is a repo-wide policy call.

## Spec Context

Repository tooling, outside any spec.

Tracks-Bead: astro-plan-0g8e
Closes-Bead: astro-plan-0g8e

Merge-Bead: astro-plan-3u3t
