### PR TITLE
build: pin the Rust toolchain to 1.98.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
             libayatana-appindicator3-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         if: needs.changes.outputs.rust == 'true'
         with:
           components: rustfmt, clippy
@@ -808,7 +808,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
       - uses: Swatinem/rust-cache@v2
 
       # Scope gate: only run when a change touches the measured crates.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -83,7 +83,7 @@ jobs:
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
             libayatana-appindicator3-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         with:
           # llvm-tools-preview provides the LLVM coverage instrumentation
           # backend that cargo-llvm-cov links against at test time.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -453,7 +453,7 @@ jobs:
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
             libayatana-appindicator3-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
 
       # cache-on-failure deliberately left at its default (false). Saving from a
@@ -575,7 +575,7 @@ jobs:
             echo "archive_usable=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
 
       - uses: Swatinem/rust-cache@v2
@@ -682,7 +682,7 @@ jobs:
             echo "archive_usable=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
         if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -64,7 +64,7 @@ jobs:
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
             libayatana-appindicator3-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -96,7 +96,7 @@ jobs:
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
             libayatana-appindicator3-dev patchelf
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.98.0
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,5 @@
+# CI installs the toolchain with dtolnay/rust-toolchain@<version>, which ignores
+# this file. Bump both together or CI and local builds diverge.
 [toolchain]
-channel = "stable"
+channel = "1.98.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

- Builds use Rust 1.98.0 everywhere instead of whatever `stable` resolves to on the day a job runs, so a new upstream Rust release cannot change this build.
- `rust-toolchain.toml` sets `channel = "1.98.0"`; all eight CI steps use `dtolnay/rust-toolchain@1.98.0` (`ci.yml` x2, `coverage.yml`, `e2e.yml` x3, `release-gate.yml`, `release-please.yml`). Both places are pinned because the action installs its own ref and ignores `rust-toolchain.toml`.
- 1.98.0 is the version the runners already resolved: the last green `ci.yml` run on main (run 32521352293) reported `rustc 1.98.0 (88d9e12ae 2026-08-18)` on ubuntu, macOS, and windows. A toolchain upgrade is now a one-line change.

Verified locally with the pinned toolchain (`rustc --version` reports 1.98.0 from the file): `cargo fmt --all --check` exit 0, `cargo clippy --workspace --all-targets --all-features -- -D warnings` exit 0, `actionlint` on the five edited workflows exit 0.

Merge-Bead: astro-plan-1vxpl
Tracks-Bead: astro-plan-lvu0d