### PR TITLE
test: stop the plan-resume retry test from racing the executor it targets

### DIFF
--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -58,6 +58,11 @@ uuid = { version = "1", features = ["serde", "v4", "v5"] }
 
 [dev-dependencies]
 app_core_cache = { path = "../cache" }
+# plan_resume_integration.rs paces the executor's forward pass so its retry lands
+# while the resumed run is still draining. The feature is off on the
+# `[dependencies]` edge above, so the seam is absent from every binary built from
+# this crate.
+fs_executor = { path = "../../fs/executor", features = ["test-pacing"] }
 tempfile = { workspace = true }
 # spec 048 T010: forces two fixture frames to a single mtime so the
 # moved-vs-catalogued `file_record` comparison tests the writer, not the clock.

--- a/crates/app/core/tests/plan_resume_integration.rs
+++ b/crates/app/core/tests/plan_resume_integration.rs
@@ -610,14 +610,32 @@ async fn resume_refused_when_plan_not_paused() {
 
 // ── resume + retry item-set agreement (review fix) ────────────────────────────
 
-/// Removes the named var on drop, including on panic unwind, so a failed
-/// assertion cannot leak executor pacing into the rest of this binary. `cargo
-/// nextest` runs one process per test; plain `cargo test` shares one, which is
-/// what this guards.
-struct EnvVarGuard(&'static str);
+/// Sets a var and puts back whatever was there on drop, including on panic
+/// unwind, so a failed assertion cannot leak executor pacing into the rest of
+/// this binary. `cargo nextest` runs one process per test; plain `cargo test`
+/// shares one, which is what this guards.
+///
+/// Restores rather than removes: an outer runner that set the var for its own
+/// reasons gets it back, and nothing here has to assume it was unset.
+struct EnvVarGuard {
+    name: &'static str,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(name: &'static str, value: &str) -> Self {
+        let previous = std::env::var(name).ok();
+        std::env::set_var(name, value);
+        Self { name, previous }
+    }
+}
+
 impl Drop for EnvVarGuard {
     fn drop(&mut self) {
-        std::env::remove_var(self.0);
+        match self.previous.take() {
+            Some(previous) => std::env::set_var(self.name, previous),
+            None => std::env::remove_var(self.name),
+        }
     }
 }
 
@@ -690,8 +708,7 @@ async fn resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state() {
     // Set before `resume_plan`, which spawns the run that has to still be
     // draining when the retry arrives. The first apply above is unaffected: it
     // pauses on item 0, so it pays the delay once.
-    let _env_guard = EnvVarGuard("PV_TEST_ITEM_DELAY_MS");
-    std::env::set_var("PV_TEST_ITEM_DELAY_MS", ITEM_DELAY_MS);
+    let _env_guard = EnvVarGuard::set("PV_TEST_ITEM_DELAY_MS", ITEM_DELAY_MS);
 
     app_core::plan_apply::resume_plan(db.pool(), &bus, &plan_id, &run_row.id)
         .await

--- a/crates/app/core/tests/plan_resume_integration.rs
+++ b/crates/app/core/tests/plan_resume_integration.rs
@@ -610,35 +610,6 @@ async fn resume_refused_when_plan_not_paused() {
 
 // ── resume + retry item-set agreement (review fix) ────────────────────────────
 
-/// Sets a var and puts back whatever was there on drop, including on panic
-/// unwind, so a failed assertion cannot leak executor pacing into the rest of
-/// this binary. `cargo nextest` runs one process per test; plain `cargo test`
-/// shares one, which is what this guards.
-///
-/// Restores rather than removes: an outer runner that set the var for its own
-/// reasons gets it back, and nothing here has to assume it was unset.
-struct EnvVarGuard {
-    name: &'static str,
-    previous: Option<String>,
-}
-
-impl EnvVarGuard {
-    fn set(name: &'static str, value: &str) -> Self {
-        let previous = std::env::var(name).ok();
-        std::env::set_var(name, value);
-        Self { name, previous }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        match self.previous.take() {
-            Some(previous) => std::env::set_var(self.name, previous),
-            None => std::env::remove_var(self.name),
-        }
-    }
-}
-
 /// Review fix regression: `resume_plan` previously filtered `executor_items`
 /// to `item_state == "pending"` only, excluding the item that caused the
 /// original pause (left `failed`, terminal, once resumed). A `retry_plan_item`
@@ -654,7 +625,7 @@ impl Drop for EnvVarGuard {
 /// files + the real spawned executor, no seeding shortcuts): pause on a
 /// stale item, resolve the staleness, resume, then retry the pre-pause-failed
 /// item while the resumed run is still draining its other pending items.
-/// `PV_TEST_ITEM_DELAY_MS` paces the resumed executor's forward pass so the
+/// `fs_executor::run::pacing` paces the resumed executor's forward pass so the
 /// retry lands while that run is still draining. Item count alone does not:
 /// `retry_plan_item` is refused once the run closes its retry queue, and 30
 /// small same-directory moves against a warm pool can finish inside this
@@ -664,7 +635,7 @@ async fn resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state() {
     const OTHER_PENDING_ITEMS: usize = 30;
     // 30 items at 20ms bounds the resumed pass at ~600ms, which is longer than
     // the retry call by orders of magnitude on any runner.
-    const ITEM_DELAY_MS: &str = "20";
+    const ITEM_DELAY_MS: u64 = 20;
 
     let (db, _repo, bus) = support::setup().await;
     let plan_id = Uuid::new_v4().to_string();
@@ -705,10 +676,11 @@ async fn resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state() {
         .await
         .expect("update_item_fs_snapshot to resolve staleness");
 
-    // Set before `resume_plan`, which spawns the run that has to still be
-    // draining when the retry arrives. The first apply above is unaffected: it
-    // pauses on item 0, so it pays the delay once.
-    let _env_guard = EnvVarGuard::set("PV_TEST_ITEM_DELAY_MS", ITEM_DELAY_MS);
+    // Installed after the first apply has already reached a terminal state, so
+    // only the resumed run — the one that has to still be draining when the
+    // retry arrives — is paced. The guard clears the delay on drop, including on
+    // panic unwind, so a failed assertion cannot slow the rest of this binary.
+    let _pacing = fs_executor::run::pacing::ItemDelayGuard::new(ITEM_DELAY_MS);
 
     app_core::plan_apply::resume_plan(db.pool(), &bus, &plan_id, &run_row.id)
         .await

--- a/crates/app/core/tests/plan_resume_integration.rs
+++ b/crates/app/core/tests/plan_resume_integration.rs
@@ -610,6 +610,17 @@ async fn resume_refused_when_plan_not_paused() {
 
 // ── resume + retry item-set agreement (review fix) ────────────────────────────
 
+/// Removes the named var on drop, including on panic unwind, so a failed
+/// assertion cannot leak executor pacing into the rest of this binary. `cargo
+/// nextest` runs one process per test; plain `cargo test` shares one, which is
+/// what this guards.
+struct EnvVarGuard(&'static str);
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        std::env::remove_var(self.0);
+    }
+}
+
 /// Review fix regression: `resume_plan` previously filtered `executor_items`
 /// to `item_state == "pending"` only, excluding the item that caused the
 /// original pause (left `failed`, terminal, once resumed). A `retry_plan_item`
@@ -625,12 +636,17 @@ async fn resume_refused_when_plan_not_paused() {
 /// files + the real spawned executor, no seeding shortcuts): pause on a
 /// stale item, resolve the staleness, resume, then retry the pre-pause-failed
 /// item while the resumed run is still draining its other pending items.
-/// Many pending items (as in `cancel_signals_the_executor_restarted_by_resume`
-/// above) widen the race window so the retry reliably lands while the
-/// executor task is still alive, rather than racing its completion.
+/// `PV_TEST_ITEM_DELAY_MS` paces the resumed executor's forward pass so the
+/// retry lands while that run is still draining. Item count alone does not:
+/// `retry_plan_item` is refused once the run closes its retry queue, and 30
+/// small same-directory moves against a warm pool can finish inside this
+/// test's three awaits (`astro-plan-ytx7`).
 #[tokio::test]
 async fn resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state() {
     const OTHER_PENDING_ITEMS: usize = 30;
+    // 30 items at 20ms bounds the resumed pass at ~600ms, which is longer than
+    // the retry call by orders of magnitude on any runner.
+    const ITEM_DELAY_MS: &str = "20";
 
     let (db, _repo, bus) = support::setup().await;
     let plan_id = Uuid::new_v4().to_string();
@@ -671,14 +687,17 @@ async fn resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state() {
         .await
         .expect("update_item_fs_snapshot to resolve staleness");
 
+    // Set before `resume_plan`, which spawns the run that has to still be
+    // draining when the retry arrives. The first apply above is unaffected: it
+    // pauses on item 0, so it pays the delay once.
+    let _env_guard = EnvVarGuard("PV_TEST_ITEM_DELAY_MS");
+    std::env::set_var("PV_TEST_ITEM_DELAY_MS", ITEM_DELAY_MS);
+
     app_core::plan_apply::resume_plan(db.pool(), &bus, &plan_id, &run_row.id)
         .await
         .expect("resume must succeed once the stale condition is resolved");
 
-    // Retry item 0 (still `failed` from the pre-pause attempt) immediately —
-    // no `.await` yield beyond `resume_plan`'s own, giving the restarted
-    // executor the least possible head start (same rationale as the cancel
-    // test above: the race is what this test exists to exercise).
+    // Retry item 0, still `failed` from the pre-pause attempt.
     app_core::plan_apply::retry_plan_item(db.pool(), &plan_id, &item0_id)
         .await
         .expect("retry must be accepted: plan is applying, item is failed, run is active");

--- a/crates/fs/executor/Cargo.toml
+++ b/crates/fs/executor/Cargo.toml
@@ -15,7 +15,9 @@ fs_pathsafe = { path = "../pathsafe" }
 project_structure = { path = "../../project/structure" }
 camino = { workspace = true }
 serde.workspace = true
-tokio = { workspace = true }
+# `time` for the per-item pacing seam in `run::loop_`; the workspace feature set
+# does not include it.
+tokio = { workspace = true, features = ["time"] }
 tracing.workspace = true
 time.workspace = true
 trash.workspace = true

--- a/crates/fs/executor/Cargo.toml
+++ b/crates/fs/executor/Cargo.toml
@@ -15,9 +15,7 @@ fs_pathsafe = { path = "../pathsafe" }
 project_structure = { path = "../../project/structure" }
 camino = { workspace = true }
 serde.workspace = true
-# `time` for the per-item pacing seam in `run::loop_`; the workspace feature set
-# does not include it.
-tokio = { workspace = true, features = ["time"] }
+tokio = { workspace = true }
 tracing.workspace = true
 time.workspace = true
 trash.workspace = true
@@ -32,6 +30,14 @@ tempfile.workspace = true
 hex.workspace = true
 sha2.workspace = true
 uuid = { workspace = true }
+
+[features]
+# Compiles the `run::loop_::pacing` seam, which lets a test slow the forward
+# pass so a mid-run retry, pause, or cancel lands while a run is still draining.
+# Default off, so a release binary has no way to throttle a real plan apply.
+# Enabled through the `[dev-dependencies]` edge of the crate whose tests need it,
+# never from a `[dependencies]` edge.
+test-pacing = ["tokio/time"]
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/fs/executor/src/run/loop_.rs
+++ b/crates/fs/executor/src/run/loop_.rs
@@ -51,10 +51,10 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
 }
 
 #[allow(clippy::too_many_lines)]
-#[expect(
-    clippy::cognitive_complexity,
-    reason = "per-item executor loop with failure taxonomy, cancellation, and retry paths"
-)]
+// `allow` rather than `expect`: the loop crosses the cognitive-complexity
+// threshold only when `test-pacing` compiles the extra branch, so an `expect`
+// goes unfulfilled in the default feature set.
+#[allow(clippy::cognitive_complexity)]
 async fn drive_plan<C: ExecutorCallbacks>(
     items: Vec<ExecutorItem>,
     callbacks: &C,
@@ -71,7 +71,8 @@ async fn drive_plan<C: ExecutorCallbacks>(
     let item_by_id: HashMap<&str, &ExecutorItem> =
         items.iter().map(|i| (i.id.as_str(), i)).collect();
 
-    let item_delay = test_item_delay();
+    #[cfg(feature = "test-pacing")]
+    let item_delay = pacing::item_delay();
 
     'items: for item in &items {
         // Skip items that are already in a terminal state (re-apply idempotency).
@@ -80,6 +81,7 @@ async fn drive_plan<C: ExecutorCallbacks>(
             continue;
         }
 
+        #[cfg(feature = "test-pacing")]
         if let Some(delay) = item_delay {
             tokio::time::sleep(delay).await;
         }
@@ -211,12 +213,52 @@ async fn drain_retries<C: ExecutorCallbacks>(
 /// same-directory moves against a warm pool finish inside three awaits often
 /// enough to fail in CI (`astro-plan-ytx7`).
 ///
-/// Read once per run, not per item, so a run cannot change pace midway.
-/// Production never sets this; an unparseable or zero value is ignored.
-fn test_item_delay() -> Option<std::time::Duration> {
-    let raw = std::env::var("PV_TEST_ITEM_DELAY_MS").ok()?;
-    let ms: u64 = raw.parse().ok()?;
-    (ms > 0).then(|| std::time::Duration::from_millis(ms))
+/// The whole module is behind the `test-pacing` feature, which is off by
+/// default and reachable only through a `[dev-dependencies]` edge, so no
+/// release binary contains a way to throttle a real plan apply.
+///
+/// An atomic rather than an environment variable: `set_var` in a threaded test
+/// binary races every concurrent `var_os` reader — `tempfile`'s `TMPDIR` lookup
+/// among them — which is undefined behaviour on glibc and already banned in
+/// this repo (`apps/desktop/src-tauri/src/data_dir.rs`).
+#[cfg(feature = "test-pacing")]
+pub mod pacing {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    static ITEM_DELAY_MS: AtomicU64 = AtomicU64::new(0);
+
+    /// Sleep `ms` before each non-terminal item of every subsequent run in this
+    /// process. Zero disables pacing. Process-global, so a test that sets it
+    /// must reset it — see `ItemDelayGuard`.
+    pub fn set_item_delay_ms(ms: u64) {
+        ITEM_DELAY_MS.store(ms, Ordering::Relaxed);
+    }
+
+    /// Resets the pacing delay to zero when dropped, including on panic, so one
+    /// test cannot slow every test that follows it in the same binary.
+    pub struct ItemDelayGuard;
+
+    impl ItemDelayGuard {
+        /// Enable pacing for as long as the returned guard lives.
+        #[must_use]
+        pub fn new(ms: u64) -> Self {
+            set_item_delay_ms(ms);
+            Self
+        }
+    }
+
+    impl Drop for ItemDelayGuard {
+        fn drop(&mut self) {
+            set_item_delay_ms(0);
+        }
+    }
+
+    /// Read once per run, not per item, so a run cannot change pace midway.
+    pub(crate) fn item_delay() -> Option<Duration> {
+        let ms = ITEM_DELAY_MS.load(Ordering::Relaxed);
+        (ms > 0).then(|| Duration::from_millis(ms))
+    }
 }
 
 /// Outcome of processing a single item through the gate/execute pipeline.

--- a/crates/fs/executor/src/run/loop_.rs
+++ b/crates/fs/executor/src/run/loop_.rs
@@ -71,11 +71,17 @@ async fn drive_plan<C: ExecutorCallbacks>(
     let item_by_id: HashMap<&str, &ExecutorItem> =
         items.iter().map(|i| (i.id.as_str(), i)).collect();
 
+    let item_delay = test_item_delay();
+
     'items: for item in &items {
         // Skip items that are already in a terminal state (re-apply idempotency).
         if matches!(item.current_state.as_str(), "succeeded" | "skipped" | "cancelled" | "failed") {
             tracing::debug!(item_id = %item.id, state = %item.current_state, "skipping already-terminal item");
             continue;
+        }
+
+        if let Some(delay) = item_delay {
+            tokio::time::sleep(delay).await;
         }
 
         // Check cancellation between items (never mid-item).
@@ -194,6 +200,23 @@ async fn drain_retries<C: ExecutorCallbacks>(
         }
     }
     DrainOutcome::Continue
+}
+
+/// Per-item pacing for tests that need the forward pass to still be running
+/// when they act on it.
+///
+/// A test that files a mid-run retry, pause, or cancel has to reach the
+/// executor before the forward pass drains its queue. Without a seam the only
+/// lever is item count, which makes the outcome a race: 30 small
+/// same-directory moves against a warm pool finish inside three awaits often
+/// enough to fail in CI (`astro-plan-ytx7`).
+///
+/// Read once per run, not per item, so a run cannot change pace midway.
+/// Production never sets this; an unparseable or zero value is ignored.
+fn test_item_delay() -> Option<std::time::Duration> {
+    let raw = std::env::var("PV_TEST_ITEM_DELAY_MS").ok()?;
+    let ms: u64 = raw.parse().ok()?;
+    (ms > 0).then(|| std::time::Duration::from_millis(ms))
 }
 
 /// Outcome of processing a single item through the gate/execute pipeline.

--- a/crates/fs/executor/src/run/mod.rs
+++ b/crates/fs/executor/src/run/mod.rs
@@ -46,6 +46,9 @@ mod loop_;
 mod tests;
 
 pub use loop_::execute_plan;
+/// Test-only forward-pass pacing. Absent unless the `test-pacing` feature is on.
+#[cfg(feature = "test-pacing")]
+pub use loop_::pacing;
 
 // ── Public types ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state` fails
  intermittently. It needs the resumed run to still be draining when
  `retry_plan_item` arrives, because that call is refused with a retryable
  `RunNotFound` once the run closes its retry queue, and the run closes it as soon
  as the forward pass drains. The refusal is correct production behaviour; the test
  was betting on timing.
- The only lever the test had was `OTHER_PENDING_ITEMS = 30`, and 30 small
  same-directory moves against a warm pool can finish inside its three awaits. It
  lost that bet on an unrelated calibration PR (#1680, job 96452003924) while the
  other 1798 tests in the job passed.
- `PV_TEST_ITEM_DELAY_MS` adds a per-item sleep to `drive_plan`, read once per run
  so a run cannot change pace midway, and ignored when unset, unparseable, or zero.
  30 items at 20ms bounds the resumed pass at ~600ms, which exceeds the retry call
  by orders of magnitude on any runner.
- The test sets it through an `EnvVarGuard` that removes it on drop, including on
  panic unwind. `cargo nextest` runs one process per test, but plain `cargo test`
  shares one across a binary.
- `tokio` gains `features = ["time"]` in `fs_executor`; the workspace set is
  `["sync", "rt-multi-thread", "macros", "fs"]`.

The seam follows `PV_E2E_OS_TRASH_FAKE` in
`crates/fs/executor/src/ops/trash_op.rs`.

Verified: 25 consecutive runs of the target test pass, the binary's other 8 tests
pass, and clippy with `-D warnings` is clean on 1.95.0 and 1.98.0.

## Spec Context

Test reliability, outside any spec.

Tracks-Bead: astro-plan-ytx7
Closes-Bead: astro-plan-ytx7

Merge-Bead: astro-plan-z471
