### PR TITLE
fix: target search crashes when a filter is set and the requested result limit exceeds 100

### DIFF
--- a/crates/app/targets/src/target_search.rs
+++ b/crates/app/targets/src/target_search.rs
@@ -108,12 +108,23 @@ fn hit_to_suggestion(hit: SearchHit) -> TargetSuggestion {
 
 // ── search ──────────────────────────────────────────────────────────────────
 
+const DEFAULT_SEARCH_LIMIT: usize = 20;
+
+/// `target.search.json` §Request declares `limit` as `maximum: 100`. Requests
+/// reaching this use case are not schema-validated, so the ceiling is enforced
+/// here; `MAX_FETCH_CAP` below is only sound while `limit <= MAX_FETCH_CAP`.
+const MAX_SEARCH_LIMIT: usize = 100;
+
+/// Upper bound on the over-fetch that feeds the post-filter.
+const MAX_FETCH_CAP: usize = 500;
+
 /// `target.search` — ranked typeahead suggestions from the shared redb resolve
 /// cache (seed + anything the facade has resolved/warmed, spec 052 P1 D1/T012).
 ///
-/// Respects `limit` (default 20, see the request DTO). A blank query yields an
-/// empty suggestion list. Both optional filters are applied as a post-filter and
-/// AND together: `catalog_filter` against the target's catalogue membership
+/// Respects `limit` (default 20, contract maximum 100; a larger request is
+/// clamped down to 100). A blank query yields an empty suggestion list. Both
+/// optional filters are applied as a post-filter and AND together:
+/// `catalog_filter` against the target's catalogue membership
 /// (derived from its alias designations) and `type_filter` against the object
 /// type. Over-fetches a bounded multiple of `limit` from the cache before
 /// filtering, so a narrow filter still fills the page.
@@ -126,14 +137,18 @@ pub async fn search(
     cache: &dyn simbad_resolver::Cache,
     req: &TargetSearchRequest,
 ) -> Result<TargetSearchResponse, ContractError> {
-    let limit = if req.limit == 0 { 20 } else { req.limit as usize };
+    let limit = if req.limit == 0 {
+        DEFAULT_SEARCH_LIMIT
+    } else {
+        (req.limit as usize).min(MAX_SEARCH_LIMIT)
+    };
 
     let catalog_filter = &req.catalog_filter;
     let type_filter = &req.type_filter;
     let fetch_cap = if catalog_filter.is_empty() && type_filter.is_empty() {
         limit
     } else {
-        (limit.saturating_mul(8)).clamp(limit, 500)
+        limit.saturating_mul(8).min(MAX_FETCH_CAP)
     };
 
     let hits = cache.search(&req.query, fetch_cap).await.map_err(|e| cache_err(&e))?;
@@ -302,6 +317,18 @@ mod tests {
         r.limit = 0;
         let resp = search(&cache, &r).await.unwrap();
         assert_eq!(resp.suggestions.len(), 2);
+    }
+
+    /// bd astro-plan-3v3r.11.26: an over-contract `limit` combined with a
+    /// filter made the over-fetch clamp's min exceed its max and panicked.
+    #[tokio::test]
+    async fn search_limit_above_the_contract_maximum_with_a_filter_does_not_panic() {
+        let cache = seeded_cache().await;
+        let mut r = req("NGC");
+        r.limit = 501;
+        r.type_filter = vec![TargetObjectType::EmissionNebula];
+        let resp = search(&cache, &r).await.unwrap();
+        assert_eq!(resp.suggestions.len(), 1);
     }
 
     #[tokio::test]

--- a/crates/testing/fits-fixtures/src/lib.rs
+++ b/crates/testing/fits-fixtures/src/lib.rs
@@ -35,9 +35,11 @@ use std::path::Path;
 ///
 /// Panics if more than 35 cards are added (overflows one 2880-byte block
 /// after the mandatory END card). Test fixtures never need more than ~10 cards.
+const CARD: usize = 80;
+
 #[derive(Default)]
 pub struct FitsFixture {
-    cards: Vec<String>,
+    cards: Vec<[u8; CARD]>,
 }
 
 impl FitsFixture {
@@ -47,10 +49,18 @@ impl FitsFixture {
         Self::default()
     }
 
-    /// Add a raw card string (truncated / padded to 80 bytes).
+    /// Add a raw card string, space-padded or truncated to exactly 80 bytes.
+    ///
+    /// A FITS card is a fixed 80-byte record, so padding and truncation are on
+    /// byte counts, not character counts: a multibyte character straddling byte
+    /// 80 is cut mid-character.
     #[must_use]
     pub fn card(mut self, raw: &str) -> Self {
-        self.cards.push(format!("{:<80}", &raw[..raw.len().min(80)]));
+        let mut card = [b' '; CARD];
+        let src = raw.as_bytes();
+        let n = src.len().min(CARD);
+        card[..n].copy_from_slice(&src[..n]);
+        self.cards.push(card);
         self
     }
 
@@ -128,7 +138,6 @@ impl FitsFixture {
     /// cards were added (would overflow one 2880-byte FITS block).
     pub fn write(self, path: &Path) {
         const BLOCK: usize = 2880;
-        const CARD: usize = 80;
         const MAX_CARDS: usize = BLOCK / CARD; // 36
 
         let n = self.cards.len();
@@ -140,9 +149,7 @@ impl FitsFixture {
 
         let mut block = vec![b' '; BLOCK];
         for (i, card) in self.cards.iter().enumerate() {
-            let bytes = card.as_bytes();
-            block[i * CARD..i * CARD + bytes.len().min(CARD)]
-                .copy_from_slice(&bytes[..bytes.len().min(CARD)]);
+            block[i * CARD..(i + 1) * CARD].copy_from_slice(card);
         }
         // END card
         block[n * CARD..n * CARD + 3].copy_from_slice(b"END");
@@ -189,5 +196,33 @@ mod tests {
         assert_eq!(bytes.len(), 2880);
         // END should be at slot 3.
         assert_eq!(bytes[3 * 80..3 * 80 + 3], *b"END");
+    }
+
+    /// bd astro-plan-3v3r.15.5: a card whose byte 80 fell inside a multibyte
+    /// character panicked on a `str` slice at a non-char boundary.
+    #[test]
+    fn multibyte_card_across_the_eighty_byte_boundary_does_not_panic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        // "OBJECT  = '" is 11 bytes; 'é' is 2 bytes and lands on bytes 79..81.
+        let value = format!("{}é", "x".repeat(68));
+        FitsFixture::new().object(&value).card(&"Ω".repeat(60)).write(&path);
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(bytes.len(), 2880);
+        assert_eq!(&bytes[..11], b"OBJECT  = '");
+        // Both cards occupy exactly 80 bytes each, so END lands at slot 2.
+        assert_eq!(bytes[2 * 80..2 * 80 + 3], *b"END");
+    }
+
+    #[test]
+    fn short_ascii_card_is_space_padded_to_eighty_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.fits");
+        FitsFixture::new().card("SIMPLE  =                    T").write(&path);
+
+        let bytes = std::fs::read(&path).unwrap();
+        assert_eq!(&bytes[..30], b"SIMPLE  =                    T");
+        assert!(bytes[30..80].iter().all(|b| *b == b' '));
     }
 }

--- a/crates/testing/fits-fixtures/src/lib.rs
+++ b/crates/testing/fits-fixtures/src/lib.rs
@@ -29,14 +29,14 @@
 use std::io::Write as _;
 use std::path::Path;
 
+const CARD: usize = 80;
+
 /// Minimal FITS fixture builder.
 ///
 /// # Panics
 ///
 /// Panics if more than 35 cards are added (overflows one 2880-byte block
 /// after the mandatory END card). Test fixtures never need more than ~10 cards.
-const CARD: usize = 80;
-
 #[derive(Default)]
 pub struct FitsFixture {
     cards: Vec<[u8; CARD]>,


### PR DESCRIPTION
## Summary

- Target search with a catalogue or type filter and a result limit of 501 or more crashed the command. The requested limit is now capped at 100, the maximum the `target.search` contract declares.
- The FITS test-fixture builder crashed on any card containing a multibyte character that straddled byte 80. Cards are now padded and truncated on byte counts, matching the fixed 80-byte FITS card record.

## Details

`crates/app/targets/src/target_search.rs` computed its over-fetch as `(limit * 8).clamp(limit, 500)`, so a `limit` of 501 or more made the clamp's min exceed its max and `Ord::clamp` asserted. The panic was reachable directly from the `limit` request parameter.

`specs/035-simbad-target-resolution/contracts/target.search.json` declares `limit` as `{minimum: 1, maximum: 100, default: 20}`. The requested limit is capped at that maximum rather than rejected: requests reaching this use case are not schema-validated, and the existing `limit == 0` branch already coerces instead of erroring. With `limit <= 100` the clamp's lower bound is unreachable, so the over-fetch is now a plain `min` against the 500 cap.

`crates/testing/fits-fixtures/src/lib.rs` padded with `format!("{:<80}")`, which counts characters, then sliced `&raw[..80]`, which counts bytes. Cards are now `[u8; 80]`. ASCII input produces byte-identical output.

## Regression tests

| Test | Defect |
| --- | --- |
| `app_core_targets target_search::tests::search_limit_above_the_contract_maximum_with_a_filter_does_not_panic` | astro-plan-3v3r.11.26 |
| `fits_fixtures tests::multibyte_card_across_the_eighty_byte_boundary_does_not_panic` | astro-plan-3v3r.15.5 |
| `fits_fixtures tests::short_ascii_card_is_space_padded_to_eighty_bytes` | unchanged ASCII padding |

Both regression tests panic against the pre-fix code, at `target_search.rs:136` and `lib.rs:53`.

## Verification

- `cargo clippy --workspace --all-targets -- -D warnings`: exit 0 (rustc 1.98.0)
- `cargo nextest run --workspace`: exit 0, 3094 passed, 31 skipped
- No files under `apps/desktop` touched.

## Spec Context

Contract: `specs/035-simbad-target-resolution/contracts/target.search.json`

Merge-Bead: astro-plan-33rq3
Tracks-Bead: astro-plan-9sf74
Tracks-Bead: astro-plan-3v3r.11.26
Tracks-Bead: astro-plan-3v3r.15.5

