### PR TITLE
test(fs-executor): gate the pacing seam on an ordering instead of a sleep

### DIFF
--- a/crates/app/core/tests/plan_resume_integration.rs
+++ b/crates/app/core/tests/plan_resume_integration.rs
@@ -625,17 +625,17 @@ async fn resume_refused_when_plan_not_paused() {
 /// files + the real spawned executor, no seeding shortcuts): pause on a
 /// stale item, resolve the staleness, resume, then retry the pre-pause-failed
 /// item while the resumed run is still draining its other pending items.
-/// `fs_executor::run::pacing` paces the resumed executor's forward pass so the
-/// retry lands while that run is still draining. Item count alone does not:
-/// `retry_plan_item` is refused once the run closes its retry queue, and 30
-/// small same-directory moves against a warm pool can finish inside this
-/// test's three awaits (`astro-plan-ytx7`).
+///
+/// `fs_executor::run::pacing` parks the resumed forward pass at its first item
+/// boundary, and this test files the retry only after observing that arrival, so
+/// "the run is still draining" is an ordering it asserts rather than a duration
+/// it waits out. Item count alone does not establish it: `retry_plan_item` is
+/// refused once the run closes its retry queue, and 30 small same-directory
+/// moves against a warm pool can finish inside this test's three awaits
+/// (`astro-plan-ytx7`).
 #[tokio::test]
 async fn resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state() {
     const OTHER_PENDING_ITEMS: usize = 30;
-    // 30 items at 20ms bounds the resumed pass at ~600ms, which is longer than
-    // the retry call by orders of magnitude on any runner.
-    const ITEM_DELAY_MS: u64 = 20;
 
     let (db, _repo, bus) = support::setup().await;
     let plan_id = Uuid::new_v4().to_string();
@@ -678,18 +678,46 @@ async fn resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state() {
 
     // Installed after the first apply has already reached a terminal state, so
     // only the resumed run — the one that has to still be draining when the
-    // retry arrives — is paced. The guard clears the delay on drop, including on
-    // panic unwind, so a failed assertion cannot slow the rest of this binary.
-    let _pacing = fs_executor::run::pacing::ItemDelayGuard::new(ITEM_DELAY_MS);
+    // retry arrives — is gated. Dropping the gate releases every remaining
+    // boundary, including on panic unwind, so a failed assertion below cannot
+    // strand the spawned executor.
+    let gate = fs_executor::run::pacing::ItemGate::install();
 
     app_core::plan_apply::resume_plan(db.pool(), &bus, &plan_id, &run_row.id)
         .await
         .expect("resume must succeed once the stale condition is resolved");
 
-    // Retry item 0, still `failed` from the pre-pause attempt.
+    // The resumed pass has parked at an item boundary: its retry queue is open
+    // and it has not yet closed the run.
+    gate.wait_for_arrival().await;
+    let gated = plans_repo::get_plan(db.pool(), &plan_id, false).await.expect("get_plan");
+    assert_eq!(gated.state, "applying", "the gated run must still be mid-apply");
+
+    // Retry item 0, still `failed` from the pre-pause attempt. `retry_plan_item`
+    // writes the item row directly (not through the progress buffer), so the
+    // transition is observable here.
     app_core::plan_apply::retry_plan_item(db.pool(), &plan_id, &item0_id)
         .await
         .expect("retry must be accepted: plan is applying, item is failed, run is active");
+    let queued = plans_repo::list_plan_items(db.pool(), &plan_id).await.expect("list_plan_items");
+    let queued0 = queued.iter().find(|i| i.id == item0_id).expect("item 0 row");
+    assert_eq!(
+        queued0.item_state, "applying",
+        "the accepted retry must flip item 0 out of `failed` before the run drains it"
+    );
+    assert!(src0.exists(), "the queued retry must not have executed while the run is gated");
+
+    // Release exactly one item. The loop drains the retry queue after every
+    // item, so the next arrival is strictly after item 0 was re-executed —
+    // making "the retry ran mid-run, not after the queue closed" an assertion
+    // rather than an inference.
+    gate.release(1);
+    gate.wait_for_arrival().await;
+    assert!(!src0.exists(), "the mid-run drain must have re-executed item 0's move");
+    assert!(dst0.exists(), "item 0's destination must exist after the mid-run drain");
+
+    // Release the rest of the run.
+    drop(gate);
 
     // Wait on ITEM 0 specifically, not on the plan. The plan can already hold a
     // terminal state left over from the pre-retry attempt, in which case

--- a/crates/app/core/tests/plan_resume_integration.rs
+++ b/crates/app/core/tests/plan_resume_integration.rs
@@ -676,12 +676,14 @@ async fn resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state() {
         .await
         .expect("update_item_fs_snapshot to resolve staleness");
 
-    // Installed after the first apply has already reached a terminal state, so
-    // only the resumed run — the one that has to still be draining when the
-    // retry arrives — is gated. Dropping the gate releases every remaining
-    // boundary, including on panic unwind, so a failed assertion below cannot
-    // strand the spawned executor.
-    let gate = fs_executor::run::pacing::ItemGate::install();
+    // Scoped to this plan, so a test running concurrently in the same binary
+    // cannot consume this gate's arrival or release permits. Installed after the
+    // first apply has already reached a terminal state, so only the resumed run
+    // — the one that has to still be draining when the retry arrives — is
+    // gated. Dropping the gate releases every remaining boundary, including on
+    // panic unwind, so a failed assertion below cannot strand the spawned
+    // executor.
+    let gate = fs_executor::run::pacing::ItemGate::install(&plan_id);
 
     app_core::plan_apply::resume_plan(db.pool(), &bus, &plan_id, &run_row.id)
         .await

--- a/crates/fs/executor/Cargo.toml
+++ b/crates/fs/executor/Cargo.toml
@@ -32,11 +32,14 @@ sha2.workspace = true
 uuid = { workspace = true }
 
 [features]
-# Compiles the `run::loop_::pacing` seam, which lets a test slow the forward
-# pass so a mid-run retry, pause, or cancel lands while a run is still draining.
-# Default off, so a release binary has no way to throttle a real plan apply.
+# Compiles the `run::loop_::pacing` seam, which parks the forward pass at each
+# item boundary so a test can file a mid-run retry, pause, or cancel while the
+# run provably still holds an open retry queue.
+# Default off, so a release binary has no way to stall a real plan apply.
 # Enabled through the `[dev-dependencies]` edge of the crate whose tests need it,
 # never from a `[dependencies]` edge.
+# `tokio/time` is the arrival timeout that turns a broken ordering into a test
+# failure rather than a hang.
 test-pacing = ["tokio/time"]
 
 [dev-dependencies]

--- a/crates/fs/executor/src/run/loop_.rs
+++ b/crates/fs/executor/src/run/loop_.rs
@@ -71,9 +71,6 @@ async fn drive_plan<C: ExecutorCallbacks>(
     let item_by_id: HashMap<&str, &ExecutorItem> =
         items.iter().map(|i| (i.id.as_str(), i)).collect();
 
-    #[cfg(feature = "test-pacing")]
-    let item_delay = pacing::item_delay();
-
     'items: for item in &items {
         // Skip items that are already in a terminal state (re-apply idempotency).
         if matches!(item.current_state.as_str(), "succeeded" | "skipped" | "cancelled" | "failed") {
@@ -82,9 +79,7 @@ async fn drive_plan<C: ExecutorCallbacks>(
         }
 
         #[cfg(feature = "test-pacing")]
-        if let Some(delay) = item_delay {
-            tokio::time::sleep(delay).await;
-        }
+        pacing::gate_item().await;
 
         // Check cancellation between items (never mid-item).
         if cancel.is_cancelled() {
@@ -204,8 +199,8 @@ async fn drain_retries<C: ExecutorCallbacks>(
     DrainOutcome::Continue
 }
 
-/// Per-item pacing for tests that need the forward pass to still be running
-/// when they act on it.
+/// Per-item gate for tests that need the forward pass to still be running when
+/// they act on it.
 ///
 /// A test that files a mid-run retry, pause, or cancel has to reach the
 /// executor before the forward pass drains its queue. Without a seam the only
@@ -213,51 +208,107 @@ async fn drain_retries<C: ExecutorCallbacks>(
 /// same-directory moves against a warm pool finish inside three awaits often
 /// enough to fail in CI (`astro-plan-ytx7`).
 ///
+/// The gate parks the loop at each non-terminal item boundary and publishes the
+/// arrival, so a test waits for an ordering it observes rather than for a
+/// duration it guessed.
+///
 /// The whole module is behind the `test-pacing` feature, which is off by
 /// default and reachable only through a `[dev-dependencies]` edge, so no
-/// release binary contains a way to throttle a real plan apply.
+/// release binary contains a way to stall a real plan apply.
 ///
-/// An atomic rather than an environment variable: `set_var` in a threaded test
-/// binary races every concurrent `var_os` reader — `tempfile`'s `TMPDIR` lookup
-/// among them — which is undefined behaviour on glibc and already banned in
-/// this repo (`apps/desktop/src-tauri/src/data_dir.rs`).
+/// A static rather than a parameter of [`execute_plan`]: the production call
+/// signature carries no test-only handle.
 #[cfg(feature = "test-pacing")]
 pub mod pacing {
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
     use std::time::Duration;
 
-    static ITEM_DELAY_MS: AtomicU64 = AtomicU64::new(0);
+    use tokio::sync::Semaphore;
 
-    /// Sleep `ms` before each non-terminal item of every subsequent run in this
-    /// process. Zero disables pacing. Process-global, so a test that sets it
-    /// must reset it — see `ItemDelayGuard`.
-    pub fn set_item_delay_ms(ms: u64) {
-        ITEM_DELAY_MS.store(ms, Ordering::Relaxed);
+    /// Bounds a wait whose ordering is already supposed to hold. Exceeding it
+    /// means the loop never reached the boundary, which a panic reports as a
+    /// test failure instead of a hang. Never used to establish ordering, so it
+    /// only has to exceed the slowest legitimate arrival.
+    const ARRIVAL_TIMEOUT: Duration = Duration::from_secs(30);
+
+    struct GateState {
+        /// Gains a permit each time the loop parks at an item boundary.
+        arrived: Semaphore,
+        /// Loses a permit each time the loop leaves an item boundary. Closed by
+        /// [`ItemGate`]'s drop, which releases every later boundary at once.
+        release: Semaphore,
     }
 
-    /// Resets the pacing delay to zero when dropped, including on panic, so one
-    /// test cannot slow every test that follows it in the same binary.
-    pub struct ItemDelayGuard;
+    static GATE: Mutex<Option<Arc<GateState>>> = Mutex::new(None);
 
-    impl ItemDelayGuard {
-        /// Enable pacing for as long as the returned guard lives.
+    /// Recovers from poisoning: a test panicking while the loop is parked must
+    /// still leave the slot usable, and a panicking `Drop` would abort.
+    fn slot() -> MutexGuard<'static, Option<Arc<GateState>>> {
+        GATE.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Park the forward pass until an installed gate releases this item.
+    ///
+    /// A no-op when no [`ItemGate`] is installed, which is every run other than
+    /// the one a gating test drives.
+    pub(crate) async fn gate_item() {
+        let Some(gate) = slot().clone() else { return };
+        gate.arrived.add_permits(1);
+        // Bound to a local declared after `gate` so the permit's borrow of it
+        // ends before `gate` itself drops.
+        let released = gate.release.acquire().await;
+        // `Err` only after `ItemGate`'s drop closed the semaphore, which is the
+        // signal to run the rest of the plan ungated.
+        if let Ok(permit) = released {
+            permit.forget();
+        }
+    }
+
+    /// An installed gate. Dropping it releases every remaining boundary,
+    /// including on a panic unwind, so a failed assertion cannot strand a
+    /// spawned executor.
+    pub struct ItemGate(Arc<GateState>);
+
+    impl ItemGate {
+        /// Gate every item boundary reached in this process from now on.
+        ///
+        /// Process-global: at most one gate per test binary at a time.
         #[must_use]
-        pub fn new(ms: u64) -> Self {
-            set_item_delay_ms(ms);
-            Self
+        pub fn install() -> Self {
+            let state =
+                Arc::new(GateState { arrived: Semaphore::new(0), release: Semaphore::new(0) });
+            *slot() = Some(Arc::clone(&state));
+            Self(state)
+        }
+
+        /// Wait until the forward pass parks at an item boundary.
+        ///
+        /// Returning proves a run is inside its forward loop, so its retry
+        /// queue is still open and a mid-run retry, pause, or cancel lands
+        /// there rather than after the run closed it.
+        ///
+        /// # Panics
+        /// If no boundary is reached within 30 seconds, meaning the run never
+        /// started or already ended.
+        pub async fn wait_for_arrival(&self) {
+            tokio::time::timeout(ARRIVAL_TIMEOUT, self.0.arrived.acquire())
+                .await
+                .expect("executor reached no item boundary: the run never started or already ended")
+                .expect("the arrival semaphore is never closed")
+                .forget();
+        }
+
+        /// Let the forward pass leave `n` further item boundaries.
+        pub fn release(&self, n: usize) {
+            self.0.release.add_permits(n);
         }
     }
 
-    impl Drop for ItemDelayGuard {
+    impl Drop for ItemGate {
         fn drop(&mut self) {
-            set_item_delay_ms(0);
+            self.0.release.close();
+            *slot() = None;
         }
-    }
-
-    /// Read once per run, not per item, so a run cannot change pace midway.
-    pub(crate) fn item_delay() -> Option<Duration> {
-        let ms = ITEM_DELAY_MS.load(Ordering::Relaxed);
-        (ms > 0).then(|| Duration::from_millis(ms))
     }
 }
 

--- a/crates/fs/executor/src/run/loop_.rs
+++ b/crates/fs/executor/src/run/loop_.rs
@@ -79,7 +79,7 @@ async fn drive_plan<C: ExecutorCallbacks>(
         }
 
         #[cfg(feature = "test-pacing")]
-        pacing::gate_item().await;
+        pacing::gate_item(&item.plan_id).await;
 
         // Check cancellation between items (never mid-item).
         if cancel.is_cancelled() {
@@ -212,6 +212,10 @@ async fn drain_retries<C: ExecutorCallbacks>(
 /// arrival, so a test waits for an ordering it observes rather than for a
 /// duration it guessed.
 ///
+/// Keyed by plan id, because integration tests share one process: an un-scoped
+/// registry lets a concurrent test's executor consume the arrival and release
+/// permits the gating test issued for its own run.
+///
 /// The whole module is behind the `test-pacing` feature, which is off by
 /// default and reachable only through a `[dev-dependencies]` edge, so no
 /// release binary contains a way to stall a real plan apply.
@@ -220,6 +224,7 @@ async fn drain_retries<C: ExecutorCallbacks>(
 /// signature carries no test-only handle.
 #[cfg(feature = "test-pacing")]
 pub mod pacing {
+    use std::collections::HashMap;
     use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
     use std::time::Duration;
 
@@ -239,20 +244,23 @@ pub mod pacing {
         release: Semaphore,
     }
 
-    static GATE: Mutex<Option<Arc<GateState>>> = Mutex::new(None);
+    static GATES: Mutex<Option<HashMap<String, Arc<GateState>>>> = Mutex::new(None);
 
     /// Recovers from poisoning: a test panicking while the loop is parked must
-    /// still leave the slot usable, and a panicking `Drop` would abort.
-    fn slot() -> MutexGuard<'static, Option<Arc<GateState>>> {
-        GATE.lock().unwrap_or_else(PoisonError::into_inner)
+    /// still leave the registry usable, and a panicking `Drop` would abort.
+    fn registry() -> MutexGuard<'static, Option<HashMap<String, Arc<GateState>>>> {
+        GATES.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
-    /// Park the forward pass until an installed gate releases this item.
+    /// Park the forward pass until the gate installed for `plan_id` releases
+    /// this item.
     ///
-    /// A no-op when no [`ItemGate`] is installed, which is every run other than
-    /// the one a gating test drives.
-    pub(crate) async fn gate_item() {
-        let Some(gate) = slot().clone() else { return };
+    /// A no-op when no [`ItemGate`] is installed for this plan, which is every
+    /// run other than the one a gating test drives.
+    pub(crate) async fn gate_item(plan_id: &str) {
+        let Some(gate) = registry().as_ref().and_then(|g| g.get(plan_id).cloned()) else {
+            return;
+        };
         gate.arrived.add_permits(1);
         // Bound to a local declared after `gate` so the permit's borrow of it
         // ends before `gate` itself drops.
@@ -267,18 +275,26 @@ pub mod pacing {
     /// An installed gate. Dropping it releases every remaining boundary,
     /// including on a panic unwind, so a failed assertion cannot strand a
     /// spawned executor.
-    pub struct ItemGate(Arc<GateState>);
+    pub struct ItemGate {
+        plan_id: String,
+        state: Arc<GateState>,
+    }
 
     impl ItemGate {
-        /// Gate every item boundary reached in this process from now on.
+        /// Gate every item boundary `plan_id`'s run reaches from now on. Runs of
+        /// other plans are unaffected.
         ///
-        /// Process-global: at most one gate per test binary at a time.
+        /// # Panics
+        /// If a gate is already installed for `plan_id`.
         #[must_use]
-        pub fn install() -> Self {
+        pub fn install(plan_id: &str) -> Self {
             let state =
                 Arc::new(GateState { arrived: Semaphore::new(0), release: Semaphore::new(0) });
-            *slot() = Some(Arc::clone(&state));
-            Self(state)
+            let prior = registry()
+                .get_or_insert_with(HashMap::new)
+                .insert(plan_id.to_owned(), Arc::clone(&state));
+            assert!(prior.is_none(), "a gate is already installed for plan {plan_id}");
+            Self { plan_id: plan_id.to_owned(), state }
         }
 
         /// Wait until the forward pass parks at an item boundary.
@@ -291,7 +307,7 @@ pub mod pacing {
         /// If no boundary is reached within 30 seconds, meaning the run never
         /// started or already ended.
         pub async fn wait_for_arrival(&self) {
-            tokio::time::timeout(ARRIVAL_TIMEOUT, self.0.arrived.acquire())
+            tokio::time::timeout(ARRIVAL_TIMEOUT, self.state.arrived.acquire())
                 .await
                 .expect("executor reached no item boundary: the run never started or already ended")
                 .expect("the arrival semaphore is never closed")
@@ -300,14 +316,16 @@ pub mod pacing {
 
         /// Let the forward pass leave `n` further item boundaries.
         pub fn release(&self, n: usize) {
-            self.0.release.add_permits(n);
+            self.state.release.add_permits(n);
         }
     }
 
     impl Drop for ItemGate {
         fn drop(&mut self) {
-            self.0.release.close();
-            *slot() = None;
+            self.state.release.close();
+            if let Some(gates) = registry().as_mut() {
+                gates.remove(&self.plan_id);
+            }
         }
     }
 }

--- a/crates/fs/executor/src/run/mod.rs
+++ b/crates/fs/executor/src/run/mod.rs
@@ -46,7 +46,8 @@ mod loop_;
 mod tests;
 
 pub use loop_::execute_plan;
-/// Test-only forward-pass pacing. Absent unless the `test-pacing` feature is on.
+/// Test-only forward-pass item gate. Absent unless the `test-pacing` feature is
+/// on.
 #[cfg(feature = "test-pacing")]
 pub use loop_::pacing;
 


### PR DESCRIPTION
## What changed

The `test-pacing` seam in `fs_executor` parks the forward pass at each
non-terminal item boundary and publishes the arrival, so a test drives the run
step by step. It replaces a per-item sleep.

`resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state` now asserts
the ordering it depends on:

1. Wait for the resumed pass to park at its first item boundary, then assert the
   plan is still `applying`.
2. File the retry; assert item 0 left `failed` for `applying` and that its source
   file has not moved.
3. Release exactly one item and wait for the next arrival, which is strictly
   after the post-item retry drain; assert item 0's move happened.
4. Drop the gate, releasing the rest of the run.

The seam is a `tokio::sync::Semaphore` pair behind the default-off `test-pacing`
feature: arrivals accumulate as permits the test consumes, releases are permits
the loop consumes, and `close()` on the guard's `Drop` releases every remaining
boundary, including on a panic unwind. Arrival waits are bounded at 30s and panic
on expiry, which turns a broken ordering into a reported failure rather than a
hang; the bound does not establish the ordering.

The gate registry is keyed by plan id. Integration tests share one process, so a
single process-global gate let a concurrent test's executor park on this gate's
`release` semaphore and publish arrivals into its `arrived` semaphore. `gate_item`
takes `&item.plan_id` and returns without touching a semaphore when that plan has
no installed gate. `ItemGate::install` panics on a duplicate plan id rather than
replacing a live gate.

Plan id rather than the alternatives: `RetryQueue` and the executor instance are
both constructed inside `app_core`, so a test cannot name either one; a tokio
task-local does not reach the executor, which runs in a task the test did not
spawn; threading a handle through `execute_plan` would put a test-only parameter
in the production signature.

The production path is unchanged: the module, its call site, and the
`tokio/time` dependency are all gated on `test-pacing`, which is reachable only
through a `[dev-dependencies]` edge.

## EnvVarGuard

The bead also asked for an `EnvVarGuard` dedupe. At HEAD the workspace holds
exactly one definition (`crates/app/core/src/plan_apply/tests.rs:1089`), and no
other env-restoring `Drop` impl exists, so no copies remain to delete.

## Verification

Every run below used `CARGO_TARGET_DIR=/Users/sjors/tmp/cargo-target/fix-0sgb1-r2`
at `4e7a38148`.

| Command | Result |
| --- | --- |
| `cargo test -p app_core --test plan_resume_integration`, 6 consecutive runs, no name filter | 6 pass, 0 fail; 9 tests per run |
| `cargo test -p app_core` | exit 0, 536 passed, 0 failed |
| `cargo test -p fs_executor` | exit 0, 123 passed across 4 suites |
| `cargo clippy -p fs_executor --all-targets -- -D warnings` | exit 0 |
| `cargo clippy -p fs_executor --all-targets --features test-pacing -- -D warnings` | exit 0 |
| `cargo clippy -p app_core --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --check` | exit 0 |

The full-binary run with no name filter is the measurement that matters here: an
`--exact` run executes the gating test alone and cannot observe cross-test permit
interference.

Inverting the ordering proves the gate is load-bearing. Releasing the whole run
and waiting for the plan to reach a terminal state before filing the retry fails
the test at `plan_resume_integration.rs:705` with `PlanNotInApply`. That edit was
reverted before the commit.

Merge-Bead: astro-plan-vp8w6
Tracks-Bead: astro-plan-0sgb.1
Closes-Bead: astro-plan-0sgb.1
