### PR TITLE
fix(calibration): honour the age limit and the gain/binning match-required settings

### DIFF
--- a/crates/app/calibration/src/matching/loaders.rs
+++ b/crates/app/calibration/src/matching/loaders.rs
@@ -187,6 +187,14 @@ async fn load_config_from_db(pool: &SqlitePool) -> MatchingRuleConfig {
         // "Offset match required" toggle (spec 043 P8).
         config.require_same_offset = row.require_same_offset;
 
+        // "Gain match required" and "Binning match required" toggles. Same dead
+        // config class as the fields below: the pane persisted both and no rule
+        // read them, so clearing either toggle changed nothing (astro-plan-rcvr).
+        // `require_same_camera` is deliberately not read here — the matcher has
+        // no camera dimension to relax (astro-plan-3y8tt).
+        config.require_same_gain = row.require_same_gain;
+        config.require_same_binning = row.require_same_binning;
+
         // Sensor temperature tolerance. Previously this row field was loaded
         // and then ignored: the UI wrote `temperature_tolerance_c` here while
         // the engine only ever read the `calibrationDarkTempTolerance` settings

--- a/crates/app/calibration/src/matching/loaders.rs
+++ b/crates/app/calibration/src/matching/loaders.rs
@@ -201,6 +201,21 @@ async fn load_config_from_db(pool: &SqlitePool) -> MatchingRuleConfig {
         if let Some(n) = usable_tolerance(row.temperature_tolerance_c) {
             config.dark_temp_tolerance_c = n;
         }
+
+        // "Dark / bias age tolerance" input. Same dead-config class as the
+        // temperature field above: persisted and editable, read by no rule
+        // (astro-plan-rcvr). Zero and negative limits are rejected rather than
+        // honoured — a zero limit would refuse every master whose observing
+        // night differs at all, which no user picking "0" is asking for.
+        if row.aging_limit_days > 0 {
+            #[expect(
+                clippy::cast_precision_loss,
+                reason = "day counts are far below f64's exact-integer range"
+            )]
+            {
+                config.age_limit_days = row.aging_limit_days as f64;
+            }
+        }
     }
 
     // Read AFTER the row, so this key still wins where both are set. It is the

--- a/crates/app/calibration/src/matching/tests.rs
+++ b/crates/app/calibration/src/matching/tests.rs
@@ -811,3 +811,96 @@ async fn load_config_reads_aging_limit_days_from_tolerances_table() {
         config.age_limit_days
     );
 }
+
+/// astro-plan-rcvr: the "Gain match required" and "Binning match required"
+/// toggles must change which masters the engine keeps, not just what the row
+/// stores. Both were persisted and read by no rule.
+///
+/// The assertion runs the rules with the loaded config so a value that reaches
+/// `MatchingRuleConfig` but is ignored by the rules still fails.
+#[tokio::test]
+async fn load_config_relaxes_gain_and_binning_hard_rules_from_tolerances_table() {
+    let _guard = lock_cache_tests().await;
+    let db = test_db().await;
+
+    let row =
+        persistence_calibration::repositories::calibration_tolerances::CalibrationTolerancesRow {
+            temperature_tolerance_c: 5.0,
+            exposure_tolerance_s: 2.0,
+            aging_limit_days: 365,
+            require_same_camera: true,
+            require_same_gain: false,
+            require_same_binning: false,
+            require_same_offset: true,
+        };
+    persistence_calibration::repositories::calibration_tolerances::update(db.pool(), &row)
+        .await
+        .unwrap();
+    caches::invalidate_calibration_config();
+    let config = load_config(db.pool()).await;
+
+    let session = calibration_core::SessionInfo {
+        id: "ses-rcvr".to_owned(),
+        session_type: "light".to_owned(),
+        gain: Some(100.0),
+        offset: Some(50.0),
+        exposure_s: Some(300.0),
+        temp_c: Some(-10.0),
+        filter: Some("Ha".to_owned()),
+        rotation_deg: Some(0.0),
+        binning: Some("1x1".to_owned()),
+        optic_train: Some("train-a".to_owned()),
+        ..Default::default()
+    };
+    let dark = calibration_core::MasterInfo {
+        id: "m-dark-rcvr".to_owned(),
+        kind: calibration_core::CalibrationKind::Dark,
+        gain: Some(200.0),
+        offset: Some(50.0),
+        exposure_s: Some(300.0),
+        temp_c: Some(-10.0),
+        filter: None,
+        rotation_deg: None,
+        binning: None,
+        optic_train: None,
+        source_session_id: None,
+        observing_night_date: None,
+    };
+    let flat = calibration_core::MasterInfo {
+        id: "m-flat-rcvr".to_owned(),
+        kind: calibration_core::CalibrationKind::Flat,
+        gain: Some(100.0),
+        offset: None,
+        exposure_s: None,
+        temp_c: None,
+        filter: Some("Ha".to_owned()),
+        rotation_deg: Some(0.0),
+        binning: Some("2x2".to_owned()),
+        optic_train: Some("train-a".to_owned()),
+        source_session_id: None,
+        observing_night_date: None,
+    };
+
+    let strict = calibration_core::ranking::MatchingRuleConfig::default();
+    assert!(
+        calibration_core::rules::dark::evaluate(&session, &dark, &strict).is_none(),
+        "the gain mismatch must be excluded while the toggle is set"
+    );
+    assert!(
+        calibration_core::rules::dark::evaluate(&session, &dark, &config).is_some(),
+        "clearing Gain match required must keep the mismatched dark"
+    );
+    assert!(
+        calibration_core::rules::flat::evaluate(&session, &flat, &strict).is_none(),
+        "the binning mismatch must be excluded while the toggle is set"
+    );
+    assert!(
+        calibration_core::rules::flat::evaluate(&session, &flat, &config).is_some(),
+        "clearing Binning match required must keep the mismatched flat"
+    );
+
+    // The config cache is process-global: leaving a relaxed config in it makes
+    // any later test that reads `load_config` without priming its own row see
+    // relaxed hard rules (#988).
+    caches::invalidate_calibration_config();
+}

