### PR TITLE
fix: an environment variable can no longer divert system-trash deletes in a release build

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -88,7 +88,9 @@ dev-tools = ["app_core/dev-tools"]
 # The embedded server listens on 127.0.0.1:4445; the tauri-webdriver CLI
 # (cargo install tauri-webdriver --locked) proxies :4444 → :4445.
 # Release binaries MUST NOT enable this feature (Constitution Principle V).
-e2e = ["dep:tauri-plugin-webdriver"]
+# Also compiles the headless OS-trash double the harness needs, since the Shell
+# trash blocks forever without an interactive window-station.
+e2e = ["dep:tauri-plugin-webdriver", "app_core/e2e-trash-fake"]
 
 [lints]
 workspace = true

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -62,7 +62,9 @@ app_core_cache = { path = "../cache" }
 # while the resumed run is still draining. The feature is off on the
 # `[dependencies]` edge above, so the seam is absent from every binary built from
 # this crate.
-fs_executor = { path = "../../fs/executor", features = ["test-pacing"] }
+# `e2e-trash-fake` additionally lets plan_apply's trash-destination test drive
+# the executor's trash path without an interactive desktop.
+fs_executor = { path = "../../fs/executor", features = ["test-pacing", "e2e-trash-fake"] }
 tempfile = { workspace = true }
 # spec 048 T010: forces two fixture frames to a single mtime so the
 # moved-vs-catalogued `file_record` comparison tests the writer, not the clock.
