### PR TITLE
fix: the targets table's star and designation columns stay pinned while scrolling

### DIFF
--- a/apps/desktop/src/features/targets/targets-table.css.ts
+++ b/apps/desktop/src/features/targets/targets-table.css.ts
@@ -87,12 +87,24 @@ globalStyle(`${scroll} ${table} thead th:nth-child(-n + 2)`, {
   position: 'sticky',
 });
 
-globalStyle(`${scroll} ${table} thead th:nth-child(1)`, { left: 0 });
+// `left` goes on the body cells as well as the headers. `position: sticky` with
+// an `auto` inset does not stick at all, so heading-only offsets left the star
+// and designation cells scrolling out from under their own pinned headers
+// whenever the table was narrower than its 1000px minimum.
+globalStyle(
+  `${scroll} ${table} thead th:nth-child(1), ${scroll} ${table} ${row} > td:nth-child(1)`,
+  { left: 0 },
+);
 
-globalStyle(`${scroll} ${table} thead th:nth-child(2)`, {
-  left: 'var(--pv-targets-star-w)',
-  boxShadow: `1px 0 0 ${vars.borderSubtle}`,
-});
+globalStyle(
+  `${scroll} ${table} thead th:nth-child(2), ${scroll} ${table} ${row} > td:nth-child(2)`,
+  {
+    left: 'var(--pv-targets-star-w)',
+    // Seam marking: a box-shadow tracks the sticky cell, where a border-right
+    // detaches from it while scrolling.
+    boxShadow: `1px 0 0 ${vars.borderSubtle}`,
+  },
+);
 
 globalStyle(`${scroll} ${table} ${row} > td:nth-child(-n + 2)`, {
   position: 'sticky',

--- a/tests/e2e/targets_table_pinned_columns.spec.ts
+++ b/tests/e2e/targets_table_pinned_columns.spec.ts
@@ -1,0 +1,116 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Regression: the star and designation columns stay pinned while the Targets
+ * table scrolls horizontally.
+ *
+ * `position: sticky` with an `auto` inset does not stick. When the vanilla-extract
+ * rewrite assigned `left` to `thead th` only, the two body cells kept
+ * `position: sticky` and lost their offsets, so they scrolled out from under
+ * their own still-pinned headers. Both halves render as "sticky" to any
+ * computed-style or class-name check, which is why this asserts measured
+ * geometry after a real scroll.
+ *
+ * Viewport is deliberately narrower than the table's 1000px `min-width`, since
+ * that is the only condition under which the table scrolls horizontally at all.
+ */
+import {
+  test,
+  expect,
+  seedSetupComplete,
+  disableOnboarding,
+  assertDefined,
+} from './support/harness';
+
+const SCROLL_BY = 300;
+
+test.beforeEach(async ({ page }) => {
+  // 820px < the table's 1000px min-width, so the scroll container overflows.
+  await page.setViewportSize({ width: 820, height: 900 });
+  await disableOnboarding(page);
+  seedSetupComplete(page);
+});
+
+test.describe('targets table · pinned columns', () => {
+  test('the star and designation cells hold their position when scrolled horizontally', async ({
+    page,
+  }) => {
+    await page.goto('/#/targets');
+
+    const firstRow = page
+      .locator('tbody tr')
+      .filter({ has: page.locator('td') })
+      .first();
+    await expect(firstRow).toBeVisible({ timeout: 8_000 });
+
+    const starCell = firstRow.locator('td').nth(0);
+    const desigCell = firstRow.locator('td').nth(1);
+    const typeCell = firstRow.locator('td').nth(2);
+    const starHeader = page.locator('thead th').nth(0);
+    const desigHeader = page.locator('thead th').nth(1);
+
+    const before = {
+      star: assertDefined(await starCell.boundingBox(), 'star cell has no box'),
+      desig: assertDefined(
+        await desigCell.boundingBox(),
+        'designation cell has no box',
+      ),
+      type: assertDefined(await typeCell.boundingBox(), 'type cell has no box'),
+      starHeader: assertDefined(
+        await starHeader.boundingBox(),
+        'star header has no box',
+      ),
+      desigHeader: assertDefined(
+        await desigHeader.boundingBox(),
+        'designation header has no box',
+      ),
+    };
+
+    // Scroll the container that actually overflows, and confirm it moved —
+    // otherwise the assertions below would pass on a table that never scrolled.
+    const scrolled = await page.evaluate((by) => {
+      const containers = Array.from(document.querySelectorAll('div')).filter(
+        (el) =>
+          el.scrollWidth > el.clientWidth + 10 && el.querySelector('table'),
+      );
+      const el = containers[0];
+      if (!el) return -1;
+      el.scrollLeft = by;
+      return el.scrollLeft;
+    }, SCROLL_BY);
+    expect(scrolled).toBeGreaterThan(0);
+
+    const after = {
+      star: assertDefined(await starCell.boundingBox(), 'star cell has no box'),
+      desig: assertDefined(
+        await desigCell.boundingBox(),
+        'designation cell has no box',
+      ),
+      type: assertDefined(await typeCell.boundingBox(), 'type cell has no box'),
+      starHeader: assertDefined(
+        await starHeader.boundingBox(),
+        'star header has no box',
+      ),
+      desigHeader: assertDefined(
+        await desigHeader.boundingBox(),
+        'designation header has no box',
+      ),
+    };
+
+    // The unpinned third column is the control: it must have moved left by the
+    // scroll amount, proving the scroll took effect on the table itself.
+    expect(before.type.x - after.type.x).toBeGreaterThan(scrolled - 2);
+
+    // The pinned pair holds. 1px of slack absorbs sub-pixel layout rounding.
+    expect(Math.abs(after.star.x - before.star.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(after.desig.x - before.desig.x)).toBeLessThanOrEqual(1);
+
+    // And each body cell stays aligned with its own header, which is the
+    // specific breakage: headers pinned, cells adrift.
+    expect(Math.abs(after.star.x - after.starHeader.x)).toBeLessThanOrEqual(1);
+    expect(Math.abs(after.desig.x - after.desigHeader.x)).toBeLessThanOrEqual(
+      1,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- The targets table pins its star and designation columns while the rest of the
  row scrolls horizontally. Since #1668 only the headers stayed put, so the body
  cells scrolled away from them. Both columns pin again.
- Added an end-to-end regression test for the pinned pair.

## Cause

The vanilla-extract port kept `left` on the two first-column header selectors but
dropped the matching `.pv-targets-table__row > td` rules that
`apps/desktop/src/styles/components/targets.css:101-111` carried before deletion.
`position: sticky` with an `auto` inset does not stick.

## Change

- `apps/desktop/src/features/targets/targets-table.css.ts:87`: the two
  left-offset rules cover the body cells as well as the headers.
- `tests/e2e/targets_table_pinned_columns.spec.ts`: 820px viewport (below the
  table's 1000px `minWidth`), scroll the container to 300px, then assert column 3
  moved by the scroll amount while columns 1 and 2 held their x and matched their
  own header x.

## Red/green evidence

| Tree state | `pnpm test:e2e targets_table_pinned_columns` |
| --- | --- |
| CSS fix reverted, spec present | 1 failed, star cell x moved 300, expected <= 1 |
| CSS fix applied | 1 passed (11.7s) |

`pnpm lint` exit 0. `pnpm typecheck` exit 0.

## Spec Context

Both files existed only in the reclaimed `css/j3by` worktree and were stranded
when #1668 merged as eca1f1e19.

Tracks-Bead: astro-plan-r0tgd
Closes-Bead: astro-plan-r0tgd
Merge-Bead: astro-plan-g7nmp
