### PR TITLE
fix: the inventory list contract documents the pagination it already supports

### DIFF
--- a/packages/contracts/src/generated/envelope.d.ts
+++ b/packages/contracts/src/generated/envelope.d.ts
@@ -9,12 +9,7 @@
  * Transport-neutral operation envelopes, operation events, handles, and error DTOs.
  */
 export type AstroLibraryManagerContractEnvelopes =
-  | RequestEnvelope
-  | OkResponseEnvelope
-  | ErrorResponseEnvelope
-  | OperationHandle
-  | OperationEvent
-  | ContractError;
+  RequestEnvelope | OkResponseEnvelope | ErrorResponseEnvelope | OperationHandle | OperationEvent | ContractError;
 export type ContractVersion = "1.0.0";
 export type OperationName = string;
 export type RequestId = string;

--- a/packages/contracts/src/generated/inventory.list.d.ts
+++ b/packages/contracts/src/generated/inventory.list.d.ts
@@ -54,6 +54,14 @@ export interface InventoryFilters {
    * When set, limits sessions to the given canonical state. 'ignored' sessions are excluded from the default ledger (no filter or filter='all'); use reviewFilter='ignored' to surface them (FR-010 Cmd+K action navigates to /inventory?reviewFilter=ignored).
    */
   reviewFilter?: "all" | "discovered" | "candidate" | "needs_review" | "confirmed" | "rejected" | "ignored";
+  /**
+   * Maximum sessions per source root. Server default is 1000 when omitted. Existing callers that omit the field continue to work.
+   */
+  limit?: number;
+  /**
+   * Sessions to skip before applying limit (0-based, per source root).
+   */
+  offset?: number;
 }
 export interface InventorySource {
   id: Uuid;
@@ -61,6 +69,10 @@ export interface InventorySource {
   kind: SourceKind;
   state: SourceState;
   sessions: InventorySession[];
+  /**
+   * true when more sessions exist beyond the current offset+limit page. false for an unbounded fetch or when the last session has been returned. Callers that do not paginate can ignore this field.
+   */
+  hasMore?: boolean;
 }
 export interface InventorySession {
   id: Uuid;

--- a/packages/contracts/src/generated/lifecycle.transition.d.ts
+++ b/packages/contracts/src/generated/lifecycle.transition.d.ts
@@ -24,13 +24,7 @@ export type Request =
 export type ContractVersion = "2.0.0";
 export type Uuid = string;
 export type ProjectState =
-  | "setup_incomplete"
-  | "ready"
-  | "prepared"
-  | "processing"
-  | "completed"
-  | "archived"
-  | "blocked";
+  "setup_incomplete" | "ready" | "prepared" | "processing" | "completed" | "archived" | "blocked";
 /**
  * Human-readable label recorded on the audit entry (e.g. 'Unarchived').
  */
@@ -81,13 +75,7 @@ export type Timestamp = string;
  * Any per-family lifecycle state value. Use the family-specific enums in the discriminated Request sub-schemas; this alias exists only for the Response shape where the family is fixed by the corresponding request.
  */
 export type LifecycleState =
-  | ProjectState
-  | PlanState
-  | SessionState
-  | DataSourceState
-  | FileRecordState
-  | PreparedSourceState
-  | ProjectionState;
+  ProjectState | PlanState | SessionState | DataSourceState | FileRecordState | PreparedSourceState | ProjectionState;
 export type ErrorCode =
   | "transition.refused"
   | "entity.not_found"

--- a/packages/contracts/src/generated/native.reveal.d.ts
+++ b/packages/contracts/src/generated/native.reveal.d.ts
@@ -20,12 +20,7 @@ export interface NativeReveal {
      * Optional context tag for audit-log correlation.
      */
     entityKind?:
-      | "inbox_item"
-      | "inventory_row"
-      | "project_manifest"
-      | "master_calibration"
-      | "registered_source"
-      | "other";
+      "inbox_item" | "inventory_row" | "project_manifest" | "master_calibration" | "registered_source" | "other";
     entityId?: string;
   };
   response:

--- a/specs/006-inventory-library-lifecycle/contracts/inventory.list.json
+++ b/specs/006-inventory-library-lifecycle/contracts/inventory.list.json
@@ -90,6 +90,16 @@
         "reviewFilter": {
           "$ref": "#/$defs/ReviewFilter",
           "description": "When set, limits sessions to the given canonical state. 'ignored' sessions are excluded from the default ledger (no filter or filter='all'); use reviewFilter='ignored' to surface them (FR-010 Cmd+K action navigates to /inventory?reviewFilter=ignored)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum sessions per source root. Server default is 1000 when omitted. Existing callers that omit the field continue to work."
+        },
+        "offset": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Sessions to skip before applying limit (0-based, per source root)."
         }
       }
     },
@@ -170,6 +180,11 @@
         "sessions": {
           "type": "array",
           "items": { "$ref": "#/$defs/InventorySession" }
+        },
+        "hasMore": {
+          "type": "boolean",
+          "default": false,
+          "description": "true when more sessions exist beyond the current offset+limit page. false for an unbounded fetch or when the last session has been returned. Callers that do not paginate can ignore this field."
         }
       }
     },

--- a/tests/contract/contract_schema_parity.rs
+++ b/tests/contract/contract_schema_parity.rs
@@ -212,3 +212,80 @@ fn generated_typescript_exposes_schema_contract_names() {
         );
     }
 }