--- a/crates/app/calibration/src/matching/tests.rs
+++ b/crates/app/calibration/src/matching/tests.rs
@@ -767,3 +767,47 @@ async fn an_out_of_range_persisted_penalty_falls_back_to_the_engine_default() {
         );
     }
 }
+
+/// `aging_limit_days` is the second dead-config field on this row
+/// (astro-plan-rcvr): editable in Settings > Calibration Matching, read by no
+/// rule. Asserting against `MatchingRuleConfig` rather than a round-trip is
+/// what distinguishes "persisted" from "consumed".
+#[tokio::test]
+async fn load_config_reads_aging_limit_days_from_tolerances_table() {
+    let _guard = lock_cache_tests().await;
+    let db = test_db().await;
+
+    // Neither the column default (365) nor any engine default.
+    let mut row =
+        persistence_calibration::repositories::calibration_tolerances::CalibrationTolerancesRow {
+            temperature_tolerance_c: 5.0,
+            exposure_tolerance_s: 2.0,
+            aging_limit_days: 30,
+            require_same_camera: true,
+            require_same_gain: true,
+            require_same_binning: true,
+            require_same_offset: true,
+        };
+    persistence_calibration::repositories::calibration_tolerances::update(db.pool(), &row)
+        .await
+        .unwrap();
+    caches::invalidate_calibration_config();
+    let config = load_config(db.pool()).await;
+    assert!(
+        (config.age_limit_days - 30.0).abs() < f64::EPSILON,
+        "the Settings age limit must reach MatchingRuleConfig; got {}",
+        config.age_limit_days
+    );
+
+    row.aging_limit_days = 0;
+    persistence_calibration::repositories::calibration_tolerances::update(db.pool(), &row)
+        .await
+        .unwrap();
+    caches::invalidate_calibration_config();
+    let config = load_config(db.pool()).await;
+    assert!(
+        (config.age_limit_days - 365.0).abs() < f64::EPSILON,
+        "a zero limit must fall back to the engine default; got {}",
+        config.age_limit_days
+    );
+}

--- a/crates/calibration/core/src/ranking.rs
+++ b/crates/calibration/core/src/ranking.rs
@@ -118,6 +118,16 @@ pub struct MatchingRuleConfig {
     /// original strict behaviour).
     pub require_same_offset: bool,
 
+    // ── Age tolerance (dark and bias) ──
+    /// Maximum accepted age gap in days between the light session's observing
+    /// night and the master's. Default 365. A master beyond the limit is kept
+    /// as a candidate and reported as an out-of-tolerance `DateProximity`
+    /// mismatch; the dimension is skipped entirely when either observing night
+    /// is unknown, so a master with no date is never penalised for age.
+    pub age_limit_days: f64,
+    /// Age soft max penalty. Default 0.3.
+    pub age_max_penalty: f64,
+
     // ── UI ──
     /// When true, the assign dialog pre-fills with the top candidate (R-Prefill).
     pub prefill_suggestion: bool,
@@ -138,6 +148,8 @@ impl Default for MatchingRuleConfig {
             flat_override_penalty: 0.3,
             bias_override_penalty: 0.3,
             require_same_offset: true,
+            age_limit_days: 365.0,
+            age_max_penalty: 0.3,
             prefill_suggestion: true,
         }
     }
@@ -166,6 +178,12 @@ impl MatchingRuleConfig {
     #[must_use]
     pub fn flat_night_config(&self) -> SoftDimConfig {
         SoftDimConfig::new(self.flat_night_tolerance_nights, self.flat_night_max_penalty)
+    }
+
+    /// `SoftDimConfig` for dark/bias master age tolerance.
+    #[must_use]
+    pub fn age_config(&self) -> SoftDimConfig {
+        SoftDimConfig::new(self.age_limit_days, self.age_max_penalty)
     }
 }
 

