### PR TITLE
fix: an unreadable folder no longer stops artifact detection or reports present artifacts as missing

### DIFF
--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -181,28 +181,59 @@ fn tool_id_from_project_tool(project_tool: &str) -> String {
 /// for project output folders in v1) — neither into a symlinked directory
 /// nor as a symlinked file.
 fn real_read_dir(dir: &Path) -> Result<Vec<PathBuf>, String> {
-    let mut out = Vec::new();
-    real_read_dir_into(dir, &mut out)?;
-    Ok(out)
+    let (files, skipped) = real_read_dir_reporting(dir)?;
+    if !skipped.is_empty() {
+        tracing::warn!(
+            count = skipped.len(),
+            "artifact watcher: unreadable directories skipped during reconcile: {}",
+            skipped.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
+        );
+    }
+    Ok(files)
 }
 
-/// Recursion helper for [`real_read_dir`]; `out` accumulates real file paths
-/// across the whole subtree.
-fn real_read_dir_into(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+/// [`real_read_dir`] plus the subdirectories that could not be read.
+///
+/// `workflow_artifacts::reconcile` takes a `&Path -> Result<Vec<PathBuf>, _>`
+/// lister, so the skipped list cannot travel with the files; [`real_read_dir`]
+/// logs it instead.
+fn real_read_dir_reporting(dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>), String> {
+    let mut files = Vec::new();
+    let mut skipped = Vec::new();
     let entries =
         std::fs::read_dir(dir).map_err(|e| format!("read_dir({}) failed: {e}", dir.display()))?;
+    real_read_dir_into(entries, &mut files, &mut skipped);
+    Ok((files, skipped))
+}
+
+/// Recursion helper for [`real_read_dir_reporting`]; `files` accumulates real
+/// file paths across the whole subtree and `skipped` the directories whose
+/// `read_dir` failed.
+///
+/// An unreadable subdirectory is skipped, not propagated: one
+/// permission-denied directory must not abort reconciliation for every
+/// artifact elsewhere under the project root (matches
+/// `fs_pathsafe::real_files_under`).
+fn real_read_dir_into(
+    entries: std::fs::ReadDir,
+    files: &mut Vec<PathBuf>,
+    skipped: &mut Vec<PathBuf>,
+) {
     for entry in entries.flatten() {
         let Ok(file_type) = entry.file_type() else { continue };
         if file_type.is_symlink() {
             continue;
         }
+        let path = entry.path();
         if file_type.is_dir() {
-            real_read_dir_into(&entry.path(), out)?;
+            match std::fs::read_dir(&path) {
+                Ok(child) => real_read_dir_into(child, files, skipped),
+                Err(_) => skipped.push(path),
+            }
         } else if file_type.is_file() {
-            out.push(entry.path());
+            files.push(path);
         }
     }
-    Ok(())
 }
 
 /// Real (size, mtime) probe. Uses `symlink_metadata` and rejects symlinks
@@ -817,5 +848,47 @@ mod tests {
         let found = real_read_dir(dir.path()).unwrap();
 
         assert!(found.is_empty(), "must not descend into a symlinked directory: found {found:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn real_read_dir_skips_an_unreadable_subdirectory_and_reports_it() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let sibling_dir = dir.path().join("output");
+        std::fs::create_dir_all(&sibling_dir).unwrap();
+        let sibling_file = sibling_dir.join("integration.xisf");
+        std::fs::write(&sibling_file, b"x").unwrap();
+        let top_file = dir.path().join("top.fits");
+        std::fs::write(&top_file, b"x").unwrap();
+        let locked = dir.path().join("locked");
+        std::fs::create_dir_all(&locked).unwrap();
+        std::fs::write(locked.join("hidden.fits"), b"x").unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        // root (and any CAP_DAC_READ_SEARCH holder) bypasses mode bits, which
+        // would make the assertion vacuous.
+        if std::fs::read_dir(&locked).is_ok() {
+            std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+            eprintln!(
+                "skipping: this environment can read a mode-000 directory (running as root?)"
+            );
+            return;
+        }
+
+        let reported = real_read_dir_reporting(dir.path());
+        let whole_walk = real_read_dir(dir.path());
+
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let (found, skipped) = reported.unwrap();
+        assert!(found.contains(&top_file), "top-level sibling must still be reconciled");
+        assert!(found.contains(&sibling_file), "nested sibling must still be reconciled");
+        assert_eq!(skipped, vec![locked], "the unreadable directory must be reported");
+        assert!(
+            whole_walk.is_ok(),
+            "an unreadable subdirectory must not fail the whole walk: {whole_walk:?}"
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -180,30 +180,12 @@ fn tool_id_from_project_tool(project_tool: &str) -> String {
 /// Constitution: never follows symlinks/junctions (no per-root opt-in exists
 /// for project output folders in v1) — neither into a symlinked directory
 /// nor as a symlinked file.
-fn real_read_dir(dir: &Path) -> Result<Vec<PathBuf>, String> {
-    let (files, skipped) = real_read_dir_reporting(dir)?;
-    if !skipped.is_empty() {
-        tracing::warn!(
-            count = skipped.len(),
-            "artifact watcher: unreadable directories skipped during reconcile: {}",
-            skipped.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
-        );
-    }
-    Ok(files)
-}
-
-/// [`real_read_dir`] plus the subdirectories that could not be read.
-///
-/// `workflow_artifacts::reconcile` takes a `&Path -> Result<Vec<PathBuf>, _>`
-/// lister, so the skipped list cannot travel with the files; [`real_read_dir`]
-/// logs it instead.
-fn real_read_dir_reporting(dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>), String> {
-    let mut files = Vec::new();
-    let mut skipped = Vec::new();
+fn real_read_dir(dir: &Path) -> Result<workflow_artifacts::DirListing, String> {
+    let mut listing = workflow_artifacts::DirListing::default();
     let entries =
         std::fs::read_dir(dir).map_err(|e| format!("read_dir({}) failed: {e}", dir.display()))?;
-    real_read_dir_into(entries, &mut files, &mut skipped);
-    Ok((files, skipped))
+    real_read_dir_into(entries, &mut listing.files, &mut listing.unreadable);
+    Ok(listing)
 }
 
 /// Recursion helper for [`real_read_dir_reporting`]; `files` accumulates real
@@ -213,7 +195,8 @@ fn real_read_dir_reporting(dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>), S
 /// An unreadable subdirectory is skipped, not propagated: one
 /// permission-denied directory must not abort reconciliation for every
 /// artifact elsewhere under the project root (matches
-/// `fs_pathsafe::real_files_under`).
+/// `fs_pathsafe::real_files_under`). Callers must treat `skipped` as unknown
+/// state, never as absence.
 fn real_read_dir_into(
     entries: std::fs::ReadDir,
     files: &mut Vec<PathBuf>,
@@ -379,6 +362,16 @@ async fn run_attach_reconciliation(
     )
     .map_err(|e| format!("reconcile failed: {e}"))?;
 
+    let unreadable: Vec<String> =
+        report.unreadable_dirs.iter().map(|p| p.to_string_lossy().into_owned()).collect();
+    if !unreadable.is_empty() {
+        tracing::warn!(
+            count = unreadable.len(),
+            "artifact watcher: unreadable directories skipped during reconcile: {}",
+            unreadable.join(", ")
+        );
+    }
+
     let mut seen_ids: Vec<String> = Vec::new();
     let mut gone: Vec<app_core::artifact::GoneArtifact> = Vec::new();
     for (rel_path, outcome) in report.existing {
@@ -391,6 +384,7 @@ async fn run_attach_reconciliation(
                 });
             }
             workflow_artifacts::ReconcileOutcome::Seen => seen_ids.push(row.id.clone()),
+            workflow_artifacts::ReconcileOutcome::Unknown => {}
         }
     }
 
@@ -414,6 +408,7 @@ async fn run_attach_reconciliation(
     // otherwise pays one commit per row on every drawer open. A failed phase is
     // logged, not propagated — the remaining phases still run, matching the old
     // per-row loops' tolerance of individual failures.
+    app_core::artifact::report_scan_incomplete(bus, project_id, &unreadable).await;
     if let Err(e) = app_core::artifact::touch_seen(pool, &seen_ids).await {
         tracing::warn!(count = seen_ids.len(), "artifact watcher: seen phase failed: {e}");
     }
@@ -813,7 +808,7 @@ mod tests {
         std::fs::write(&top_file, b"x").unwrap();
         std::fs::write(&nested_file, b"x").unwrap();
 
-        let found = real_read_dir(dir.path()).unwrap();
+        let found = real_read_dir(dir.path()).unwrap().files;
 
         assert!(found.contains(&top_file), "top-level file must be found");
         assert!(found.contains(&nested_file), "file nested under a subfolder must be found");
@@ -827,7 +822,7 @@ mod tests {
         let deep_file = deep_dir.join("integration.xisf");
         std::fs::write(&deep_file, b"x").unwrap();
 
-        let found = real_read_dir(dir.path()).unwrap();
+        let found = real_read_dir(dir.path()).unwrap().files;
 
         assert!(found.contains(&deep_file), "file nested two levels deep must be found");
     }
@@ -845,7 +840,7 @@ mod tests {
         let link_path = dir.path().join("linked_output");
         std::os::unix::fs::symlink(real_target.path(), &link_path).unwrap();
 
-        let found = real_read_dir(dir.path()).unwrap();
+        let found = real_read_dir(dir.path()).unwrap().files;
 
         assert!(found.is_empty(), "must not descend into a symlinked directory: found {found:?}");
     }
@@ -877,18 +872,13 @@ mod tests {
             return;
         }
 
-        let reported = real_read_dir_reporting(dir.path());
         let whole_walk = real_read_dir(dir.path());
 
         std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-        let (found, skipped) = reported.unwrap();
-        assert!(found.contains(&top_file), "top-level sibling must still be reconciled");
-        assert!(found.contains(&sibling_file), "nested sibling must still be reconciled");
-        assert_eq!(skipped, vec![locked], "the unreadable directory must be reported");
-        assert!(
-            whole_walk.is_ok(),
-            "an unreadable subdirectory must not fail the whole walk: {whole_walk:?}"
-        );
+        let listing = whole_walk.expect("an unreadable subdirectory must not fail the whole walk");
+        assert!(listing.files.contains(&top_file), "top-level sibling must still be reconciled");
+        assert!(listing.files.contains(&sibling_file), "nested sibling must still be reconciled");
+        assert_eq!(listing.unreadable, vec![locked], "the unreadable directory must be reported");
     }
 }

--- a/apps/desktop/src-tauri/tests/artifact_watcher_unreadable_subdir.rs
+++ b/apps/desktop/src-tauri/tests/artifact_watcher_unreadable_subdir.rs
@@ -1,0 +1,140 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Real-backend integration test: an artifact under a directory the
+//! reconciliation walk cannot read stays `present` and the skip is recorded.
+//!
+//! Companion to `artifact_watcher_missing_reconciliation.rs`, which covers the
+//! `Gone` branch. Unreadable is not absent: the walk skips the subtree so the
+//! rest of the project still reconciles, and the rows underneath it must not be
+//! rewritten as `missing` on the strength of a directory nobody could open.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use audit::bus::EventBus;
+use audit::event_bus::{
+    EventEnvelope, TOPIC_ARTIFACT_DETECTED, TOPIC_ARTIFACT_MISSING, TOPIC_ARTIFACT_SCAN_INCOMPLETE,
+};
+use persistence_core::Database;
+
+use desktop_shell::watcher::{
+    attach_project_watcher, detach_project_watcher, new_artifact_watcher_registry,
+};
+
+async fn insert_projects_row(pool: &sqlx::SqlitePool, path: &str) -> String {
+    let id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO projects \
+         (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
+         VALUES (?, 'Watcher Unreadable-Subdir Project', 'PixInsight', 'setup_incomplete', ?, NULL, 0, \
+                 '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+    )
+    .bind(&id)
+    .bind(path)
+    .execute(pool)
+    .await
+    .expect("insert projects row");
+    id
+}
+
+async fn wait_for_topic(
+    rx: &mut tokio::sync::broadcast::Receiver<EventEnvelope<serde_json::Value>>,
+    topic: &str,
+    deadline: tokio::time::Instant,
+) -> Option<EventEnvelope<serde_json::Value>> {
+    loop {
+        match tokio::time::timeout_at(deadline, rx.recv()).await {
+            Ok(Ok(env)) if env.topic == topic => return Some(env),
+            Ok(Ok(_)) => {}
+            Ok(Err(_)) | Err(_) => return None,
+        }
+    }
+}
+
+/// `true` when this process can still read `dir` at mode 000 — root and any
+/// `CAP_DAC_READ_SEARCH` holder bypass mode bits, which would make the whole
+/// test vacuous.
+fn mode_bits_are_enforced(dir: &Path) -> bool {
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o000))
+        .expect("chmod 000 the subdirectory");
+    std::fs::read_dir(dir).is_err()
+}
+
+#[tokio::test]
+async fn artifact_under_an_unreadable_subdirectory_is_not_marked_missing() {
+    let db = Database::in_memory().await.expect("in-memory database");
+    db.migrate().await.expect("run migrations");
+    let pool = db.pool().clone();
+    let bus = EventBus::with_pool(pool.clone());
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let project_root: PathBuf = dir.path().canonicalize().expect("canonicalize tempdir");
+    let project_id = insert_projects_row(&pool, &project_root.to_string_lossy()).await;
+
+    let output_dir = project_root.join("output");
+    std::fs::create_dir(&output_dir).expect("create output subdirectory");
+    let file_path = output_dir.join("unreadable_subdir_M42_L.xisf");
+    std::fs::write(&file_path, b"not-a-real-xisf-file").expect("write artifact file");
+
+    let registry = new_artifact_watcher_registry();
+
+    let mut rx_detect = bus.subscribe();
+    attach_project_watcher(&pool, &bus, &registry, &project_id)
+        .await
+        .expect("first attach_project_watcher");
+    let detect_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    let detected_env = wait_for_topic(&mut rx_detect, TOPIC_ARTIFACT_DETECTED, detect_deadline)
+        .await
+        .expect("artifact.detected must fire from the on-attach reconciliation pass");
+    let artifact_id =
+        detected_env.payload["artifactId"].as_str().expect("artifactId is a string").to_owned();
+
+    detach_project_watcher(&registry, &project_id).await;
+
+    if !mode_bits_are_enforced(&output_dir) {
+        std::fs::set_permissions(&output_dir, std::fs::Permissions::from_mode(0o755))
+            .expect("restore permissions");
+        eprintln!("skipping: this environment can read a mode-000 directory (running as root?)");
+        return;
+    }
+
+    let mut rx_scan = bus.subscribe();
+    let attached = attach_project_watcher(&pool, &bus, &registry, &project_id).await;
+    let scan_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    let scan_env =
+        wait_for_topic(&mut rx_scan, TOPIC_ARTIFACT_SCAN_INCOMPLETE, scan_deadline).await;
+    let missing_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+    let missing_env = wait_for_topic(&mut rx_scan, TOPIC_ARTIFACT_MISSING, missing_deadline).await;
+
+    let state =
+        sqlx::query_as::<_, (String,)>("SELECT state FROM processing_artifacts WHERE id = ?")
+            .bind(&artifact_id)
+            .fetch_one(&pool)
+            .await
+            .map(|row| row.0);
+
+    // Restore before asserting so the tempdir can always be removed.
+    std::fs::set_permissions(&output_dir, std::fs::Permissions::from_mode(0o755))
+        .expect("restore permissions");
+
+    attached.expect("second attach_project_watcher must survive the unreadable subdirectory");
+    let scan_env = scan_env.expect("artifact.scan_incomplete must record the skipped directory");
+    assert_eq!(scan_env.payload["projectId"].as_str(), Some(project_id.as_str()));
+    assert_eq!(
+        scan_env.payload["unreadablePaths"].as_array().map(Vec::len),
+        Some(1),
+        "the skipped directory must be named in the audit payload"
+    );
+    assert!(
+        missing_env.is_none(),
+        "no artifact.missing may fire for a subtree the walk could not read"
+    );
+    assert_eq!(
+        state.expect("query artifact state"),
+        "present",
+        "an artifact under an unreadable directory is unknown state, not absent state"
+    );
+}

--- a/crates/app/lifecycle/src/artifact/mod.rs
+++ b/crates/app/lifecycle/src/artifact/mod.rs
@@ -66,7 +66,8 @@ pub use launches::{complete_run, reattribute, sweep_stale_launches};
 pub use list::list;
 pub use missing_recovered::{mark_recovered, mark_resolved};
 pub use reconcile_batch::{
-    detect_batch, mark_missing_batch, touch_seen, DetectedFile, GoneArtifact,
+    detect_batch, mark_missing_batch, report_scan_incomplete, touch_seen, DetectedFile,
+    GoneArtifact,
 };
 
 // ── Shared helpers ───────────────────────────────────────────────────────────

--- a/crates/app/lifecycle/src/artifact/reconcile_batch.rs
+++ b/crates/app/lifecycle/src/artifact/reconcile_batch.rs
@@ -17,9 +17,10 @@
 
 use audit::bus::EventBus;
 use audit::event_bus::{
-    ArtifactClassified, ArtifactDetected, ArtifactMissing, ArtifactUpdated,
+    ArtifactClassified, ArtifactDetected, ArtifactMissing, ArtifactScanIncomplete, ArtifactUpdated,
     CalibrationMatchSourceMissing, Source, TOPIC_ARTIFACT_CLASSIFIED, TOPIC_ARTIFACT_DETECTED,
-    TOPIC_ARTIFACT_MISSING, TOPIC_ARTIFACT_UPDATED, TOPIC_CALIBRATION_MATCH_SOURCE_MISSING,
+    TOPIC_ARTIFACT_MISSING, TOPIC_ARTIFACT_SCAN_INCOMPLETE, TOPIC_ARTIFACT_UPDATED,
+    TOPIC_CALIBRATION_MATCH_SOURCE_MISSING,
 };
 use domain_core::ids::{new_id, Timestamp};
 use sqlx::SqlitePool;
@@ -115,6 +116,29 @@ pub async fn mark_missing_batch(
 
     publish_all(bus, &events).await;
     Ok(())
+}
+
+/// Record that a reconcile scan could not read `unreadable_paths`, so its
+/// coverage of the project is partial.
+///
+/// Nothing is written to the artifact rows: paths under an unreadable directory
+/// are unknown state, and the audit row is the only record that the scan skipped
+/// them.
+pub async fn report_scan_incomplete(bus: &EventBus, project_id: &str, unreadable_paths: &[String]) {
+    if unreadable_paths.is_empty() {
+        return;
+    }
+    let events: Vec<BatchEvent> = event(
+        TOPIC_ARTIFACT_SCAN_INCOMPLETE,
+        &ArtifactScanIncomplete {
+            project_id: project_id.to_owned(),
+            unreadable_paths: unreadable_paths.to_vec(),
+            at: Timestamp::now_iso(),
+        },
+    )
+    .into_iter()
+    .collect();
+    publish_all(bus, &events).await;
 }
 
 /// A file the reconcile scan found on disk.

--- a/crates/audit-types/src/event_bus.rs
+++ b/crates/audit-types/src/event_bus.rs
@@ -484,6 +484,22 @@ pub struct ArtifactMissing {
 
 pub const TOPIC_ARTIFACT_MISSING: &str = "artifact.missing";
 
+/// Payload for the `artifact.scan_incomplete` topic.
+///
+/// Emitted when a reconciliation scan skipped one or more directories it could
+/// not read. Artifacts beneath those paths were neither confirmed present nor
+/// marked missing, so the scan's coverage is partial (constitution II: a skipped
+/// subtree in a custody-relevant walk is recorded, never swallowed).
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactScanIncomplete {
+    pub project_id: String,
+    pub unreadable_paths: Vec<String>,
+    pub at: String,
+}
+
+pub const TOPIC_ARTIFACT_SCAN_INCOMPLETE: &str = "artifact.scan_incomplete";
+
 /// Payload for the `artifact.recovered` topic (spec 012, T007).
 ///
 /// Emitted when a `missing` artifact is found again on disk.

--- a/crates/workflow/artifacts/src/lib.rs
+++ b/crates/workflow/artifacts/src/lib.rs
@@ -33,7 +33,7 @@ pub use attribution::{attribute, reattribute_candidates, LaunchRef, DEFAULT_ATTR
 pub use classifier::{classify, ClassificationResult, ClassificationSource};
 pub use default_rules::all as default_artifact_rules;
 pub use project_mapping::{resolve_project_for_path, ProjectPathRef};
-pub use reconciler::{reconcile, NewDetection, ReconcileOutcome, ReconcileReport};
+pub use reconciler::{reconcile, DirListing, NewDetection, ReconcileOutcome, ReconcileReport};
 pub use rules::{ArtifactKind, ArtifactRule, MatchKind};
 pub use watcher::{
     check_stability, extension_allowed, FileSnapshot, StabilityStatus, WatchEvent, WatchEventKind,

--- a/crates/workflow/artifacts/src/reconciler.rs
+++ b/crates/workflow/artifacts/src/reconciler.rs
@@ -13,6 +13,11 @@
 //!   (caller transitions them to `missing` state).
 //! - Files in the DB that are **present** → returned as `Seen` (caller can
 //!   refresh `last_seen_at`).
+//! - Files in the DB that live under a directory the walk could not read →
+//!   returned as `Unknown` (caller transitions nothing).
+//!
+//! Absent and unreadable are distinct: an unreadable subtree is unknown state,
+//! not absent state, so its rows must never be reported as missing.
 //!
 //! The reconciler never modifies the database itself: all state changes are
 //! passed back to the caller so the persistence + audit path is centralised
@@ -33,6 +38,21 @@ pub enum ReconcileOutcome {
     Seen,
     /// File is no longer on disk; transition to `missing`.
     Gone,
+    /// The file's directory could not be read, so presence is undetermined;
+    /// change nothing.
+    Unknown,
+}
+
+/// One directory walk's result: the real files found, plus the directories whose
+/// contents could not be read.
+///
+/// An unreadable directory is skipped rather than aborting the walk, so its
+/// paths are reported separately — `reconcile` needs them to tell an absent file
+/// apart from an unobservable one.
+#[derive(Debug, Default)]
+pub struct DirListing {
+    pub files: Vec<PathBuf>,
+    pub unreadable: Vec<PathBuf>,
 }
 
 /// A new file detected by the reconciliation scan (not yet in the DB).
@@ -52,6 +72,9 @@ pub struct ReconcileReport {
     pub existing: Vec<(RelativePath, ReconcileOutcome)>,
     /// Files found on disk that are not yet in the DB.
     pub new_files: Vec<NewDetection>,
+    /// Directories the walk could not read. The caller surfaces these; every row
+    /// beneath one is reported `Unknown` rather than `Gone`.
+    pub unreadable_dirs: Vec<PathBuf>,
 }
 
 /// Reconcile the output folder at `output_dir` against the set of known paths
@@ -70,10 +93,10 @@ pub fn reconcile<ReadDir, Meta>(
     metadata_fn: &Meta,
 ) -> Result<ReconcileReport, String>
 where
-    ReadDir: Fn(&Path) -> Result<Vec<PathBuf>, String>,
+    ReadDir: Fn(&Path) -> Result<DirListing, String>,
     Meta: Fn(&Path) -> Option<(u64, std::time::SystemTime)>,
 {
-    let on_disk: Vec<PathBuf> = read_dir_fn(output_dir)?;
+    let DirListing { files: on_disk, unreadable } = read_dir_fn(output_dir)?;
 
     // Build a set of file names (lowercased) for fast lookup.
     let on_disk_lower: std::collections::HashSet<String> = on_disk
@@ -92,6 +115,8 @@ where
                 .unwrap_or_default();
             let outcome = if on_disk_lower.contains(&file_name) {
                 ReconcileOutcome::Seen
+            } else if under_unreadable(output_dir, rel, &unreadable) {
+                ReconcileOutcome::Unknown
             } else {
                 ReconcileOutcome::Gone
             };
@@ -121,7 +146,20 @@ where
         })
         .collect();
 
-    Ok(ReconcileReport { existing, new_files })
+    Ok(ReconcileReport { existing, new_files, unreadable_dirs: unreadable })
+}
+
+/// Whether the DB row `rel` resolves to a path inside one of the `unreadable`
+/// directories.
+///
+/// `Path::join` returns `rel` unchanged when it is already absolute, which covers
+/// both the absolute paths the detect phase stores and project-relative rows.
+fn under_unreadable(output_dir: &Path, rel: &str, unreadable: &[PathBuf]) -> bool {
+    if unreadable.is_empty() {
+        return false;
+    }
+    let absolute = output_dir.join(rel);
+    unreadable.iter().any(|dir| absolute.starts_with(dir))
 }
 
 #[cfg(test)]
@@ -133,10 +171,10 @@ mod tests {
         (size, SystemTime::UNIX_EPOCH)
     }
 
-    fn make_read_dir(files: Vec<&str>) -> impl Fn(&Path) -> Result<Vec<PathBuf>, String> {
+    fn make_read_dir(files: Vec<&str>) -> impl Fn(&Path) -> Result<DirListing, String> {
         let dir = PathBuf::from("/output");
         let paths: Vec<PathBuf> = files.into_iter().map(|f| dir.join(f)).collect();
-        move |_| Ok(paths.clone())
+        move |_| Ok(DirListing { files: paths.clone(), unreadable: Vec::new() })
     }
 
     #[test]
@@ -198,6 +236,40 @@ mod tests {
         assert!(matches!(report.existing[0], (_, ReconcileOutcome::Gone)));
         // "other.xisf" is new.
         assert_eq!(report.new_files.len(), 1);
+    }
+
+    #[test]
+    fn row_under_an_unreadable_directory_is_unknown_not_gone() {
+        let locked = PathBuf::from("/output/locked");
+        let read_dir = move |_: &Path| {
+            Ok(DirListing {
+                files: vec![PathBuf::from("/output/visible.xisf")],
+                unreadable: vec![locked.clone()],
+            })
+        };
+        let meta = |_: &Path| Some(fake_meta(512));
+        let known = vec![
+            "/output/locked/result.xisf".to_owned(),
+            "/output/elsewhere/vanished.xisf".to_owned(),
+        ];
+
+        let report = reconcile(
+            Path::new("/output"),
+            &known,
+            crate::watcher::DEFAULT_WATCH_EXTENSIONS,
+            &read_dir,
+            &meta,
+        )
+        .unwrap();
+
+        assert_eq!(
+            report.existing,
+            vec![
+                ("/output/locked/result.xisf".to_owned(), ReconcileOutcome::Unknown),
+                ("/output/elsewhere/vanished.xisf".to_owned(), ReconcileOutcome::Gone),
+            ]
+        );
+        assert_eq!(report.unreadable_dirs, vec![PathBuf::from("/output/locked")]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- One unreadable folder under a project root no longer aborts the on-attach
  artifact reconciliation pass for the whole root.
- Artifacts inside a folder the app cannot read stay `present`. They are no
  longer reported as missing on the strength of a directory nobody could open.
- A skipped folder is recorded in the audit trail (`artifact.scan_incomplete`)
  so a partial scan is visible.

## What changed

`real_read_dir_into` in `apps/desktop/src-tauri/src/watcher.rs` propagated the
`read_dir` error for a subdirectory it could not read, so one permission-denied
directory anywhere under a project root aborted reconciliation for that root and
every artifact elsewhere under it went unobserved.

Skipping the unreadable directory alone is not sufficient, and on its own is
worse than the abort. `workflow_artifacts::reconcile` classifies a recorded row
whose file name is absent from the walk's file list as `ReconcileOutcome::Gone`,
and `run_attach_reconciliation` persists that through `mark_missing_batch`. A
walk that silently omits a subtree therefore reports every present artifact
under it as `missing` — a custody claim about files that are on disk and intact.

Absent and unreadable are now distinct states:

- `real_read_dir` returns a `workflow_artifacts::DirListing`: the real files
  found plus the directories whose contents could not be read
  (`crates/workflow/artifacts/src/reconciler.rs`).
- `reconcile` classifies a row that resolves inside one of those directories as
  the new `ReconcileOutcome::Unknown`. `run_attach_reconciliation` neither
  touches nor transitions an `Unknown` row.
- The skipped paths reach an audit row via the new `artifact.scan_incomplete`
  topic (`crates/audit-types/src/event_bus.rs`, published by
  `app_core::artifact::report_scan_incomplete`), alongside the existing `warn`
  log. Constitution II: a partial scan of a custody-relevant walk is recorded,
  not swallowed.

A `read_dir` failure on the project root itself still returns `Err`, which
signals root-unavailable rather than a partial subtree.

`fs_pathsafe::real_files_under` (`crates/fs/pathsafe/src/lib.rs:185`) already
skips rather than propagates, so the two walkers now agree.

## Tests

`apps/desktop/src-tauri/tests/artifact_watcher_unreadable_subdir.rs` records an
artifact under `output/`, detaches the watcher, sets `output/` to mode 000, and
re-attaches. It asserts the row is still `present`, that no `artifact.missing`
fires, and that `artifact.scan_incomplete` names the skipped directory.

`real_read_dir_skips_an_unreadable_subdirectory_and_reports_it` in `watcher.rs`
covers the walk: a mode-000 subdirectory alongside a top-level file and a nested
file, both siblings still returned, the locked path reported, `Ok` not `Err`.

`row_under_an_unreadable_directory_is_unknown_not_gone` in `reconciler.rs`
covers the classification split: a row under the unreadable directory is
`Unknown`, a row absent from a readable directory is still `Gone`.

Both filesystem tests are `unix`-only and skip themselves with a printed message
when the environment can read a mode-000 directory (running as root), where the
assertion would be vacuous.

## Verification

Run in the branch worktree with `CARGO_TARGET_DIR` set per-branch:

| Command | Result |
| --- | --- |
| `cargo test -p workflow_artifacts -p app_core_lifecycle -p audit_types -p desktop_shell` | 190 passed, 20 suites, exit 0 |
| `cargo clippy -p workflow_artifacts -p app_core_lifecycle -p audit_types -p desktop_shell --all-targets` | no issues, exit 0 |
| `cargo fmt --all` | clean |

Merge-Bead: astro-plan-gn3ix
Tracks-Bead: astro-plan-0sgb.4
Tracks-Bead: astro-plan-3v3r.8.41
Closes-Bead: astro-plan-0sgb.4
Closes-Bead: astro-plan-3v3r.8.41