+
+/// Spec 006 T001 copied its two contracts into `packages/contracts/schemas/` as
+/// build-time mirrors, which makes the spec file and the mirror two records of
+/// one contract with nothing holding them together. They came apart: pagination
+/// (`limit`, `offset`, `hasMore`) was added to the mirror and to three Rust
+/// crates, and the spec copy never got it (`astro-plan-9aq6`).
+///
+/// Compares parsed JSON, so formatting and key order are free to differ.
+#[test]
+fn spec_contracts_match_their_packages_contracts_mirrors() {
+    let root = repo_root();
+
+    for stem in ["inventory.list", "inventory.session.review"] {
+        let spec_path =
+            root.join(format!("specs/006-inventory-library-lifecycle/contracts/{stem}.json"));
+        let mirror_path = root.join(format!("packages/contracts/schemas/{stem}.schema.json"));
+
+        let spec: Value = serde_json::from_str(
+            &fs::read_to_string(&spec_path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", spec_path.display())),
+        )
+        .unwrap_or_else(|error| panic!("{} is not valid JSON: {error}", spec_path.display()));
+
+        let mirror: Value =
+            serde_json::from_str(&fs::read_to_string(&mirror_path).unwrap_or_else(|error| {
+                panic!("failed to read {}: {error}", mirror_path.display())
+            }))
+            .unwrap_or_else(|error| panic!("{} is not valid JSON: {error}", mirror_path.display()));
+
+        let mut differences = Vec::new();
+        collect_json_differences(&spec, &mirror, "", &mut differences);
+
+        assert!(
+            differences.is_empty(),
+            "{stem}: the spec contract and its packages/contracts mirror disagree at \
+             {} location(s):\n{}\n\nThe mirror is what tests/contract validates and what the \
+             TypeScript declarations are generated from, so port the change into {} rather \
+             than reverting the mirror.",
+            differences.len(),
+            differences.join("\n"),
+            spec_path.display()
+        );
+    }
+}
+
+/// Records the JSON pointers at which `spec` and `mirror` disagree.
+///
+/// Whole-value equality is enough to fail the assertion but not to act on it:
+/// these contracts are ~6 KB each, and printing both sides buries a
+/// three-field difference. Recurses into objects so the message names the
+/// pointer, and stops at the first differing scalar or array.
+fn collect_json_differences(spec: &Value, mirror: &Value, at: &str, out: &mut Vec<String>) {
+    let here = if at.is_empty() { "(root)".to_owned() } else { at.to_owned() };
+
+    match (spec, mirror) {
+        (Value::Object(spec_map), Value::Object(mirror_map)) => {
+            for (key, spec_value) in spec_map {
+                match mirror_map.get(key) {
+                    Some(mirror_value) => {
+                        collect_json_differences(
+                            spec_value,
+                            mirror_value,
+                            &format!("{at}/{key}"),
+                            out,
+                        );
+                    }
+                    None => out.push(format!("  {at}/{key}: in the spec copy only")),
+                }
+            }
+            for key in mirror_map.keys().filter(|key| !spec_map.contains_key(*key)) {
+                out.push(format!("  {at}/{key}: in the mirror only"));
+            }
+        }
+        _ if spec != mirror => out.push(format!("  {here}: values differ")),
+        _ => {}
+    }
+}


### PR DESCRIPTION
## Summary

- Spec 006 T001 copied its two contracts into `packages/contracts/schemas/` as
  build-time mirrors, which left one contract with two records and nothing holding
  them together. They came apart: `limit`, `offset`, and `hasMore` were added to
  the mirror and implemented in `crates/contracts/core`, `crates/app/core`, and
  `crates/persistence/targets`, and the spec copy never got them.
- Neither copy is canonical, and the generator resolves the tie the other way from
  what the mirror's test coverage suggests: `build-schemas.mjs:87` lists the
  mirrors first and the spec contracts second, then `:106` writes each in that
  order, so the spec copy is written last and silently overwrites the mirror's
  output for the same contract. The stale `inventory.list.d.ts` in this branch is
  what that looks like — the mirror had the pagination fields and the declarations
  did not. Porting the three fields into the spec copy makes both parse to equal
  JSON, which removes the question rather than answering it.
- `spec_contracts_match_their_packages_contracts_mirrors` holds both pairs
  together from here. It reports the JSON pointers that disagree instead of
  printing both 6 KB documents, so a failure can be acted on without diffing by
  hand.

Verified: 25/25 tests in `contract_schema_parity` pass. Removing `limit` from the
spec copy and flipping `hasMore.default` fails the new test with both pointers
named. Clippy `-D warnings` is clean on 1.95.0 and 1.98.0.

`inventory.session.review.json` was already byte-identical to its mirror and is
unchanged; it is now covered by the same test.

## Spec Context

Spec 006 contract artifact, brought back in line with what the backend
implements.

Tracks-Bead: astro-plan-9aq6
Closes-Bead: astro-plan-9aq6

Merge-Bead: astro-plan-sf3b

## Why no check caught the stale declarations

`scripts/check-generated-drift.sh:25` covers `packages/contracts/src/generated/`
in its default path set, and `just check-generated` runs it — but only on the Rust
lane. This change touches `packages/contracts/schemas/` and `specs/*/contracts/`,
neither of which sets the `rust` filter, so no job ran a drift check at all. #1683
adds the no-Rust leg that closes it. (An earlier commit message on this branch
blamed the justfile recipe's path list; that was wrong, and the squash body
supersedes it.)