--- a/crates/calibration/core/src/ranking.rs
+++ b/crates/calibration/core/src/ranking.rs
@@ -81,6 +81,7 @@ impl SoftDimConfig {
 /// `calibrationDarkOverridePenalty`, `calibrationFlatOverridePenalty`,
 /// `calibrationBiasOverridePenalty`, `calibrationPrefillSuggestion`.
 #[derive(Clone, Debug)]
+#[allow(clippy::struct_excessive_bools)] // Distinct orthogonal per-field match-required flags
 pub struct MatchingRuleConfig {
     // ── Dark tolerances ──
     /// Dark exposure soft tolerance (percentage, 0–100). Default 5.0 → ±5%.
@@ -117,6 +118,18 @@ pub struct MatchingRuleConfig {
     /// the candidate. Default: `true` (offset always required, matching the
     /// original strict behaviour).
     pub require_same_offset: bool,
+    /// When true, a master must carry the same GAIN as the light session for
+    /// dark, bias, and flat matching (hard rule). When false, a missing or
+    /// mismatched gain costs
+    /// [`RELAXED_HARD_RULE_PENALTY`](crate::rules::RELAXED_HARD_RULE_PENALTY)
+    /// instead of excluding the candidate. Default: `true`.
+    pub require_same_gain: bool,
+    /// When true, a flat master must carry the same BINNING as the light session
+    /// (hard rule). When false, a missing or mismatched binning costs
+    /// [`RELAXED_HARD_RULE_PENALTY`](crate::rules::RELAXED_HARD_RULE_PENALTY)
+    /// instead of excluding the candidate. Dark and bias matching does not
+    /// compare binning at all, so this flag does not reach them. Default: `true`.
+    pub require_same_binning: bool,
 
     // ── Age tolerance (dark and bias) ──
     /// Maximum accepted age gap in days between the light session's observing
@@ -148,6 +161,8 @@ impl Default for MatchingRuleConfig {
             flat_override_penalty: 0.3,
             bias_override_penalty: 0.3,
             require_same_offset: true,
+            require_same_gain: true,
+            require_same_binning: true,
             age_limit_days: 365.0,
             age_max_penalty: 0.3,
             prefill_suggestion: true,

--- a/crates/calibration/core/src/rules/bias.rs
+++ b/crates/calibration/core/src/rules/bias.rs
@@ -5,9 +5,12 @@
 #![allow(clippy::collapsible_match, clippy::single_match_else, clippy::must_use_candidate)]
 //!
 //! Hard dimensions: `gain`, `offset` — exact match required.
-//! No soft dimensions: exposure and temperature are explicitly excluded.
+//! Exposure and temperature are explicitly excluded from bias matching.
+//! Soft dimension: `date_proximity` (master age), evaluated only when both the
+//! session and the master carry an observing night.
 //!
-//! `dimensions_matched ∪ dimensions_mismatched` contains only `gain` and `offset`.
+//! `dimensions_matched ∪ dimensions_mismatched` therefore contains `gain` and
+//! `offset`, plus `date_proximity` when both observing nights are known.
 
 use crate::candidate::{CalibrationMatch, MatchedDim, MismatchedDim, SelectionReason};
 use crate::ranking::MatchingRuleConfig;
@@ -61,6 +64,15 @@ pub fn evaluate(
             confidence -= 0.2;
         }
     }
+
+    // ── Soft rule: master age (±age_limit_days) ───────────────────────────────
+    confidence -= crate::rules::apply_age_rule(
+        session.observing_night_date.as_deref(),
+        master.observing_night_date.as_deref(),
+        config,
+        &mut matched,
+        &mut mismatched,
+    );
 
     Some(CalibrationMatch::new(
         session.id.clone(),
@@ -238,5 +250,33 @@ mod tests {
         m.temp_c = Some(50.0);
         let r = evaluate(&session(100.0, 50.0), &m, &MatchingRuleConfig::default());
         assert!(r.is_some(), "exposure/temp differences should not affect bias matching");
+    }
+
+    #[test]
+    fn aging_limit_days_changes_the_match_outcome() {
+        let mut s = session(100.0, 50.0);
+        s.observing_night_date = Some("2026-01-01".to_owned());
+        let mut m = bias_master(100.0, 50.0);
+        m.observing_night_date = Some("2020-01-01".to_owned());
+
+        let strict = evaluate(&s, &m, &MatchingRuleConfig::default())
+            .expect("an over-age bias stays a candidate");
+        assert!(
+            strict.dimensions_mismatched.iter().any(|d| d.dimension == "date_proximity"),
+            "default 365-day limit should report the bias as out of age tolerance"
+        );
+
+        let relaxed = MatchingRuleConfig { age_limit_days: 3000.0, ..Default::default() };
+        let lenient = evaluate(&s, &m, &relaxed).expect("relaxed limit keeps the candidate");
+        assert!(
+            lenient.dimensions_mismatched.is_empty(),
+            "a limit above the gap should leave no mismatched dimension"
+        );
+        assert!(
+            lenient.confidence > strict.confidence,
+            "raising the limit should raise confidence: {} vs {}",
+            lenient.confidence,
+            strict.confidence
+        );
     }
 }

--- a/crates/calibration/core/src/rules/bias.rs
+++ b/crates/calibration/core/src/rules/bias.rs
@@ -4,7 +4,9 @@
 //! Bias frame matching rule (spec 007 US3, FR-005).
 #![allow(clippy::collapsible_match, clippy::single_match_else, clippy::must_use_candidate)]
 //!
-//! Hard dimensions: `gain`, `offset` — exact match required.
+//! Hard dimensions: `gain`, `offset` — exact match required unless the user
+//! clears the corresponding Settings toggle, which turns the dimension into a
+//! soft penalty instead of an exclusion.
 //! Exposure and temperature are explicitly excluded from bias matching.
 //! Soft dimension: `date_proximity` (master age), evaluated only when both the
 //! session and the master carry an observing night.
@@ -34,36 +36,23 @@ pub fn evaluate(
     let mut mismatched: Vec<MismatchedDim> = Vec::new();
     let mut confidence = 1.0_f64;
 
-    // ── Hard rule: gain ───────────────────────────────────────────────────────
-    if crate::rules::hard_rule_numeric(session.gain, master.gain) {
-        matched.push(MatchedDim::exact(Dimension::Gain));
-    } else {
-        return None;
-    }
-
-    // ── Hard rule: offset (controlled by config.require_same_offset) ─────────
-    //
-    // Mirrors the dark rule: strict by default, relaxable via policy flag.
-    match (session.offset, master.offset) {
-        (Some(so), Some(mo)) => {
-            if (so - mo).abs() < crate::rules::HARD_RULE_EPSILON {
-                matched.push(MatchedDim::exact(Dimension::Offset));
-            } else if config.require_same_offset {
-                return None;
-            } else {
-                mismatched
-                    .push(MismatchedDim::out_of_tolerance(Dimension::Offset, (so - mo).abs()));
-                confidence -= 0.2;
-            }
-        }
-        _ => {
-            if config.require_same_offset {
-                return None;
-            }
-            mismatched.push(MismatchedDim::metadata_missing(Dimension::Offset));
-            confidence -= 0.2;
-        }
-    }
+    // ── Hard rules: gain and offset (relaxable per config) ────────────────────
+    confidence -= crate::rules::relaxable_numeric(
+        Dimension::Gain,
+        session.gain,
+        master.gain,
+        config.require_same_gain,
+        &mut matched,
+        &mut mismatched,
+    )?;
+    confidence -= crate::rules::relaxable_numeric(
+        Dimension::Offset,
+        session.offset,
+        master.offset,
+        config.require_same_offset,
+        &mut matched,
+        &mut mismatched,
+    )?;
 
     // ── Soft rule: master age (±age_limit_days) ───────────────────────────────
     confidence -= crate::rules::apply_age_rule(
@@ -250,6 +239,24 @@ mod tests {
         m.temp_c = Some(50.0);
         let r = evaluate(&session(100.0, 50.0), &m, &MatchingRuleConfig::default());
         assert!(r.is_some(), "exposure/temp differences should not affect bias matching");
+    }
+
+    #[test]
+    fn require_same_gain_changes_the_match_outcome() {
+        let s = session(100.0, 50.0);
+        let m = bias_master(200.0, 50.0);
+        assert!(
+            evaluate(&s, &m, &MatchingRuleConfig::default()).is_none(),
+            "a gain mismatch must exclude the bias while the toggle is set"
+        );
+
+        let relaxed = MatchingRuleConfig { require_same_gain: false, ..Default::default() };
+        let r = evaluate(&s, &m, &relaxed).expect("clearing the toggle keeps the bias");
+        assert!(
+            r.dimensions_mismatched.iter().any(|d| d.dimension == "gain"),
+            "the relaxed gain must be reported as a mismatch"
+        );
+        assert!(r.confidence < 1.0, "a relaxed gain must cost confidence: {}", r.confidence);
     }
 
     #[test]

--- a/crates/calibration/core/src/rules/dark.rs
+++ b/crates/calibration/core/src/rules/dark.rs
@@ -3,7 +3,9 @@
 
 //! Dark frame matching rule (spec 007 US1, FR-003).
 //!
-//! Hard dimensions: `gain`, `offset` — exact match required.
+//! Hard dimensions: `gain`, `offset` — exact match required unless the user
+//! clears the corresponding Settings toggle, which turns the dimension into a
+//! soft penalty instead of an exclusion.
 //! Soft dimensions: `exposure` ±5% (default), `temperature` ±2°C (default),
 //! `date_proximity` (master age) ±365 days (default), the last evaluated only
 //! when both the session and the master carry an observing night.
@@ -31,42 +33,23 @@ pub fn evaluate(
     let mut mismatched: Vec<MismatchedDim> = Vec::new();
     let mut confidence = 1.0_f64;
 
-    // ── Hard rule: gain ───────────────────────────────────────────────────────
-    if crate::rules::hard_rule_numeric(session.gain, master.gain) {
-        matched.push(MatchedDim::exact(Dimension::Gain));
-    } else {
-        // Hard rule violation, or missing metadata on either side — exclude.
-        return None;
-    }
-
-    // ── Hard rule: offset (controlled by config.require_same_offset) ─────────
-    //
-    // When `require_same_offset` is true (default) the offset must match
-    // exactly, mirroring the unconditional gain hard-rule above. When false a
-    // missing or mismatched offset is reported as a metadata-missing soft entry
-    // and reduces confidence rather than excluding the candidate entirely.
-    match (session.offset, master.offset) {
-        (Some(so), Some(mo)) => {
-            if (so - mo).abs() < crate::rules::HARD_RULE_EPSILON {
-                matched.push(MatchedDim::exact(Dimension::Offset));
-            } else if config.require_same_offset {
-                return None;
-            } else {
-                // Offset differs but policy allows it — report as soft mismatch.
-                mismatched
-                    .push(MismatchedDim::out_of_tolerance(Dimension::Offset, (so - mo).abs()));
-                confidence -= 0.2; // fixed soft penalty when offset relaxed
-            }
-        }
-        _ => {
-            if config.require_same_offset {
-                return None;
-            }
-            // Missing offset with relaxed policy — soft metadata-missing entry.
-            mismatched.push(MismatchedDim::metadata_missing(Dimension::Offset));
-            confidence -= 0.2;
-        }
-    }
+    // ── Hard rules: gain and offset (relaxable per config) ────────────────────
+    confidence -= crate::rules::relaxable_numeric(
+        Dimension::Gain,
+        session.gain,
+        master.gain,
+        config.require_same_gain,
+        &mut matched,
+        &mut mismatched,
+    )?;
+    confidence -= crate::rules::relaxable_numeric(
+        Dimension::Offset,
+        session.offset,
+        master.offset,
+        config.require_same_offset,
+        &mut matched,
+        &mut mismatched,
+    )?;
 
     // ── Soft rule: exposure (±tolerance%) ─────────────────────────────────────
     let exp_cfg = config.dark_exposure_config();
@@ -458,6 +441,24 @@ mod tests {
             lenient.confidence,
             strict.confidence
         );
+    }
+
+    #[test]
+    fn require_same_gain_changes_the_match_outcome() {
+        let s = session(100.0, 50.0, 300.0, -10.0);
+        let m = master(200.0, 50.0, 300.0, -10.0);
+        assert!(
+            evaluate(&s, &m, &MatchingRuleConfig::default()).is_none(),
+            "a gain mismatch must exclude the master while the toggle is set"
+        );
+
+        let relaxed = MatchingRuleConfig { require_same_gain: false, ..Default::default() };
+        let r = evaluate(&s, &m, &relaxed).expect("clearing the toggle keeps the master");
+        assert!(
+            r.dimensions_mismatched.iter().any(|d| d.dimension == "gain"),
+            "the relaxed gain must be reported as a mismatch"
+        );
+        assert!(r.confidence < 1.0, "a relaxed gain must cost confidence: {}", r.confidence);
     }
 
     #[test]

--- a/crates/calibration/core/src/rules/dark.rs
+++ b/crates/calibration/core/src/rules/dark.rs
@@ -4,7 +4,9 @@
 //! Dark frame matching rule (spec 007 US1, FR-003).
 //!
 //! Hard dimensions: `gain`, `offset` — exact match required.
-//! Soft dimensions: `exposure` ±5% (default), `temperature` ±2°C (default).
+//! Soft dimensions: `exposure` ±5% (default), `temperature` ±2°C (default),
+//! `date_proximity` (master age) ±365 days (default), the last evaluated only
+//! when both the session and the master carry an observing night.
 //!
 //! Missing temperature metadata falls back to gain+offset+exposure matching
 //! with reduced confidence (metadata_missing penalty per spec edge-case).
@@ -128,6 +130,15 @@ pub fn evaluate(
             confidence -= temp_cfg.max_penalty;
         }
     }
+
+    // ── Soft rule: master age (±age_limit_days) ───────────────────────────────
+    confidence -= crate::rules::apply_age_rule(
+        session.observing_night_date.as_deref(),
+        master.observing_night_date.as_deref(),
+        config,
+        &mut matched,
+        &mut mismatched,
+    );
 
     Some(CalibrationMatch::new(
         session.id.clone(),
@@ -404,5 +415,65 @@ mod tests {
         for dim in &["gain", "offset", "exposure", "temperature"] {
             assert!(all_dims.contains(dim), "missing dimension: {dim}");
         }
+    }
+
+    fn dated(night: &str) -> (SessionInfo, MasterInfo) {
+        let mut s = session(100.0, 50.0, 300.0, -10.0);
+        s.observing_night_date = Some("2026-01-01".to_owned());
+        let mut m = master(100.0, 50.0, 300.0, -10.0);
+        m.observing_night_date = Some(night.to_owned());
+        (s, m)
+    }
+
+    fn age_dim_state(r: &CalibrationMatch) -> (bool, bool) {
+        (
+            r.dimensions_matched.iter().any(|d| d.dimension == "date_proximity"),
+            r.dimensions_mismatched.iter().any(|d| d.dimension == "date_proximity"),
+        )
+    }
+
+    #[test]
+    fn aging_limit_days_changes_the_match_outcome() {
+        // ~6 years older than the session's observing night.
+        let (s, m) = dated("2020-01-01");
+
+        let strict = evaluate(&s, &m, &MatchingRuleConfig::default())
+            .expect("an over-age master stays a candidate");
+        assert_eq!(
+            age_dim_state(&strict),
+            (false, true),
+            "default 365-day limit should report the master as out of age tolerance"
+        );
+
+        let relaxed = MatchingRuleConfig { age_limit_days: 3000.0, ..Default::default() };
+        let lenient = evaluate(&s, &m, &relaxed).expect("relaxed limit keeps the candidate");
+        assert_eq!(
+            age_dim_state(&lenient),
+            (true, false),
+            "a limit above the gap should accept the age within tolerance"
+        );
+        assert!(
+            lenient.confidence > strict.confidence,
+            "raising the limit should raise confidence: {} vs {}",
+            lenient.confidence,
+            strict.confidence
+        );
+    }
+
+    #[test]
+    fn an_unknown_observing_night_is_not_penalised_as_age() {
+        // `master()` leaves both observing nights unset.
+        let r = evaluate(
+            &session(100.0, 50.0, 300.0, -10.0),
+            &master(100.0, 50.0, 300.0, -10.0),
+            &MatchingRuleConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            age_dim_state(&r),
+            (false, false),
+            "age must be skipped, not scored, when an observing night is missing"
+        );
+        assert!((r.confidence - 1.0).abs() < 1e-9, "confidence={}", r.confidence);
     }
 }

--- a/crates/calibration/core/src/rules/flat.rs
+++ b/crates/calibration/core/src/rules/flat.rs
@@ -10,6 +10,8 @@
 )]
 //!
 //! Hard dimensions: `filter`, `binning`, `optic_train`, `gain` (exact, 2026-05-23 decision).
+//! `binning` and `gain` become soft penalties when the user clears their
+//! Settings "match required" toggles; `filter` and `optic_train` stay exact.
 //! Soft dimensions: `rotation` ±0.5° (default), `observing_night_proximity` (±7 nights default).
 //!
 //! Selection reasons prioritize same_session > same_night > compatible_fallback.
@@ -42,13 +44,15 @@ pub fn evaluate(
         _ => return None,
     }
 
-    // ── Hard rule: binning ────────────────────────────────────────────────────
-    match (session.binning.as_deref(), master.binning.as_deref()) {
-        (Some(sb), Some(mb)) if crate::rules::hard_rule_string(Some(sb), Some(mb)) => {
-            matched.push(MatchedDim::exact_string(Dimension::Binning, sb));
-        }
-        _ => return None,
-    }
+    // ── Hard rule: binning (relaxable per config) ─────────────────────────────
+    confidence -= crate::rules::relaxable_string(
+        Dimension::Binning,
+        session.binning.as_deref(),
+        master.binning.as_deref(),
+        config.require_same_binning,
+        &mut matched,
+        &mut mismatched,
+    )?;
 
     // ── Hard rule: optic_train ────────────────────────────────────────────────
     match (session.optic_train.as_deref(), master.optic_train.as_deref()) {
@@ -59,11 +63,14 @@ pub fn evaluate(
     }
 
     // ── Hard rule: gain (exact, no tolerance — 2026-05-23 decision) ───────────
-    if crate::rules::hard_rule_numeric(session.gain, master.gain) {
-        matched.push(MatchedDim::exact(Dimension::Gain));
-    } else {
-        return None;
-    }
+    confidence -= crate::rules::relaxable_numeric(
+        Dimension::Gain,
+        session.gain,
+        master.gain,
+        config.require_same_gain,
+        &mut matched,
+        &mut mismatched,
+    )?;
 
     // ── Soft rule: rotation ───────────────────────────────────────────────────
     let rot_cfg = config.flat_rotation_config();
@@ -412,5 +419,39 @@ mod tests {
             .collect();
         assert!(!all_dims.contains(&"exposure"), "flat should not have exposure dimension");
         assert!(!all_dims.contains(&"temperature"), "flat should not have temperature dimension");
+    }
+
+    #[test]
+    fn require_same_gain_changes_the_match_outcome() {
+        let m = master_flat("Ha", "1x1", "train-a", 200.0, 0.0, "2026-01-15");
+        assert!(
+            evaluate(&session(), &m, &MatchingRuleConfig::default()).is_none(),
+            "a gain mismatch must exclude the flat while the toggle is set"
+        );
+
+        let relaxed = MatchingRuleConfig { require_same_gain: false, ..Default::default() };
+        let r = evaluate(&session(), &m, &relaxed).expect("clearing the toggle keeps the flat");
+        assert!(
+            r.dimensions_mismatched.iter().any(|d| d.dimension == "gain"),
+            "the relaxed gain must be reported as a mismatch"
+        );
+        assert!(r.confidence < 1.0, "a relaxed gain must cost confidence: {}", r.confidence);
+    }
+
+    #[test]
+    fn require_same_binning_changes_the_match_outcome() {
+        let m = master_flat("Ha", "2x2", "train-a", 100.0, 0.0, "2026-01-15");
+        assert!(
+            evaluate(&session(), &m, &MatchingRuleConfig::default()).is_none(),
+            "a binning mismatch must exclude the flat while the toggle is set"
+        );
+
+        let relaxed = MatchingRuleConfig { require_same_binning: false, ..Default::default() };
+        let r = evaluate(&session(), &m, &relaxed).expect("clearing the toggle keeps the flat");
+        assert!(
+            r.dimensions_mismatched.iter().any(|d| d.dimension == "binning"),
+            "the relaxed binning must be reported as a mismatch"
+        );
+        assert!(r.confidence < 1.0, "a relaxed binning must cost confidence: {}", r.confidence);
     }
 }

--- a/crates/calibration/core/src/rules/mod.rs
+++ b/crates/calibration/core/src/rules/mod.rs
@@ -6,6 +6,9 @@ pub mod bias;
 pub mod dark;
 pub mod flat;
 
+use crate::candidate::{MatchedDim, MismatchedDim};
+use crate::Dimension;
+
 /// Float-equality tolerance for hard-rule numeric dimensions (gain, offset).
 /// Guards against floating-point representation noise from FITS/XISF header
 /// parsing — this is not a tuning knob (unlike the soft-dimension tolerances
@@ -28,4 +31,35 @@ pub fn hard_rule_numeric(session_val: Option<f64>, master_val: Option<f64>) -> b
 #[must_use]
 pub fn hard_rule_string(session_val: Option<&str>, master_val: Option<&str>) -> bool {
     matches!((session_val, master_val), (Some(s), Some(m)) if s == m)
+}
+
+/// Soft age rule shared by `dark` and `bias`: penalise a master whose observing
+/// night is far from the light session's, bounded by
+/// [`MatchingRuleConfig::age_limit_days`](crate::ranking::MatchingRuleConfig::age_limit_days).
+///
+/// Returns the confidence penalty to subtract, pushing at most one
+/// [`Dimension::DateProximity`] entry. An unknown observing night on either
+/// side is not evidence of an old master, so the dimension is skipped and no
+/// penalty applies — this keeps age-unaware callers on their previous scores.
+pub fn apply_age_rule(
+    session_night: Option<&str>,
+    master_night: Option<&str>,
+    config: &crate::ranking::MatchingRuleConfig,
+    matched: &mut Vec<MatchedDim>,
+    mismatched: &mut Vec<MismatchedDim>,
+) -> f64 {
+    let (Some(sd), Some(md)) = (session_night, master_night) else {
+        return 0.0;
+    };
+    let Some(age_days) = crate::ranking::night_distance(sd, md) else {
+        return 0.0;
+    };
+    let cfg = config.age_config();
+    if let Some(penalty) = cfg.penalty(age_days) {
+        matched.push(MatchedDim::soft(Dimension::DateProximity, age_days, 0.0, age_days));
+        penalty
+    } else {
+        mismatched.push(MismatchedDim::out_of_tolerance(Dimension::DateProximity, age_days));
+        cfg.max_penalty
+    }
 }

--- a/crates/calibration/core/src/rules/mod.rs
+++ b/crates/calibration/core/src/rules/mod.rs
@@ -33,6 +33,74 @@ pub fn hard_rule_string(session_val: Option<&str>, master_val: Option<&str>) -> 
     matches!((session_val, master_val), (Some(s), Some(m)) if s == m)
 }
 
+/// Confidence penalty applied when a relaxed hard rule lets a mismatched or
+/// missing dimension through. Shared by gain, offset, and binning so a relaxed
+/// toggle costs the same wherever it is set.
+pub const RELAXED_HARD_RULE_PENALTY: f64 = 0.2;
+
+/// Numeric hard rule that the user can relax, shared by the gain and offset
+/// comparisons in `bias`/`dark`/`flat`.
+///
+/// Returns `None` to exclude the candidate, or `Some(penalty)` to subtract from
+/// its confidence. With `required` true the dimension behaves as an exact hard
+/// rule; with it false a mismatch becomes an out-of-tolerance entry and a
+/// missing value a metadata-missing entry, each costing
+/// [`RELAXED_HARD_RULE_PENALTY`].
+pub fn relaxable_numeric(
+    dimension: Dimension,
+    session_val: Option<f64>,
+    master_val: Option<f64>,
+    required: bool,
+    matched: &mut Vec<MatchedDim>,
+    mismatched: &mut Vec<MismatchedDim>,
+) -> Option<f64> {
+    match (session_val, master_val) {
+        (Some(s), Some(m)) if (s - m).abs() < HARD_RULE_EPSILON => {
+            matched.push(MatchedDim::exact(dimension));
+            Some(0.0)
+        }
+        _ if required => None,
+        (Some(s), Some(m)) => {
+            mismatched.push(MismatchedDim::out_of_tolerance(dimension, (s - m).abs()));
+            Some(RELAXED_HARD_RULE_PENALTY)
+        }
+        _ => {
+            mismatched.push(MismatchedDim::metadata_missing(dimension));
+            Some(RELAXED_HARD_RULE_PENALTY)
+        }
+    }
+}
+
+/// String hard rule that the user can relax, used by the flat binning
+/// comparison. Filter and optic train stay unconditional.
+///
+/// Mirrors [`relaxable_numeric`]: `None` excludes, `Some(penalty)` keeps the
+/// candidate at reduced confidence.
+pub fn relaxable_string(
+    dimension: Dimension,
+    session_val: Option<&str>,
+    master_val: Option<&str>,
+    required: bool,
+    matched: &mut Vec<MatchedDim>,
+    mismatched: &mut Vec<MismatchedDim>,
+) -> Option<f64> {
+    match (session_val, master_val) {
+        (Some(s), Some(m)) if s == m => {
+            matched.push(MatchedDim::exact_string(dimension, s));
+            Some(0.0)
+        }
+        _ if required => None,
+        (Some(_), Some(_)) => {
+            mismatched.push(MismatchedDim::hard(dimension));
+            Some(RELAXED_HARD_RULE_PENALTY)
+        }
+        _ => {
+            mismatched.push(MismatchedDim::metadata_missing(dimension));
+            Some(RELAXED_HARD_RULE_PENALTY)
+        }
+    }
+}
+
 /// Soft age rule shared by `dark` and `bias`: penalise a master whose observing
 /// night is far from the light session's, bounded by
 /// [`MatchingRuleConfig::age_limit_days`](crate::ranking::MatchingRuleConfig::age_limit_days).


### PR DESCRIPTION
Three fields on the `calibration_tolerances` row were persisted and read by no
matching rule. Clearing a toggle or editing the age limit in Settings >
Calibration Matching changed nothing about which masters the engine kept.

## What matching now reads

| Field | Before | After |
| --- | --- | --- |
| `aging_limit_days` | no `MatchingRuleConfig` field, no rule consumed master age | `MatchingRuleConfig::age_limit_days`, consumed by the dark and bias rules as a `date_proximity` soft dimension |
| `require_same_gain` | persisted, unread | `MatchingRuleConfig::require_same_gain`, consumed by dark, bias, and flat |
| `require_same_binning` | persisted, unread | `MatchingRuleConfig::require_same_binning`, consumed by flat |

A cleared toggle turns its dimension into a soft mismatch costing 0.2
confidence instead of excluding the candidate, which is how
`require_same_offset` already behaved. Filter and optic train stay
unconditional hard rules.

`require_same_offset` and `temperature_tolerance_c` were already wired before
this branch and are unchanged.

## Default-behaviour change

Honouring the age limit adds a dimension rather than assigning to an existing
one, so dark and bias matching changes at default settings: a master whose
observing night is more than 365 days from the light session's is now reported
as an out-of-tolerance `date_proximity` mismatch and loses 0.3 confidence.
Before, master age was not scored at all. A master or session with an unknown
observing night is skipped, not penalised
(`crates/calibration/core/src/rules/mod.rs`, `apply_age_rule`).

The toggles change nothing at their defaults: all three default to required,
which is the previous exclusion behaviour.

## Two fields deliberately left alone

`require_same_camera` is not read. `SessionInfo` and `MasterInfo` carry no
camera field and the rules define no camera dimension, so honouring the toggle
means adding a matching dimension and a fingerprint source for it. Tracked on
`astro-plan-3y8tt`.

`exposure_tolerance_s` is not read, and the bead premise that a user sets it
does not hold. `apps/desktop/src/features/settings/CalibrationMatching.tsx:44`
records that the field is not surfaced in the pane; it is held in state only so
each persist echoes the fetched value back to a non-optional `f64` DTO. No
input element or handler exists for it. The column is absolute seconds and the
matcher's `dark_exposure_tolerance_pct` is a percentage of the reference
exposure, which the config loader does not have. Tracked on `astro-plan-u3w1g`
as a product decision: drop the column or add a control and settle the unit.

## Refactor

The gain and offset comparisons in `dark` and `bias` were duplicated
match-on-both-`Option`s blocks with identical relax semantics. They collapse
into `rules::relaxable_numeric`; `rules::relaxable_string` covers flat binning.

`MatchingRuleConfig` reaches four bools and takes
`#[allow(clippy::struct_excessive_bools)]`, as the sibling DTO and row types
already do.

## Verification

Run in this worktree at `97a791b46` (after merging `origin/main`):

| Command | Result |
| --- | --- |
| `cargo test -p calibration_core -p app_core_calibration` | exit 0 — 167 passed, 0 failed (44 + 122 + 1) |
| `cargo clippy -p calibration_core -p app_core_calibration --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --check -p calibration_core -p app_core_calibration` | exit 0 |

No existing test was modified. The branch appends nine tests: four for the age
limit, five for the two toggles.

Each wiring was neutralised to confirm its test detects the defect:

- removing the two loader assignments and disabling the age-limit branch fails
  `load_config_relaxes_gain_and_binning_hard_rules_from_tolerances_table` and
  `load_config_reads_aging_limit_days_from_tolerances_table` (2 failed, 42
  passed).
- making `relaxable_numeric` and `relaxable_string` ignore their `required`
  argument fails all four new rule tests plus the four pre-existing offset
  relaxation tests in `dark` and `bias` (8 failed, 114 passed).

## Drift left in place

Doc comments in `crates/contracts/core/src/calibration_tolerances.rs:20`,
`crates/persistence/calibration/src/repositories/calibration_tolerances.rs:26`,
and `apps/desktop/src-tauri/src/commands/calibration_tolerances.rs:9` still
name `require_same_offset` as the only field feeding `MatchingRuleConfig`.
Those files are outside this node's scope. The contract schema and the settings
UI need no change: the toggles and the age input already exist with the
defaults this branch honours.

Tracks-Bead: astro-plan-rcvr
Closes-Bead: astro-plan-rcvr
Merge-Bead: astro-plan-ei636
