### PR TITLE
fix: catch drift in the generated contract type declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,7 @@ jobs:
       frontend_full: ${{ steps.decide.outputs.frontend_full }}
       docs_only: ${{ steps.decide.outputs.docs_only }}
       scripts: ${{ steps.filter.outputs.scripts }}
+      spec_contracts: ${{ steps.filter.outputs.spec_contracts }}
       all_files: ${{ steps.filter.outputs.all_files }}
     steps:
       - uses: actions/checkout@v4
@@ -172,6 +173,11 @@ jobs:
               - '**/*.css'
             scripts:
               - 'scripts/**'
+            # Feeds the TypeScript declaration generator, so it has to trigger
+            # the drift gate. Narrower than `docs`, which would put a
+            # Rust-compiling gate behind every markdown edit.
+            spec_contracts:
+              - 'specs/*/contracts/**'
             docs:
               - 'docs/**'
               - 'e2e-agentic-test/**'
@@ -648,14 +654,26 @@ jobs:
         run: pnpm --filter @astro-plan/desktop size
 
       # --- Generated contract / binding drift gate (review finding W1) ---
-      # Regenerates Rust->TS bindings and contracts and fails on drift. Compiles
+      # Regenerates Rust->TS bindings, contract schemas, and the
+      # json-schema-to-typescript declarations, then fails on drift. Compiles
       # Rust, so it belongs to the Rust lane. Linux-only for the same reason as
       # clippy and the doctests above: the generator's output is OS-agnostic and
       # every file it writes is pinned to `eol=lf` in .gitattributes, so the
-      # `git diff --exit-code` verdict cannot differ per platform.
+      # verdict cannot differ per platform.
       - name: Generated contract/binding drift
         if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
         run: just check-generated
+
+      # The declaration generator also reads `packages/contracts/schemas/` and
+      # `specs/*/contracts/`, neither of which sets the `rust` filter. This leg
+      # covers them without the Rust toolchain, system webkit, or cargo cache
+      # that a frontend-only change does not install.
+      - name: Contract declaration drift (no Rust)
+        if: >-
+          runner.os == 'Linux' && needs.changes.outputs.rust != 'true' &&
+          (needs.changes.outputs.frontend == 'true' ||
+          needs.changes.outputs.spec_contracts == 'true')
+        run: just check-contracts-ts
 
       # A frontend-only change leaves this leg with every step skipped on macOS
       # and Windows. The leg still has to report its required context, so say in

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,9 @@ jobs:
   integration:
     name: Unit + integration (L1+L2) — ${{ matrix.os }}
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.scripts == 'true'
+    if: >-
+      needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true' ||
+      needs.changes.outputs.scripts == 'true' || needs.changes.outputs.spec_contracts == 'true'
     strategy:
       fail-fast: false # report each platform distinctly (FR-011)
       matrix:
@@ -316,25 +318,35 @@ jobs:
           shared-key: "rust-${{ matrix.os }}-v2"
 
       - uses: pnpm/action-setup@v6
-        if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
+        if: >-
+          needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true' ||
+          needs.changes.outputs.spec_contracts == 'true'
         with:
           version: 11.17.0
 
       - uses: actions/setup-node@v4
-        if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
+        if: >-
+          needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true' ||
+          needs.changes.outputs.spec_contracts == 'true'
         with:
           node-version: 24
           cache: pnpm
 
-      # `just` drives the DB-boundary ratchet and the generated-drift gate, both
-      # of which run under the Rust lane.
+      # `just` drives the DB-boundary ratchet, the generated-drift gate, and the
+      # no-Rust contract-declaration drift gate below. That last one runs on the
+      # frontend and spec-contract lanes, so gating this install on `rust` alone
+      # left it calling a `just` that was never installed.
       - uses: taiki-e/install-action@v2
-        if: needs.changes.outputs.rust == 'true'
+        if: >-
+          needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true' ||
+          needs.changes.outputs.spec_contracts == 'true'
         with:
           tool: just,nextest
 
       - name: Install JS deps
-        if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
+        if: >-
+          needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true' ||
+          needs.changes.outputs.spec_contracts == 'true'
         run: pnpm install --frozen-lockfile
 
       # Vite's dependency-optimizer output. Restored AFTER `pnpm install`
@@ -727,7 +739,9 @@ jobs:
   integration-idle:
     name: Unit + integration (L1+L2) — ${{ matrix.os }}
     needs: changes
