### PR TITLE
fix: target coordinates no longer display 60 in the seconds field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
  "sessions",
  "sha2 0.10.9",
  "simbad-resolver",
- "skymath 0.7.1",
+ "skymath 0.7.2",
  "sqlx",
  "target-match",
  "targeting",
@@ -856,7 +856,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "skymath 0.7.1",
+ "skymath 0.7.2",
  "time",
 ]
 
@@ -1431,7 +1431,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simbad-resolver",
- "skymath 0.7.1",
+ "skymath 0.7.2",
  "specta",
  "specta-typescript",
  "sqlx",
@@ -3443,7 +3443,7 @@ name = "metadata_core"
 version = "0.1.0"
 dependencies = [
  "serde",
- "skymath 0.7.1",
+ "skymath 0.7.2",
  "thiserror 2.0.19",
  "toml 0.9.12+spec-1.1.0",
 ]
@@ -5680,7 +5680,7 @@ name = "sessions"
 version = "0.1.0"
 dependencies = [
  "domain_core",
- "skymath 0.7.1",
+ "skymath 0.7.2",
  "thiserror 2.0.19",
  "time",
  "uuid",
@@ -5822,9 +5822,9 @@ dependencies = [
 
 [[package]]
 name = "skymath"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe8c5c80aca9d4212b3b0a5f743d8e9f5c945e221136f346c5b141149e68660"
+checksum = "f8778103b2c0df97997a13aaf7ca04ba98e406cdd1bbab48bbe364a0afeedd78"
 dependencies = [
  "thiserror 2.0.19",
  "time",
@@ -6443,7 +6443,7 @@ name = "targeting"
 version = "0.1.0"
 dependencies = [
  "simbad-resolver",
- "skymath 0.7.1",
+ "skymath 0.7.2",
  "target-match",
  "uuid",
 ]
@@ -6459,7 +6459,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simbad-resolver",
- "skymath 0.7.1",
+ "skymath 0.7.2",
  "sqlx",
  "targeting",
  "tempfile",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ targeting = { path = "../../../crates/targeting" }
 # target.moon_opposition.batch (#634): geocentric Sun/Moon position
 # (sun_position/moon_position — not re-exported by `targeting`, which only
 # re-exports the coordinate primitives).
-skymath = "0.7.1"
+skymath = "0.7.2"
 contracts_core = { path = "../../../crates/contracts/core" }
 domain_core = { path = "../../../crates/domain/core" }
 fs_inventory = { path = "../../../crates/fs/inventory" }

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -37,7 +37,7 @@ hex.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
 sha2.workspace = true
-skymath = "0.7.1"
+skymath = "0.7.2"
 sqlx.workspace = true
 target-match = "0.5.1"
 # spec 052 P3: the cone-search suggestion use case needs the upstream crate's

--- a/crates/calibration/core/Cargo.toml
+++ b/crates/calibration/core/Cargo.toml
@@ -12,7 +12,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 # Issue #921: circular_distance replaces the hand-rolled `(a - b).abs()` flat
 # rotation delta, which max-penalized correct flats straddling the 0/360 seam.
-skymath = "0.7.1"
+skymath = "0.7.2"
 # spec 042 (T201): ISO-8601 date parsing + Julian-day arithmetic for
 # observing-night proximity (replaces the hand-rolled YMD parse + JDN math).
 time = { workspace = true }

--- a/crates/metadata/core/Cargo.toml
+++ b/crates/metadata/core/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { workspace = true }
-skymath = "0.7.1"
+skymath = "0.7.2"
 thiserror = { workspace = true }
 toml = "0.9.5"
 

--- a/crates/sessions/Cargo.toml
+++ b/crates/sessions/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 domain_core = { path = "../domain/core" }
-skymath = "0.7.1"
+skymath = "0.7.2"
 thiserror = { workspace = true }
 time = { workspace = true }
 

--- a/crates/targeting/Cargo.toml
+++ b/crates/targeting/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/lib.rs"
 
 [dependencies]
 target-match = "0.5.1"
-skymath = "0.7.1"
+skymath = "0.7.2"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
 simbad-resolver = "0.5.0"
 

--- a/crates/targeting/resolver/Cargo.toml
+++ b/crates/targeting/resolver/Cargo.toml
@@ -50,7 +50,7 @@ persistence_targets = { path = "../../persistence/targets" }
 simbad-resolver = "0.5.0"
 # IAU constellation-from-coordinates, for `canonical_target.constellation`
 # enrichment at the in-use write (spec 052 P1 D8).
-skymath = "0.7.1"
+skymath = "0.7.2"
 
 [dev-dependencies]
 # `#[tokio::test]` only — no production `tokio` usage in this crate (the

--- a/crates/targeting/src/astro_format.rs
+++ b/crates/targeting/src/astro_format.rs
@@ -9,6 +9,11 @@
 //! over to an invalid `"...:60"` field the way a naive `seconds.toFixed(0)`
 //! on the raw remainder can.
 //!
+//! That carry-safety holds from skymath 0.7.2. At 0.7.1 and earlier the crate
+//! rounded in value units and re-split, emitting a `60` seconds field for 3115
+//! RA and 1420 Dec millidegree values; `seconds_carry_never_shows_60` pins the
+//! inputs that regressed, so a downgrade or lock refresh fails here.
+//!
 //! skymath exposes no h/m/s (or d/m/s) component accessors — only the fully
 //! formatted colon/space-separated string — so the astronomy-notation display
 //! (`HHhMMmSSs` / `±DD°MM′SS″`, matching the deleted TS `fmtRa`/`fmtDec`) is
@@ -94,6 +99,23 @@ mod tests {
         let s = sexagesimal(0.0, 44.999_999_999).unwrap();
         assert_eq!(s.dec, "+45\u{b0}00\u{2032}00\u{2033}");
         assert!(!s.dec.contains("60\u{2033}"), "dec={}", s.dec);
+    }
+
+    /// Inputs that skymath 0.7.1 printed with an out-of-domain `60` field.
+    /// Each expectation is the carried value, so a regression that reinstates
+    /// value-unit rounding fails on the string rather than on a `60` substring.
+    #[test]
+    fn seconds_carry_never_shows_60() {
+        const CASES: [(f64, f64, &str, &str); 3] = [
+            (15.248, -89.85, "01h01m00s", "\u{2212}89\u{b0}51\u{2032}00\u{2033}"),
+            (16.0, 0.0, "01h04m00s", "+00\u{b0}00\u{2032}00\u{2033}"),
+            (15.25, 0.0, "01h01m00s", "+00\u{b0}00\u{2032}00\u{2033}"),
+        ];
+        for (ra_deg, dec_deg, want_ra, want_dec) in CASES {
+            let s = sexagesimal(ra_deg, dec_deg).unwrap();
+            assert_eq!(s.ra, want_ra, "ra for ({ra_deg}, {dec_deg})");
+            assert_eq!(s.dec, want_dec, "dec for ({ra_deg}, {dec_deg})");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Raises `skymath` from 0.7.1 to 0.7.2 across all seven workspace manifests and
  `Cargo.lock`.
- Target coordinate displays keep the seconds field in domain.
  `sexagesimal(15.248, -89.85)` returned RA `01h00m60s` and Dec `−89°50′60″` at
  0.7.1; it returns `01h01m00s` and `−89°51′00″` at 0.7.2.
- The defect affected 3115 RA and 1420 Dec millidegree values. skymath rounded in
  value units and then re-rounded the seconds remainder in its format string;
  `crates/targeting/src/astro_format.rs:51-52` delegates carry handling to skymath,
  so platevault printed the bad field directly. Fixed upstream by
  `nightwatch-astro/skymath#35`, released as `v0.7.2`.
- `seconds_carry_never_shows_60` in `crates/targeting/src/astro_format.rs` pins
  the three inputs skymath 0.7.1 printed with a `60` field and asserts the
  carried strings. A downgrade or lock refresh that reinstates value-unit
  rounding fails there.
- The module doc in that file names 0.7.2 as the version its carry-safety claim
  depends on.

## Test plan

`cargo test -p targeting -p metadata_core -p sessions -p calibration_core -p
app_core_inbox -p targeting_resolver`: 598 passed and 1 ignored across 17 suites.
`cargo fmt -p targeting -- --check` and `cargo clippy -p targeting --all-targets`
are clean.

## Supersedes #1686

PR #1686 addresses the same defect by decomposing locally in
`crates/targeting/src/astro_format.rs`. skymath 0.7.2 covers every case that
branch covers: both millidegree sweeps report 3115 RA and 1420 Dec out-of-domain
values at 0.7.1 and zero at 0.7.2, and #1686's zero-padding, U+2212 sign, and
pole clamp all hold through the existing wrapper. The review ruling on the
collision is SUPERSEDED, so #1686 closes and `astro-plan-3v3r.8.40` re-points to
this branch.

## Scope

All seven manifests move together so the workspace states one minimum for the
crate. The caret requirement already admitted 0.7.2, so the pins record the
version the fix needs rather than changing resolution by themselves.

`Cargo.lock` holds skymath 0.6.0 under four crates: `fits-header` 0.4.2,
`xisf-header` 0.4.3, `simbad-resolver` 0.5.0, and `target-match` 0.5.1. The
`simbad-resolver` edge is a dev-dependency, so it is absent from the build
graph. None of the four calls `ra_sexagesimal`,
`dec_sexagesimal`, `format_ra`, or `format_dec` in its published source, so no
platevault display path reaches sexagesimal formatting through that pin.

Tracks-Bead: astro-plan-h6w2
Merge-Bead: astro-plan-hcs8o

