### PR TITLE
fix: plan-apply checkpoint failures now appear in the log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,6 +4502,7 @@ dependencies = [
  "thiserror 2.0.19",
  "time",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/crates/persistence/plans/Cargo.toml
+++ b/crates/persistence/plans/Cargo.toml
@@ -15,10 +15,11 @@ serde_json.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
 time.workspace = true
+tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-persistence_core = { path = "../core", features = [] }
+persistence_core = { path = "../core", features = ["test-fixture"] }
 tempfile.workspace = true
 tokio.workspace = true
 

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -33,8 +33,8 @@ use persistence_core::{DbError, DbResult};
 ///
 /// A failed checkpoint (e.g. a reader holding the WAL open) is not fatal: the
 /// intent is already committed to the WAL, boot reconciliation is the backstop,
-/// and the next automatic checkpoint will sync it. Both callers discard the
-/// error without logging and proceed.
+/// and the next automatic checkpoint will sync it. Both callers warn and
+/// proceed rather than propagating.
 async fn checkpoint_intent(conn: &mut SqliteConnection) -> DbResult<()> {
     sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)").execute(conn).await?;
     Ok(())
@@ -180,10 +180,15 @@ pub async fn cas_approved_to_applying(
     // Tier-1: sync the just-committed intent before the executor touches the
     // filesystem (see `checkpoint_intent`). Best-effort: a failed checkpoint
     // leaves the intent durable in the WAL, and boot reconciliation is the
-    // backstop, so the error is intentionally swallowed (the persistence layer
-    // carries no logging facade).
+    // backstop, so the error is logged and not propagated.
     let mut conn = pool.acquire().await?;
-    let _ = checkpoint_intent(&mut conn).await;
+    if let Err(error) = checkpoint_intent(&mut conn).await {
+        tracing::warn!(
+            plan_id,
+            %error,
+            "apply-start intent checkpoint failed; intent remains durable in the WAL"
+        );
+    }
 
     Ok(())
 }
@@ -333,7 +338,14 @@ pub async fn resume_run(pool: &SqlitePool, plan_id: &str, run_id: &str) -> DbRes
     // items, so the same intent-durability guarantee as apply-start applies.
     // Best-effort (see `cas_approved_to_applying`).
     let mut conn = pool.acquire().await?;
-    let _ = checkpoint_intent(&mut conn).await;
+    if let Err(error) = checkpoint_intent(&mut conn).await {
+        tracing::warn!(
+            plan_id,
+            run_id,
+            %error,
+            "resume intent checkpoint failed; intent remains durable in the WAL"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- A failed intent checkpoint during plan apply and plan resume produced no record anywhere. Both sites now log a warning naming the plan (and the run on resume) and the error.
- Behaviour is unchanged: the intent is committed to the WAL before the checkpoint runs and boot reconciliation is the backstop, so neither site fails the operation. This makes an already-safe best-effort path observable.
- `cargo test -p persistence_plans` compiles standalone again; the crate dev-dependency on `persistence_core` cleared the feature list and could not resolve the shared test fixtures.

Verification: `cargo fmt -p persistence_plans -- --check` 0, `cargo clippy -p persistence_plans --all-targets -- -D warnings` 0, `cargo test -p persistence_plans` 0 (75 passed).

Merge-Bead: astro-plan-6ygyj
Tracks-Bead: astro-plan-h0a8d