-    if: needs.changes.outputs.rust != 'true' && needs.changes.outputs.frontend != 'true'
+    if: >-
+      needs.changes.outputs.rust != 'true' && needs.changes.outputs.frontend != 'true' &&
+      needs.changes.outputs.spec_contracts != 'true'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/justfile
+++ b/justfile
@@ -153,13 +153,20 @@ contracts-build:
 ve-themes-check:
     pnpm --filter @astro-plan/desktop ve:themes:check
 
-# Regenerate Rust-derived JSON contract schemas and the tauri-specta
-# TypeScript bindings, then fail when either is out of sync with the
-# committed tree. Wire this into CI for spec 002 + onward.
+# Regenerate every generated artifact — Rust-derived JSON contract schemas, the
+# tauri-specta TypeScript bindings, and the json-schema-to-typescript
+# declarations — then fail when any is out of sync with the committed tree.
 check-generated:
     cargo run -q -p contracts_core --bin generate-contracts
     cargo test -q -p desktop_shell --features dev-tools --test bindings
-    git diff --exit-code specs/*/contracts/*.generated.json apps/desktop/src/bindings/
+    pnpm --filter @astro-plan/contracts build
+    bash scripts/check-generated-drift.sh
+
+# The declaration half of check-generated, without the cargo steps. For a change
+# that touches the schemas or a spec contract but no Rust.
+check-contracts-ts:
+    pnpm --filter @astro-plan/contracts build
+    bash scripts/check-generated-drift.sh packages/contracts/src/generated/
 
 # Full pre-merge gate: lint + tests + typecheck + generated-artifact drift +
 # DB/dead-caller/hot-read/lifecycle-strings boundary ratchets.

--- a/packages/contracts/scripts/build-schemas.mjs
+++ b/packages/contracts/scripts/build-schemas.mjs
@@ -60,9 +60,10 @@ const SPEC_CONTRACT_ALLOWLIST = [
   // Spec 013 — Target Lookup From FITS OBJECT
   "013-target-lookup-from-fits-object/contracts/target.lookup.json",
   "013-target-lookup-from-fits-object/contracts/target.resolve.json",
-  // Spec 006 — Inventory Lifecycle
-  "006-inventory-library-lifecycle/contracts/inventory.list.json",
-  "006-inventory-library-lifecycle/contracts/inventory.session.review.json",
+  // Spec 006's inventory.list and inventory.session.review contracts are
+  // deliberately absent: `../schemas/` holds the maintained copies of both, and
+  // those are the ones `tests/contract/contract_jsonschema_roundtrip.rs`
+  // validates against.
   // Spec 012 — Processing Artifact Observation
   "012-processing-artifact-observation/contracts/artifact.list.json",
   "012-processing-artifact-observation/contracts/artifact.classify.json",
@@ -72,15 +73,22 @@ const SPEC_CONTRACT_ALLOWLIST = [
   "019-bottom-log-viewer/contracts/log.export.json",
 ];
 
+// A missing allowlist entry means the allowlist is stale, not that this run
+// should emit fewer declaration files. The old version checked only that the
+// parent directory existed and silently dropped the entry, so a renamed spec
+// folder produced a smaller `src/generated` that the drift gate then accepted.
 function findSpecContracts() {
-  return SPEC_CONTRACT_ALLOWLIST.map((rel) => join(specsDir, rel)).filter((path) => {
-    try {
-      readdirSync(join(path, "..")); // ensure parent exists
-      return true;
-    } catch {
-      return false;
-    }
-  });
+  const paths = SPEC_CONTRACT_ALLOWLIST.map((rel) => join(specsDir, rel));
+  const missing = paths.filter((path) => !existsSync(path));
+  if (missing.length > 0) {
+    console.error(
+      `${missing.length} allowlisted spec contract(s) do not exist. Update ` +
+        "SPEC_CONTRACT_ALLOWLIST in this script:\n" +
+        missing.map((m) => `  ${m}`).join("\n"),
+    );
+    process.exit(1);
+  }
+  return paths;
 }
 
 const json2ts = resolveJson2Ts();
@@ -101,9 +109,26 @@ const stagingDir = `${generatedDir}.staging`;
 rmSync(stagingDir, { recursive: true, force: true });
 mkdirSync(stagingDir, { recursive: true });
 
-const failures = [];
+// Two schemas that reduce to the same stem write the same `.d.ts`, and the
+// second silently wins. That is how the paginated `inventory.list` schema came
+// to be overwritten by a spec copy that had never gained the pagination fields.
+const stems = new Map();
 for (const schema of schemas) {
   const stem = basename(schema, ".schema.json").replace(/\.json$/, "");
+  const existing = stems.get(stem);
+  if (existing) {
+    rmSync(stagingDir, { recursive: true, force: true });
+    console.error(
+      `Two schemas both generate ${stem}.d.ts, so one would overwrite the ` +
+        `other:\n  ${existing}\n  ${schema}\nDrop one, or rename its file.`,
+    );
+    process.exit(1);
+  }
+  stems.set(stem, schema);
+}
+
+const failures = [];
+for (const [stem, schema] of stems) {
   const output = join(stagingDir, `${stem}.d.ts`);
   const result = spawnSync(json2ts, ["-i", schema, "-o", output, "--unreachableDefinitions"], {
     stdio: "inherit",

--- a/packages/contracts/src/generated/envelope.d.ts
+++ b/packages/contracts/src/generated/envelope.d.ts
@@ -9,12 +9,7 @@
  * Transport-neutral operation envelopes, operation events, handles, and error DTOs.
  */
 export type AstroLibraryManagerContractEnvelopes =
