### PR TITLE
fix: correct the documented SQLite durability level for the local database

### DIFF
--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -88,9 +88,11 @@ impl Database {
     ///   at most losing the last un-checkpointed transaction — the database is
     ///   never corrupted.  This is materially faster than `FULL` on spinning or
     ///   network-backed storage without sacrificing integrity guarantees the app
-    ///   depends on.  Tier-1 (`FULL`) escalation per-connection for high-value
-    ///   writes (audit events, filesystem plan commits) is tracked as a follow-up
-    ///   in kyo7.49.
+    ///   depends on.  Tier-1 records are not covered by the pool default: the
+    ///   filesystem-mutation intent path escalates per commit with
+    ///   `PRAGMA wal_checkpoint(TRUNCATE)` (see `checkpoint_intent` in
+    ///   `persistence_plans::repositories::plan_apply`) rather than raising
+    ///   `synchronous` for every writer.
     /// - **`foreign_keys = ON`**: enforced explicitly so the constraint is not
     ///   silently absent if a future sqlx version changes its default.
     /// - **`busy_timeout`** (#1231): pins the wait interval so it is ours, not

--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -88,11 +88,15 @@ impl Database {
     ///   at most losing the last un-checkpointed transaction — the database is
     ///   never corrupted.  This is materially faster than `FULL` on spinning or
     ///   network-backed storage without sacrificing integrity guarantees the app
-    ///   depends on.  Tier-1 records are not covered by the pool default: the
-    ///   filesystem-mutation intent path escalates per commit with
+    ///   depends on.  No writer raises `synchronous`; this pool default is the
+    ///   only setting in the repo.  One tier-1 path syncs separately: the
+    ///   filesystem-mutation intent commit is followed by a best-effort
     ///   `PRAGMA wal_checkpoint(TRUNCATE)` (see `checkpoint_intent` in
-    ///   `persistence_plans::repositories::plan_apply`) rather than raising
-    ///   `synchronous` for every writer.
+    ///   `persistence_plans::repositories::plan_apply`), whose failure both
+    ///   call sites log and ignore.  The other tier-1 records §V names —
+    ///   frame-to-session attribution, lifecycle choices, user overrides — have
+    ///   no such escalation; whether they require one is open
+    ///   (astro-plan-53b8).
     /// - **`foreign_keys = ON`**: enforced explicitly so the constraint is not
     ///   silently absent if a future sqlx version changes its default.
     /// - **`busy_timeout`** (#1231): pins the wait interval so it is ours, not
@@ -308,15 +312,6 @@ mod tests {
         let fk_on: i64 =
             sqlx::query_scalar("PRAGMA foreign_keys").fetch_one(db.pool()).await.unwrap();
         assert_eq!(fk_on, 1, "PRAGMA foreign_keys must be 1 (ON) on every connection");
-    }
-
-    #[tokio::test]
-    async fn synchronous_normal_on_fresh_connection() {
-        let db = super::Database::in_memory().await.expect("in-memory connect");
-        // SQLite returns the numeric value: 0=OFF, 1=NORMAL, 2=FULL, 3=EXTRA.
-        let sync_level: i64 =
-            sqlx::query_scalar("PRAGMA synchronous").fetch_one(db.pool()).await.unwrap();
-        assert_eq!(sync_level, 1, "synchronous must be NORMAL (1) per tier-2 policy");
     }
 
     #[tokio::test]

--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -93,7 +93,9 @@ impl Database {
     ///   filesystem-mutation intent commit is followed by a best-effort
     ///   `PRAGMA wal_checkpoint(TRUNCATE)` (see `checkpoint_intent` in
     ///   `persistence_plans::repositories::plan_apply`), whose failure both
-    ///   call sites log and ignore.  The other tier-1 records §V names —
+    ///   call sites discard without logging — the persistence layer has no
+    ///   logging facade, and boot reconciliation is the backstop.  The other
+    ///   tier-1 records §V names —
     ///   frame-to-session attribution, lifecycle choices, user overrides — have
     ///   no such escalation; whether they require one is open
     ///   (astro-plan-53b8).

--- a/crates/persistence/core/tests/wal_journal_mode.rs
+++ b/crates/persistence/core/tests/wal_journal_mode.rs
@@ -12,8 +12,12 @@
 //! or briefly at commit for any write) blocks *every* reader sharing the same
 //! file, including unrelated poller queries on other pooled connections. WAL
 //! mode gives readers a consistent snapshot independent of an in-flight
-//! writer, removing that contention class without weakening durability
-//! (`synchronous` is left at SQLite's default `FULL`).
+//! writer, removing that contention class.
+//!
+//! `Database::connect` pairs WAL with `synchronous = NORMAL`, not SQLite's
+//! compiled-in `FULL` default; see the durability tier policy on
+//! `Database::connect`. `database_connect_reports_synchronous_normal` asserts
+//! the value SQLite reports back on a file-backed connection.
 //!
 //! These tests reproduce the underlying SQLite locking behaviour directly
 //! (via `BEGIN EXCLUSIVE`) rather than racing a real poll loop, so they are
@@ -165,4 +169,21 @@ async fn database_connect_reports_wal_journal_mode() {
         .expect("read journal_mode");
 
     assert_eq!(mode.to_lowercase(), "wal");
+}
+
+/// `Database::connect` reports `synchronous = NORMAL` back from SQLite on a
+/// file-backed database, where the setting has durability consequences (an
+/// in-memory database has none).
+#[tokio::test]
+async fn database_connect_reports_synchronous_normal() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("synchronous-check.db");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+
+    let db = Database::connect(&url).await.expect("Database::connect");
+    // 0=OFF, 1=NORMAL, 2=FULL, 3=EXTRA.
+    let (level,): (i64,) =
+        sqlx::query_as("PRAGMA synchronous").fetch_one(db.pool()).await.expect("read synchronous");
+
+    assert_eq!(level, 1, "file-backed pool must run synchronous = NORMAL (1)");
 }

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -33,7 +33,8 @@ use persistence_core::{DbError, DbResult};
 ///
 /// A failed checkpoint (e.g. a reader holding the WAL open) is not fatal: the
 /// intent is already committed to the WAL, boot reconciliation is the backstop,
-/// and the next automatic checkpoint will sync it. Callers log and proceed.
+/// and the next automatic checkpoint will sync it. Both callers discard the
+/// error without logging and proceed.
 async fn checkpoint_intent(conn: &mut SqliteConnection) -> DbResult<()> {
     sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)").execute(conn).await?;
     Ok(())


### PR DESCRIPTION
`crates/persistence/core/tests/wal_journal_mode.rs:16` said `synchronous` was
left at SQLite's default `FULL`. `crates/persistence/core/src/lib.rs:113` sets
`SqliteSynchronous::Normal`. This corrects the test module doc and moves the
pragma assertion onto a file-backed database.

Merge-Bead: astro-plan-r0tgj
Work-Bead: astro-plan-q18u

## What changed

| File | Change |
| --- | --- |
| `crates/persistence/core/tests/wal_journal_mode.rs` | Module doc now states the level the pool sets. New test `database_connect_reports_synchronous_normal` asserts `PRAGMA synchronous == 1` on a file-backed database. |
| `crates/persistence/core/src/lib.rs` | The `Database::connect` docstring deferred Tier-1 escalation to bead kyo7.49 as pending. kyo7.49 is closed and merged (#1586). The docstring now names the landed mechanism, scopes it to filesystem-mutation intents, and states that a failed checkpoint is discarded without logging. Deletes `synchronous_normal_on_fresh_connection`, superseded by the file-backed test. |
| `crates/persistence/plans/src/repositories/plan_apply.rs` | `checkpoint_intent`'s docstring said "Callers log and proceed". Both callers discard the error without logging; the docstring now says so. |

No pragma, pool option, or call site changed. The pool-wide default remains
`synchronous = NORMAL` (`src/lib.rs:113`).

## Statements audited

| Location | Claim | Verdict |
| --- | --- | --- |
| `crates/persistence/core/src/lib.rs:86` | NORMAL | True: matches `:113` |
| `crates/persistence/core/tests/wal_journal_mode.rs:16` | "left at SQLite's default `FULL`" | False; corrected here |
| `specs/062-session-heterogeneity/data-model.md:1141` | `PRAGMA synchronous = FULL` | False; outside this branch's scope, filed as astro-plan-rar3 |

`CLAUDE.md` Principle V and its 1.1.0 amendment log adopt relaxed global
durability "to enable batched writes and synchronous=NORMAL SQLite mode", with
custody guarantees concentrated on Tier-1 records. NORMAL is therefore the
correct level, and the two `FULL` claims are the wrong ones.

## Test coverage

`synchronous_normal_on_fresh_connection` asserted the pragma on an in-memory
database, where the setting is inert. It detected removal of
`.synchronous(SqliteSynchronous::Normal)` just as well as a file-backed
assertion does: sqlx emits no `synchronous` pragma unless one is set, so SQLite
reports its compiled default `FULL` (2) either way. The file-backed test is
therefore not stronger evidence, only better scoped: it observes the level
where it has durability consequences. Being a near-duplicate of the in-memory
one, it replaces it rather than joining it.

Mutation check, by deleting `.synchronous(SqliteSynchronous::Normal)` and
re-running each test:

| Test | Result with the option removed |
| --- | --- |
| `synchronous_normal_on_fresh_connection` (in-memory, now deleted) | FAILED, `left: 2` |
| `database_connect_reports_synchronous_normal` (file-backed) | FAILED, `left: 2` |

Neither test observes durability; both read the pragma back.

## Tier-1 durability

One Tier-1 escalation already exists, on one path. `checkpoint_intent`
(`crates/persistence/plans/src/repositories/plan_apply.rs:38`) issues
`PRAGMA wal_checkpoint(TRUNCATE)` after the filesystem-mutation intent commit,
called at `:169` and `:319`. It landed with kyo7.49 in #1586. It is best-effort:
both call sites discard the result with `let _ =` and do not log it, and a
failed checkpoint is not fatal because boot reconciliation is the backstop
(`plan_apply.rs:34-37`).

Making that failure visible would require a logging facade in the persistence
layer, which has none: `rg 'tracing::' crates/persistence` returns nothing, and
neither `persistence_core` nor `persistence_plans` depends on `tracing` or
`log`. This PR corrects the two docstrings that claimed otherwise instead of
adding that dependency.

Tier-1 record classes with no paired filesystem action (attribution, lifecycle
choices, user overrides) may or may not need the same escalation. That reading of
Principle V is the repo owner's call, not a code question, so it is parked on
astro-plan-53b8 with four options costed. Their write sites sit outside this
branch's scope and this PR does not audit them.

## Verification

| Command | Exit |
| --- | --- |
| `cargo fmt --all --check` | 0 |
| `cargo test -p persistence_core` | 0 (51 tests) |
| `cargo clippy -p persistence_core --all-targets -- -D warnings` | 0 |
| `cargo clippy -p persistence_plans -- -D warnings` | 0 |
| `cargo test -p persistence_plans --features persistence_core/test-fixture` | 0 (67 tests) |

`cargo test -p persistence_plans` without that feature flag fails to compile at
this branch's base as well: the crate's dev-dependency on `persistence_core`
declares `features = []` while its tests import `persistence_core::test_support`,
which is gated behind `test-fixture`. CI does not hit it because it builds
`--workspace`. Filed as astro-plan-8b0d5; not addressed here.
