### PR TITLE
fix: CI guards no longer report a clean tree when their own scan breaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
       - id: decide
         shell: bash
         run: |
+          set -euo pipefail
           shared="${{ steps.filter.outputs.force_full_shared }}"
           rust=false
           frontend=false
@@ -818,6 +819,7 @@ jobs:
         env:
           CHANGED_FILES: ${{ needs.changes.outputs.all_files }}
         run: |
+          set -euo pipefail
           args=$(printf '%s' "$CHANGED_FILES" | tr ',' '\n' | bash scripts/ci-affected-crates.sh)
           if printf '%s' "$args" | grep -qE 'app_core_inbox|persistence_inbox|fs_inventory'; then
             echo "run=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e-alert.yml
+++ b/.github/workflows/e2e-alert.yml
@@ -40,6 +40,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           # Fetch the workflow run to extract metadata
           RUN_ID="${{ github.event.workflow_run.id }}"
           RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
@@ -58,6 +59,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           RUN_ID="${{ steps.workflow.outputs.run_id }}"
 
           # Query the GitHub API for all jobs in the workflow run
@@ -93,6 +95,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           # Search for open issues with ci-regression label and "main L3 E2E" in title
           ISSUE_NUM=$(gh issue list \
             --label ci-regression \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -281,6 +281,7 @@ jobs:
         env:
           DISPATCHED: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
+          set -euo pipefail
           run=false
           if [ "$DISPATCHED" = "true" ] \
             || [ "${{ steps.filter.outputs.force_full }}" = "true" ] \
@@ -392,6 +393,7 @@ jobs:
         id: appkey
         shell: bash
         run: |
+          set -euo pipefail
           key=$(bash scripts/e2e-app-cache-key.sh)
           # An empty key would silently degrade to a bare prefix shared by
           # every commit — the worst case, a permanent stale hit. Fail loudly.
@@ -432,6 +434,7 @@ jobs:
         id: verify-app-cache
         shell: bash
         run: |
+          set -euo pipefail
           if [ "${{ steps.app-cache.outputs.cache-hit }}" = "true" ] && [ -x "${{ env.APP_BIN }}" ]; then
             echo "app_usable=true" >> "$GITHUB_OUTPUT"
           else
@@ -529,6 +532,7 @@ jobs:
         id: appkey
         shell: bash
         run: |
+          set -euo pipefail
           key=$(bash scripts/e2e-app-cache-key.sh)
           # An empty key would silently degrade to a bare prefix shared by
           # every commit — the worst case, a permanent stale hit. Fail loudly.
@@ -564,6 +568,7 @@ jobs:
         id: verify-app-cache
         shell: bash
         run: |
+          set -euo pipefail
           if [ "${{ steps.app-cache.outputs.cache-hit }}" = "true" ] && [ -f "${{ env.APP_BIN }}" ]; then
             echo "app_usable=true" >> "$GITHUB_OUTPUT"
           else
@@ -636,6 +641,7 @@ jobs:
         id: appkey
         shell: bash
         run: |
+          set -euo pipefail
           key=$(bash scripts/e2e-app-cache-key.sh)
           # An empty key would silently degrade to a bare prefix shared by
           # every commit — the worst case, a permanent stale hit. Fail loudly.
@@ -671,6 +677,7 @@ jobs:
         id: verify-app-cache
         shell: bash
         run: |
+          set -euo pipefail
           if [ "${{ steps.app-cache.outputs.cache-hit }}" = "true" ] && [ -f "${{ env.APP_BIN }}" ]; then
             echo "app_usable=true" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -195,6 +195,7 @@ jobs:
           # Only exclude the clobbered extensions on the leg that actually clobbers them.
           SKIP_WINDOWS_BUNDLES: ${{ runner.os == 'Windows' && vars.ENABLE_WINDOWS_SIGNING == 'true' }}
         run: |
+          set -euo pipefail
           # Drop .sig sidecars (signatures over the bundles, not artifacts in their own
           # right) and latest.json (a pointer regenerated on every release, so a
           # provenance claim over it ages out immediately).

--- a/scripts/branch-protection-main.sh
+++ b/scripts/branch-protection-main.sh
@@ -64,40 +64,68 @@ BRANCH="${BRANCH:-main}"
 here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFIG="$here/branch-protection-main.json"
 
+# Read the required contexts once, and refuse to report on an empty list: a
+# `while read` loop over an empty producer leaves every accumulator at 0, so
+# both verify_* functions returned PASS having inspected nothing whenever
+# python3 was missing, the config was unreadable, or the config carried no
+# required_status_checks.contexts.
+read_contexts() {
+  if ! command -v python3 >/dev/null; then
+    echo "ERROR: python3 is required to read $CONFIG." >&2
+    return 2
+  fi
+  local out
+  out=$(python3 -c '
+import json,sys
+print("\n".join(json.load(open(sys.argv[1]))["required_status_checks"]["contexts"]))' "$CONFIG") || {
+    echo "ERROR: could not read required_status_checks.contexts from $CONFIG." >&2
+    return 2
+  }
+  if [ -z "${out//[[:space:]]/}" ]; then
+    echo "ERROR: $CONFIG lists zero required_status_checks.contexts; there is nothing to verify." >&2
+    return 2
+  fi
+  printf '%s\n' "$out"
+}
+
 # The context strings contain U+2014 EM DASH, not a hyphen. A hyphen produces a
 # required context that never reports, which leaves every PR pending forever.
 verify_contexts() {
   # Only the SEPARATOR matters. Hyphens inside a word are fine
   # ("UI mock-mode (Playwright)", "ubuntu-latest"); the failure mode is a
   # spaced hyphen " - " where the job name uses " — ".
-  local bad=0
+  local bad=0 contexts
+  contexts=$(read_contexts) || return $?
   while IFS= read -r ctx; do
+    [ -n "$ctx" ] || continue
     case "$ctx" in
       *" - "*) echo "  WARN: '$ctx' uses ' - ' as a separator; job names use ' — ' (U+2014)" >&2; bad=1 ;;
     esac
-  done < <(python3 -c '
-import json,sys
-print("\n".join(json.load(open(sys.argv[1]))["required_status_checks"]["contexts"]))' "$CONFIG")
+  done <<< "$contexts"
   return $bad
 }
 
 # Guard against protecting on names no workflow produces.
 verify_names_exist() {
   local missing=0
-  local names
+  local names contexts
+  contexts=$(read_contexts) || return $?
   names=$(grep -hoE "^    name: .*" "$here/../.github/workflows/ci.yml" \
                                     "$here/../.github/workflows/e2e.yml" \
           | sed 's/^    name: //')
+  if [ -z "${names//[[:space:]]/}" ]; then
+    echo "ERROR: no job names parsed from ci.yml and e2e.yml; the name scan failed." >&2
+    return 2
+  fi
   while IFS= read -r ctx; do
+    [ -n "$ctx" ] || continue
     # matrix jobs appear in source as `... — ${{ matrix.os }}`
     local stem="${ctx% — *}"
     if ! printf '%s\n' "$names" | grep -qF "$stem"; then
       echo "  WARN: no workflow job matches '$ctx' (stem '$stem')" >&2
       missing=1
     fi
-  done < <(python3 -c '
-import json,sys
-print("\n".join(json.load(open(sys.argv[1]))["required_status_checks"]["contexts"]))' "$CONFIG")
+  done <<< "$contexts"
   return $missing
 }
 
@@ -118,7 +146,15 @@ case "${1:-show}" in
     # for a check that can never arrive. PR #1313 hit that shape from the other
     # direction — a skipped matrix job never published its expanded names — and
     # sat unmergeable until it was admin-merged.
-    if ! verify_names_exist; then
+    # rc 2 means the check could not run; ALLOW_MISSING_NAMES waives a known
+    # missing name, never a scan that inspected nothing.
+    names_rc=0
+    verify_names_exist || names_rc=$?
+    if [ "$names_rc" -eq 2 ]; then
+      echo "refusing to apply: the required-context check could not run." >&2
+      exit 2
+    fi
+    if [ "$names_rc" -ne 0 ]; then
       if [ "${ALLOW_MISSING_NAMES:-}" = "1" ]; then
         echo "  (continuing: ALLOW_MISSING_NAMES=1)" >&2
       else

--- a/scripts/check-i18n-catalog.mjs
+++ b/scripts/check-i18n-catalog.mjs
@@ -53,11 +53,22 @@ const BASELINE_PATH = path.join(here, 'i18n-catalog-baseline.txt');
 // the catalog's intentional per-screen convention.
 const DUP_MIN_LENGTH = 12;
 
+/**
+ * Zero entries means the catalog shape changed (nested groups instead of flat
+ * string values), not that the catalog is clean: without this throw the lint
+ * reported OK over a live violation and --generate drained the baseline.
+ */
 function loadCatalog() {
   const data = JSON.parse(readFileSync(CATALOG_PATH, 'utf8'));
-  return Object.entries(data).filter(
+  const entries = Object.entries(data).filter(
     ([key, value]) => key !== '$schema' && typeof value === 'string',
   );
+  if (entries.length === 0) {
+    throw new Error(
+      `${CATALOG_PATH}: no string message values parsed — the catalog layout changed; update scripts/check-i18n-catalog.mjs.`,
+    );
+  }
+  return entries;
 }
 
 function findCodeParamViolations(entries) {

--- a/scripts/check-lifecycle-strings.sh
+++ b/scripts/check-lifecycle-strings.sh
@@ -11,17 +11,41 @@
 #   bash scripts/check-lifecycle-strings.sh          # exits 0 on pass, 1 on fail
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+# `cd "$(git rev-parse --show-toplevel)"` degrades to a no-op `cd ""` at exit 0
+# when git fails, which scans the caller's cwd and reports a clean tree.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+for dir in crates apps; do
+  if [ ! -d "$dir" ]; then
+    echo "ERROR: scan root '$dir' does not exist under $ROOT." >&2
+    exit 2
+  fi
+done
+
+# grep exits 1 for "no matches" and >1 for "the scan itself failed"; collapsing
+# the two reports an unreadable tree as zero violations.
+set +e
+raw=$(grep -rn '\.lifecycle\s*[!=]=\s*"' --include='*.rs' crates/ apps/)
+rc=$?
+set -e
+if [ "$rc" -gt 1 ]; then
+  echo "ERROR: grep exited $rc scanning crates/ apps/ — the scan failed, so this run proves nothing." >&2
+  exit 2
+fi
 
 # grep -rn output: "path/file.rs:42:  content" — the comment-exclusion regex
 # must match after the "path:line:" prefix, not at line start.
-hits=$(grep -rn '\.lifecycle\s*[!=]=\s*"' --include='*.rs' crates/ apps/ \
-  | grep -v '/tests/' \
-  | grep -v 'test_support' \
-  | grep -vE ':[0-9]+:\s*//' \
-  || true)
+hits=""
+if [ -n "$raw" ]; then
+  hits=$(printf '%s\n' "$raw" \
+    | grep -v '/tests/' \
+    | grep -v 'test_support' \
+    | grep -vE ':[0-9]+:\s*//' \
+    || true)
+fi
 
-count=$(echo "$hits" | grep -c . || true)
+count=$(printf '%s' "$hits" | grep -c . || true)
 
 if [ "$count" -gt 0 ]; then
   echo "ERROR: $count raw lifecycle string comparison(s) found."

--- a/scripts/check-mock-baseline.mjs
+++ b/scripts/check-mock-baseline.mjs
@@ -42,11 +42,23 @@ const BINDINGS_PATH = path.join(DESKTOP_ROOT, 'src/bindings/index.ts');
 const MOCKS_PATH = path.join(DESKTOP_ROOT, 'src/api/mocks.ts');
 const BASELINE_PATH = path.join(here, 'mock-unmocked-baseline.txt');
 
-/** Wire command names registered in the generated bindings. */
+/**
+ * Wire command names registered in the generated bindings.
+ *
+ * An empty set means the invoke wrapper was renamed, not that the app has no
+ * commands: without this throw every command reads as mocked and --generate
+ * drains the baseline.
+ */
 function bindingCommands(src) {
-  return new Set(
+  const names = new Set(
     [...src.matchAll(/__TAURI_INVOKE\("([a-z0-9_]+)"/g)].map((m) => m[1]),
   );
+  if (names.size === 0) {
+    throw new Error(
+      'bindings/index.ts: no __TAURI_INVOKE("command") call found — the generated invoke wrapper was renamed; update scripts/check-mock-baseline.mjs.',
+    );
+  }
+  return names;
 }
 
 /**

--- a/scripts/check-perf-baseline.sh
+++ b/scripts/check-perf-baseline.sh
@@ -154,6 +154,15 @@ check() {
     stmts="$(printf '%s' "$line" | jq -r '.sqlx_stmts')"
     wall="$(printf '%s' "$line" | jq -r '.wall_ms')"
 
+    # `[[ null -gt 5 ]]` treats "null" as an unset name worth 0 and reports the
+    # scenario as within budget, so a malformed measurement reads as a pass.
+    for field in stmts wall; do
+      if [[ ! "${!field}" =~ ^-?[0-9]+$ ]]; then
+        echo "ERROR: scenario '$scenario' reported a non-numeric $field='${!field}' — perf-bench output is malformed." >&2
+        exit 1
+      fi
+    done
+
     # Look up baseline entry for this scenario.
     baseline_entry="$(jq -c --arg s "$scenario" '.[] | select(.scenario == $s)' "$BASELINE_FILE")"
     if [[ -z "$baseline_entry" ]]; then

--- a/scripts/check-pv-selector-ratchet.sh
+++ b/scripts/check-pv-selector-ratchet.sh
@@ -22,23 +22,55 @@
 #   bash scripts/check-pv-selector-ratchet.sh          # exits 0 on pass, 1 on fail
 
 set -euo pipefail
-cd "$(git rev-parse --show-toplevel)"
+
+# `cd "$(git rev-parse --show-toplevel)"` degrades to a no-op `cd ""` at exit 0
+# when git fails, which scans the caller's cwd and reports a clean tree.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# grep exits 1 for "no matches" and >1 for "the scan itself failed"; collapsing
+# the two reports a renamed or unreadable scan root as zero violations.
+scan() {
+  local root="$1" raw rc
+  if [ ! -d "$root" ]; then
+    echo "ERROR: scan root '$root' does not exist under $ROOT." >&2
+    exit 2
+  fi
+  set +e
+  raw=$(grep -rn '\.pv-[a-z]' "$root")
+  rc=$?
+  set -e
+  if [ "$rc" -gt 1 ]; then
+    echo "ERROR: grep exited $rc scanning '$root' — the scan failed, so this run proves nothing." >&2
+    exit 2
+  fi
+  printf '%s' "$raw"
+}
 
 # Playwright TS: locator('.pv-*'), locator(".pv-*"), const FOO = '.pv-*', etc.
 # Exclude toHaveClass/Attribute, /pv-/ regex, pv-mono (typography-only class),
 # and comment lines.
-ts_hits=$(grep -rn '\.pv-[a-z]' tests/e2e/ \
-  | grep -v 'toHaveClass\|toHaveAttribute\|/pv-' \
-  | grep -v '\.pv-mono' \
-  | grep -v ':[[:space:]]*//' \
-  | grep -v ':[[:space:]]*\*' \
-  || true)
+# `scan` runs in a subshell, so its `exit 2` must be re-raised here explicitly.
+ts_raw=$(scan tests/e2e/) || exit $?
+ts_hits=""
+if [ -n "$ts_raw" ]; then
+  ts_hits=$(printf '%s\n' "$ts_raw" \
+    | grep -v 'toHaveClass\|toHaveAttribute\|/pv-' \
+    | grep -v '\.pv-mono' \
+    | grep -v ':[[:space:]]*//' \
+    | grep -v ':[[:space:]]*\*' \
+    || true)
+fi
 
 # Rust: querySelector(".pv-*"), By::Css(".pv-*"), etc. — both quote styles.
 # Exclude Rust comment lines (//!, ///, //).
-rs_hits=$(grep -rn '\.pv-[a-z]' crates/e2e-tests/tests/ \
-  | grep -v ':[[:space:]]*//[/!]\?' \
-  || true)
+rs_raw=$(scan crates/e2e-tests/tests/) || exit $?
+rs_hits=""
+if [ -n "$rs_raw" ]; then
+  rs_hits=$(printf '%s\n' "$rs_raw" \
+    | grep -v ':[[:space:]]*//[/!]\?' \
+    || true)
+fi
 
 all_hits="${ts_hits}
 ${rs_hits}"


### PR DESCRIPTION
## Summary

- Six guard scripts, and thirteen workflow `run:` blocks, degraded to SUCCESS when their own machinery failed. A broken scan reported zero violations and CI went green, so every fix those guards were meant to verify was unverified.

## Which guards could not fail, and what now makes them fail

| Guard | Could not fail when | Now |
| --- | --- | --- |
| `check-lifecycle-strings.sh`, `check-pv-selector-ratchet.sh` | `git rev-parse --show-toplevel` failed: `cd ""` is a no-op at exit 0, so the ratchet scanned the caller's cwd | root derived from `BASH_SOURCE`; each scan root asserted present, exit 2 otherwise |
| the same two | the scan's `\|\| true` collapsed grep rc 1 (no matches) with rc >1 (scan failed) | the producing grep runs alone with its rc captured; rc >1 exits 2 |
| `branch-protection-main.sh` | python3 was missing, the config was unreadable, or the config listed no `required_status_checks.contexts`: a `while read` loop over an empty producer returned its untouched `bad=0`, and `apply` went on to PUT branch protection | contexts read once, an empty list is fatal; `ALLOW_MISSING_NAMES` waives a known-missing job name, never a check that could not run |
| `check-perf-baseline.sh` | a measurement arrived as JSON `null`: `[[ null -gt 5 ]]` reads "null" as an unset name worth 0 and reports the scenario as within budget | `check()` asserts both measurements are numeric, matching the guard `generate()` already had |
| `check-i18n-catalog.mjs` | the catalogue nested its values, so the parser yielded zero entries and `--generate` drained the baseline | zero parsed entries throws |
| `check-mock-baseline.mjs` | the `__TAURI_INVOKE` wrapper was renamed, so every command read as mocked and `--generate` drained the baseline | an empty command set throws, matching `mockedCommands` |
| 13 workflow `run:` blocks | a mid-block failure left a `$GITHUB_OUTPUT` key unset or partial | `set -euo pipefail` |

Every variable referenced in those thirteen blocks is env-set, and every fallible command in them already carries an explicit `|| echo ""`, so errexit changes no ordinary-case outcome. `release-gate.yml` is untouched.

## Verification

Each guard ran twice: once normally, once with its own machinery broken.

| Script | Normal | Broken |
| --- | --- | --- |
| `check-lifecycle-strings.sh` | 0 | 2 (scan root absent) |
| `check-pv-selector-ratchet.sh` | 0 | 2 (scan root absent) |
| `branch-protection-main.sh verify` | 0 | 2 (python3 absent), 2 (python3 exits 1), 2 (zero contexts) |
| `check-perf-baseline.sh --check` | 0 | 1 (`sqlx_stmts: null`) |
| `check-i18n-catalog.mjs` | 0 | 1 (nested catalogue), 1 with `--generate` |
| `check-mock-baseline.mjs` | 0 | 1 (wrapper renamed), 1 with `--generate` |

`check-perf-baseline.sh` also ran against a synthetic within-budget line (0) and an over-budget line (1), which confirms the new assertion did not displace the gate itself.

Repo-wide: `shellcheck` clean over the four changed scripts, `actionlint` clean over the four changed workflows, `pnpm lint` 0 (it chains both changed `.mjs` guards), real perf gate 0.

One finding claim did not hold up: `astro-plan-3v3r.16.18` reports that `check-pv-selector-ratchet.sh` "runs nowhere". It is absent from `just check`, and wired in CI at `.github/workflows/ci.yml:493`.

## Spec Context

Fix group G-GUARD-FAILOPEN, eleven findings.

Tracks-Bead: astro-plan-b80cl
Tracks-Bead: astro-plan-3v3r.16.10
Tracks-Bead: astro-plan-3v3r.16.11
Tracks-Bead: astro-plan-3v3r.16.12
Tracks-Bead: astro-plan-3v3r.16.13
Tracks-Bead: astro-plan-3v3r.16.14
Tracks-Bead: astro-plan-3v3r.16.18
Tracks-Bead: astro-plan-3v3r.16.19
Tracks-Bead: astro-plan-3v3r.16.20
Tracks-Bead: astro-plan-3v3r.16.21
Tracks-Bead: astro-plan-3v3r.17.9
Tracks-Bead: astro-plan-3v3r.17.16
Merge-Bead: astro-plan-jiogv