-  | RequestEnvelope
-  | OkResponseEnvelope
-  | ErrorResponseEnvelope
-  | OperationHandle
-  | OperationEvent
-  | ContractError;
+  RequestEnvelope | OkResponseEnvelope | ErrorResponseEnvelope | OperationHandle | OperationEvent | ContractError;
 export type ContractVersion = "1.0.0";
 export type OperationName = string;
 export type RequestId = string;

--- a/packages/contracts/src/generated/inventory.list.d.ts
+++ b/packages/contracts/src/generated/inventory.list.d.ts
@@ -54,6 +54,14 @@ export interface InventoryFilters {
    * When set, limits sessions to the given canonical state. 'ignored' sessions are excluded from the default ledger (no filter or filter='all'); use reviewFilter='ignored' to surface them (FR-010 Cmd+K action navigates to /inventory?reviewFilter=ignored).
    */
   reviewFilter?: "all" | "discovered" | "candidate" | "needs_review" | "confirmed" | "rejected" | "ignored";
+  /**
+   * Maximum sessions per source root. Server default is 1000 when omitted. Existing callers that omit the field continue to work.
+   */
+  limit?: number;
+  /**
+   * Sessions to skip before applying limit (0-based, per source root).
+   */
+  offset?: number;
 }
 export interface InventorySource {
   id: Uuid;
@@ -61,6 +69,10 @@ export interface InventorySource {
   kind: SourceKind;
   state: SourceState;
   sessions: InventorySession[];
+  /**
+   * true when more sessions exist beyond the current offset+limit page. false for an unbounded fetch or when the last session has been returned. Callers that do not paginate can ignore this field.
+   */
+  hasMore?: boolean;
 }
 export interface InventorySession {
   id: Uuid;

--- a/packages/contracts/src/generated/lifecycle.transition.d.ts
+++ b/packages/contracts/src/generated/lifecycle.transition.d.ts
@@ -24,13 +24,7 @@ export type Request =
 export type ContractVersion = "2.0.0";
 export type Uuid = string;
 export type ProjectState =
-  | "setup_incomplete"
-  | "ready"
-  | "prepared"
-  | "processing"
-  | "completed"
-  | "archived"
-  | "blocked";
+  "setup_incomplete" | "ready" | "prepared" | "processing" | "completed" | "archived" | "blocked";
 /**
  * Human-readable label recorded on the audit entry (e.g. 'Unarchived').
  */
@@ -81,13 +75,7 @@ export type Timestamp = string;
  * Any per-family lifecycle state value. Use the family-specific enums in the discriminated Request sub-schemas; this alias exists only for the Response shape where the family is fixed by the corresponding request.
  */
 export type LifecycleState =
-  | ProjectState
-  | PlanState
-  | SessionState
-  | DataSourceState
-  | FileRecordState
-  | PreparedSourceState
-  | ProjectionState;
+  ProjectState | PlanState | SessionState | DataSourceState | FileRecordState | PreparedSourceState | ProjectionState;
 export type ErrorCode =
   | "transition.refused"
   | "entity.not_found"

--- a/packages/contracts/src/generated/native.reveal.d.ts
+++ b/packages/contracts/src/generated/native.reveal.d.ts
@@ -20,12 +20,7 @@ export interface NativeReveal {
      * Optional context tag for audit-log correlation.
      */
     entityKind?:
-      | "inbox_item"
-      | "inventory_row"
-      | "project_manifest"
-      | "master_calibration"
-      | "registered_source"
-      | "other";
+      "inbox_item" | "inventory_row" | "project_manifest" | "master_calibration" | "registered_source" | "other";
     entityId?: string;
   };
   response:

--- a/scripts/check-generated-drift.sh
+++ b/scripts/check-generated-drift.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Generated-artifact drift gate.
+#
+# Invariant: every committed generated artifact matches what its generator
+# produces from the current sources. Run the generators first, then call this.
+#
+# Checks tracked modifications AND untracked additions. `git diff --exit-code`
+# alone reports 0 for a regeneration that only ADDS a file, so a new binding or
+# declaration could land uncommitted and the gate would pass.
+#
+# Usage:
+#   bash scripts/check-generated-drift.sh                 # every artifact path
+#   bash scripts/check-generated-drift.sh <path>...       # only these paths
+# Exits 0 on pass, 1 on drift.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ $# -gt 0 ]]; then
+  PATHS=("$@")
+else
+  PATHS=(
+    "specs/*/contracts/*.generated.json"
+    "apps/desktop/src/bindings/"
+    "packages/contracts/src/generated/"
+  )
+fi
+
+# Quoted, so git receives the wildcard as a pathspec and matches it itself. An
+# unquoted expansion would leave the shell's own glob unmatched-and-literal when
+# no spec has generated contracts yet, and git would reject the pathspec.
+status="$(git status --porcelain --untracked-files=all -- "${PATHS[@]}")"
+
+if [[ -z "$status" ]]; then
+  echo "Generated artifacts are up to date."
+  exit 0
+fi
+
+echo "Generated artifacts have drifted from their sources:" >&2
+echo "$status" >&2
+echo >&2
+git --no-pager diff -- "${PATHS[@]}" >&2 || true
+echo >&2
+echo "Regenerate and commit the result. See the check-generated recipe." >&2
+exit 1


### PR DESCRIPTION
## Summary

- `just check-generated` covered `specs/*/contracts/*.generated.json` and
  `apps/desktop/src/bindings/`, and never regenerated
  `packages/contracts/src/generated/`. The 23 committed declaration files had been
  free to rot since they were added, and four of them had.
- `scripts/check-generated-drift.sh` replaces the inline `git diff --exit-code` and
  covers all three paths. It reads `git status --porcelain --untracked-files=all`,
  because `git diff --exit-code` exits 0 for a regeneration that only **adds** a
  file, so a new binding could have landed uncommitted with the gate still green.
- New `check-contracts-ts` recipe runs the declaration half without the cargo
  steps. The existing CI drift step needs the Rust toolchain and system webkit,
  installed only when the `rust` filter fires, so it could not widen to cover a
  schema-only change. A new `spec_contracts` filter triggers the cargo-free leg for
  `specs/*/contracts/**`, which otherwise sets only `docs`.
- `build-schemas.mjs` now fails instead of going quiet on two inputs. A missing
  allowlist entry was skipped, so a renamed spec folder produced fewer declaration
  files and the gate accepted the smaller tree. Two schemas reducing to the same
  stem overwrote each other, last write wins.
- That collision was live. `packages/contracts/schemas/inventory.list.schema.json`
  carries `limit`, `offset`, and `hasMore` and is the copy
  `tests/contract/contract_jsonschema_roundtrip.rs` validates against; the spec 006
  copy never gained those fields, was generated second, and won. Both spec 006
  entries are dropped from the allowlist. Regenerating gives `inventory.list.d.ts`
  the three pagination fields and reflows three files that a
  `json-schema-to-typescript` bump had rewrapped.

Verified: the gate fails on the drift that was already committed and on an
untracked file added to a generated directory, and passes once the regenerated
output is committed. `pnpm --filter @astro-plan/contracts typecheck` and its
conformance suite pass, and shellcheck reports nothing on the new script.

Out of scope, filed separately: the stale spec 006 contract (`astro-plan-9aq6`) and
the absence of any parity check between the two generated TypeScript surfaces
(`astro-plan-nhq9`).

## Spec Context

Repository tooling, outside any spec.

Tracks-Bead: astro-plan-2add
Closes-Bead: astro-plan-2add

Merge-Bead: astro-plan-pzdr