@@ -94,6 +96,10 @@ persistence_sessions = { path = "../../persistence/sessions", features = ["test-
 # settings-key gate, and compiles the in-crate `dev_contracts` module (gated by
 # `#[cfg(feature = "dev-tools")]` in `lib.rs`).
 dev-tools = ["app_core_settings/dev-tools"]
+# Headless OS-trash double for the e2e harness (spec 037). Release binaries must
+# NOT enable this. Exists only so `desktop_shell/e2e` can reach
+# `fs_executor/e2e-trash-fake`: `desktop_shell` has no direct `fs_executor` edge.
+e2e-trash-fake = ["fs_executor/e2e-trash-fake"]
 
 [lints]
 workspace = true

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -1082,29 +1082,19 @@ async fn confirm_then_apply_executes_previously_refused_delete_item() {
     assert!(audit_count > 0, "apply_plan must write at least one durable audit_log_entry row");
 }
 
-/// Removes `PV_E2E_OS_TRASH_FAKE` on drop (including panic unwind) so a
-/// failed assertion in the test body can never leak the var into other
-/// tests in this binary (this crate has no other test that exercises the
-/// `Trash` executor action, so the var is otherwise untouched here).
-struct EnvVarGuard(&'static str);
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        std::env::remove_var(self.0);
-    }
-}
-
 /// Regression for the "trash destination is dead code" finding: both
 /// `cleanup_generator` and `archive_generator` always store
 /// `action = "archive"` for a destructive-but-reversible item; the
 /// user's plan-level "System trash" choice (`plans.destructive_destination`)
 /// was never consulted at apply time, so it silently archived into
 /// `.astro-plan-archive` regardless of what the user picked in review.
-/// `PV_E2E_OS_TRASH_FAKE` (headless-safe OS-trash double, added for the
-/// e2e harness) makes the OS-trash outcome deterministic here too.
+/// `fs_executor::ops::trash_op::fake` (headless-safe OS-trash double, added for
+/// the e2e harness) makes the OS-trash outcome deterministic here too.
 #[tokio::test]
 async fn archive_action_item_with_trash_destination_really_trashes() {
-    std::env::set_var("PV_E2E_OS_TRASH_FAKE", "1");
-    let _env_guard = EnvVarGuard("PV_E2E_OS_TRASH_FAKE");
+    // Restores real OS trash on drop, including on panic unwind, so a failed
+    // assertion below cannot divert the trash path of the rest of this binary.
+    let _fake_trash = fs_executor::ops::trash_op::fake::FakeTrashGuard::new();
 
     let dir = tempfile::tempdir().unwrap();
     let file_path = dir.path().join("intermediate.fits");

--- a/crates/e2e-tests/tests/common/helpers.rs
+++ b/crates/e2e-tests/tests/common/helpers.rs
@@ -259,8 +259,11 @@ pub(super) fn spawn_tauri_webdriver(
         // only the headless session hangs. A real Recycle-Bin move is
         // unperformable here, so the app does a deterministic filesystem
         // removal instead (see `fs_executor::ops::trash_op`), matching the
-        // FakeSpawner/FakeResolver boundary pattern. Production/live never sets
-        // this and always uses real OS trash.
+        // FakeSpawner/FakeResolver boundary pattern. A release binary ignores
+        // this variable: the read is compiled only under `desktop_shell/e2e`
+        // (which forwards to `fs_executor/e2e-trash-fake`), so the app under
+        // test must be the e2e-feature build, and production always uses real
+        // OS trash.
         .env("PV_E2E_OS_TRASH_FAKE", "1")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());

--- a/crates/fs/executor/Cargo.toml
+++ b/crates/fs/executor/Cargo.toml
@@ -38,6 +38,13 @@ uuid = { workspace = true }
 # Enabled through the `[dev-dependencies]` edge of the crate whose tests need it,
 # never from a `[dependencies]` edge.
 test-pacing = ["tokio/time"]
+# Compiles the `ops::trash_op::fake` seam, which diverts OS trash to a plain
+# file removal so headless e2e runs do not block on an interactive Shell trash.
+# Default off, so a release binary carries no way to divert the destructive path
+# of a real plan apply. Reached through `app_core/e2e-trash-fake` (itself reached
+# only from `desktop_shell/e2e`) or a `[dev-dependencies]` edge, never from a
+# release `[dependencies]` edge.
+e2e-trash-fake = []
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/fs/executor/src/ops/trash_op.rs
+++ b/crates/fs/executor/src/ops/trash_op.rs
@@ -39,6 +39,70 @@ impl Default for TrashResult {
     }
 }
 
+/// Headless OS-trash double for the e2e harness.
+///
+/// The OS Shell trash needs an interactive window-station/desktop; on a
+/// headless CI runner `trash::delete` (`IFileOperation::PerformOperations` on
+/// Windows) blocks forever. A real Recycle-Bin move is unperformable there, so
+/// under this seam [`trash_file`] removes the file deterministically instead.
+/// The observable side effect the real-UI journeys assert — the file leaves the
+/// archive subtree — is identical, and the real OS-trash primitive stays
+/// covered by this module's unit tests and by live use.
+///
+/// The whole module is behind the default-off `e2e-trash-fake` feature, so a
+/// release binary contains no way to divert a real destructive plan apply
+/// (constitution §II).
+///
+/// Two switches because there are two kinds of consumer:
+///
+/// - [`FakeTrashGuard`] for a test that calls the executor in-process. Setting
+///   the environment instead would mean `set_var` in a threaded test binary,
+///   which races every concurrent `var_os` reader — `tempfile`'s `TMPDIR`
+///   lookup among them — undefined behaviour on glibc and already banned in
+///   `apps/desktop/src-tauri/src/data_dir.rs`.
+/// - `PV_E2E_OS_TRASH_FAKE` for the e2e harness, which cannot use the guard: it
+///   drives a separate `desktop_shell` process and sets the variable in that
+///   child's initial environment (`crates/e2e-tests/tests/common/helpers.rs`),
+///   never in its own.
+#[cfg(feature = "e2e-trash-fake")]
+pub mod fake {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static FORCED: AtomicBool = AtomicBool::new(false);
+
+    /// Divert OS trash to a plain file removal for as long as the guard lives.
+    ///
+    /// Process-global: the executor is reached through async plumbing that no
+    /// test can thread a parameter through.
+    pub struct FakeTrashGuard;
+
+    impl FakeTrashGuard {
+        #[must_use]
+        pub fn new() -> Self {
+            FORCED.store(true, Ordering::Relaxed);
+            Self
+        }
+    }
+
+    impl Default for FakeTrashGuard {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    /// Restores real OS trash on drop, including on panic unwind, so one test
+    /// cannot divert the trash path of every test that follows it.
+    impl Drop for FakeTrashGuard {
+        fn drop(&mut self) {
+            FORCED.store(false, Ordering::Relaxed);
+        }
+    }
+
+    pub(super) fn enabled() -> bool {
+        FORCED.load(Ordering::Relaxed) || std::env::var_os("PV_E2E_OS_TRASH_FAKE").is_some()
+    }
+}
+
 /// Send `path` to the OS trash.
 ///
 /// When `fallback_archive_dest` is `Some`, a failed trash attempt falls back
@@ -53,16 +117,8 @@ pub fn trash_file(
     path: &Utf8Path,
     fallback_archive_dest: Option<&Utf8Path>,
 ) -> Result<TrashResult, (PlanItemFailure, TrashResult)> {
-    // E2E boundary double. The OS Shell trash needs an interactive
-    // window-station/desktop; on the headless CI runner `trash::delete`
-    // (`IFileOperation::PerformOperations` on Windows) blocks forever. A real
-    // Recycle-Bin move is unperformable there, so under the e2e harness env we
-    // remove the file deterministically — the observable side effect the
-    // real-UI journeys assert (the file leaves the archive subtree) is
-    // identical, and the real OS-trash primitive stays covered by the Layer-1
-    // unit tests below and by live use. Only the e2e harness sets this var
-    // (`crates/e2e-tests/tests/common/mod.rs`); production/release never does.
-    if std::env::var_os("PV_E2E_OS_TRASH_FAKE").is_some() {
+    #[cfg(feature = "e2e-trash-fake")]
+    if fake::enabled() {
         return match std::fs::remove_file(path) {
             Ok(()) => Ok(TrashResult { destination_used: "trash", ..TrashResult::default() }),
             Err(e) => Err((


### PR DESCRIPTION
## Summary

- A release build no longer changes how it deletes files when an environment variable is set. Sending a file to the system trash always uses the real OS trash.
- The headless test double that stood in for OS trash is now compiled out of release builds instead of switched off at run time.

## Detail

`ops::trash_op::trash_file` read `PV_E2E_OS_TRASH_FAKE` in plain `impl` code with no `#[cfg(test)]` and no feature gate. `fs_executor` is in the desktop app's dependency graph, so a shipped binary diverted OS trash to `std::fs::remove_file` whenever that variable was set — turning the user's preferred destructive route into an unrecoverable delete. Constitution II makes trash the preferred destructive route, so this is a custody hole, not a test convenience. It is the second instance of the defect class #1684 fixed for the pacing seam.

## Change

The seam moves to `ops::trash_op::fake` behind a default-off `e2e-trash-fake` Cargo feature, so the read is absent from a release build rather than merely unset.

A new feature rather than an existing one: `test-pacing` names one specific seam in the same manifest, and `dev-tools` gates the spec-021 developer surface, so reusing either would couple a destructive-path double to an unrelated flag. Consuming gates are reused rather than extended — `desktop_shell/e2e` forwards to `app_core/e2e-trash-fake`, which forwards to `fs_executor/e2e-trash-fake`. The middle hop exists because `desktop_shell` has no direct `fs_executor` edge. The e2e workflow already builds `cargo build -p desktop_shell --features e2e`, so no workflow, harness, or CI change was needed.

The environment variable survives, unlike the pacing seam's, because it has two consumers that need different switches:

| Consumer | Switch |
|---|---|
| `crates/app/core/src/plan_apply/tests.rs` (in-process) | `FakeTrashGuard`, resets on drop |
| `crates/e2e-tests/tests/common/helpers.rs` (separate `desktop_shell` process) | `PV_E2E_OS_TRASH_FAKE` in the child's initial environment |

The test's `set_var` is gone: `set_var` in a threaded test binary races every concurrent `var_os` reader — `tempfile`'s `TMPDIR` lookup among them — which is undefined behaviour on glibc and already banned in `apps/desktop/src-tauri/src/data_dir.rs`. `Command::env` is not `set_var` and carries none of that risk, and no process-global can cross a process boundary, so deleting the variable would delete the headless Windows e2e coverage the seam exists for.

## Verification

`-D warnings` clean, per-branch `CARGO_TARGET_DIR`. All exit code 0.

| Check | Result |
|---|---|
| `rg PV_E2E_OS_TRASH_FAKE release/libfs_executor.rlib`, feature off | no match |
| same grep, feature on (positive control) | 1 match |
| `cargo tree -p desktop_shell -e features -i fs_executor` | `default` only; `--features e2e` adds `app_core feature "e2e-trash-fake"` |
| `cargo clippy -p fs_executor --all-targets` (off / on / `--all-features`) | clean |
| `cargo clippy -p app_core --all-targets` | clean |
| `cargo test -p fs_executor` (off and on) | 123/123 both |
| `cargo test -p app_core --lib plan_apply` | 53/53, incl. `archive_action_item_with_trash_destination_really_trashes` |
| `cargo check -p app_core --features e2e-trash-fake` | clean |
| `cargo fmt --check` | clean |

The rlib grep with its positive control is what proves the seam is compiled out rather than merely absent from a compressed artifact.

## Audit

Every `env::var` read in `crates/` and `apps/` was classified for the same defect class. No further ungated seam, so no follow-up bead was filed.

| Read | Classification |
|---|---|
| `workflow/profiles/discover.rs` `HOME`, `PATH`, `ProgramFiles` | production configuration |
| `main.rs` `PV_DB_URL`, `data_dir.rs` `DATA_DIR_ENV` | production configuration |
| `tools/perf-bench`, `contracts_core` generator bins | dev-tool binaries outside the app graph |
| `e2e-tests` helpers/boot, `simbad_live.rs` | test-target code |
| `PV_E2E_VERSION_OVERRIDE` | gated by `dev-tools` |
| `DEV_URL_ENV` in `lib.rs` | gated by `e2e` |
| `PV_E2E_INSTANCE_ID` | gated by `cfg!(feature = "e2e")` in `bootstrap::single_instance_guard_enabled`, with a release-leak regression test |

`PV_E2E_INSTANCE_ID` uses `cfg!` rather than `#[cfg]`, which leaves the string in a release binary where an attribute would not. No value of the variable can disable the guard, so this is cosmetic and not a custody hole.

Tracks-Bead: astro-plan-5xxy
Closes-Bead: astro-plan-5xxy
Merge-Bead: astro-plan-w7wvi
