### PR TITLE
fix(security): gate the MCP bridge on dev-tools and bind it to loopback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -687,6 +687,14 @@ jobs:
         if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
         run: just check-generated
 
+      # The release gate runs this too, but only on release-please branches and
+      # tags, so a change that ships the dev surface would reach main unobserved.
+      - name: Dev surface absent from a default-feature build
+        # Rust-lane only: the check resolves the cargo feature graph, so it needs
+        # the pinned toolchain that a scripts-only change does not install.
+        if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
+        run: bash scripts/check-dev-surface-absent.sh
+
       # The declaration generator also reads `packages/contracts/schemas/` and
       # `specs/*/contracts/`, neither of which sets the `rust` filter. This leg
       # covers them without the Rust toolchain, system webkit, or cargo cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,8 +303,12 @@ jobs:
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
             libayatana-appindicator3-dev
 
+      # `scripts` arms this too: the dev-surface guard below resolves the cargo
+      # feature graph, so a scripts-only PR that edits the guard still needs the
+      # pinned toolchain to run it against itself.
       - uses: dtolnay/rust-toolchain@1.98.0
-        if: needs.changes.outputs.rust == 'true'
+        if: >-
+          needs.changes.outputs.rust == 'true' || needs.changes.outputs.scripts == 'true'
         with:
           components: rustfmt, clippy
 
@@ -690,9 +694,11 @@ jobs:
       # The release gate runs this too, but only on release-please branches and
       # tags, so a change that ships the dev surface would reach main unobserved.
       - name: Dev surface absent from a default-feature build
-        # Rust-lane only: the check resolves the cargo feature graph, so it needs
-        # the pinned toolchain that a scripts-only change does not install.
-        if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
+        # `scripts` is armed as well as `rust`: a scripts-only edit that weakens
+        # the guard must run the guard.
+        if: >-
+          runner.os == 'Linux' && (needs.changes.outputs.rust == 'true' ||
+          needs.changes.outputs.scripts == 'true')
         run: bash scripts/check-dev-surface-absent.sh
 
       # The declaration generator also reads `packages/contracts/schemas/` and

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -109,30 +109,24 @@ jobs:
           fi
 
       # --- Check 3: dev-tools OFF invariant (HARD) ---
-      # The dev-tools feature MUST NOT be a default feature, and the release
-      # build of the app crate MUST NOT resolve it (Constitution Principle V).
-      - name: Assert dev-tools feature is not enabled by default
+      # The gated features MUST NOT be defaults, the default feature graph MUST
+      # NOT resolve them or link their plugin crates, and no shipped capability
+      # may grant a gated plugin's permissions (Constitution Principle V).
+      # `scripts/check-dev-surface-absent.sh` also runs on every Rust PR in
+      # ci.yml, which this workflow's `if:` gate excludes.
+      - name: Assert the dev surface is absent from a default-feature build
         id: devtools_off
         continue-on-error: true
         run: |
           set -euo pipefail
-          STATUS=pass
-          DETAIL="dev-tools absent from default features"
-          # Static: no `default = [...]` line may enable dev-tools.
-          if grep -RInE '^\s*default\s*=\s*\[' \
-               apps/desktop/src-tauri/Cargo.toml crates/app/core/Cargo.toml 2>/dev/null \
-               | grep -q 'dev-tools'; then
-            STATUS=fail
-            DETAIL="a default feature enables dev-tools"
+          if OUT=$(bash scripts/check-dev-surface-absent.sh 2>&1); then
+            echo "status=pass" >> "$GITHUB_OUTPUT"
+            echo "detail=${OUT##*$'\n'}" >> "$GITHUB_OUTPUT"
+          else
+            echo "$OUT"
+            echo "status=fail" >> "$GITHUB_OUTPUT"
+            echo "detail=$(grep -m1 '^FAIL: ' <<<"$OUT")" >> "$GITHUB_OUTPUT"
           fi
-          # Resolved: release feature graph of the app crate must not pull dev-tools.
-          if cargo tree -p desktop_shell --release -e features -f '{p} {f}' 2>/dev/null \
-               | grep -qi 'dev-tools'; then
-            STATUS=fail
-            DETAIL="release feature graph resolves dev-tools"
-          fi
-          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
-          echo "detail=$DETAIL" >> "$GITHUB_OUTPUT"
 
       # --- Check 3b: dev surface absent from the frontend bundle (HARD) ---
       # Check 3 covers the Rust feature graph only. On the frontend the gate is a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,9 @@ tauri = { version = "2.11", default-features = false, features = ["wry"] }
 tauri-build = { version = "2.6", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
-# Tauri MCP bridge plugin (@hypothesi). Dev/debug-only surface, registered behind
-# `#[cfg(debug_assertions)]`; runs a WebSocket server on 0.0.0.0:9223 for the
+# Tauri MCP bridge plugin (@hypothesi). Dev-only surface, an optional dependency
+# of desktop_shell behind its `dev-tools` feature; runs a WebSocket server on
+# 127.0.0.1:9223 (PV_MCP_BRIDGE_BIND overrides the address) for the
 # @hypothesi/tauri-mcp-server MCP server. Requires the dev-only tauri.dev.conf.json
 # overlay (withGlobalTauri).
 tauri-plugin-mcp-bridge = "0.11"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -51,7 +51,10 @@ sqlx = { workspace = true }
 tauri = { workspace = true }
 tauri-plugin-dialog = { workspace = true }
 tauri-plugin-opener = { workspace = true }
-tauri-plugin-mcp-bridge = { workspace = true }
+# Agent-driven UI automation surface — ONLY compiled when `dev-tools` is
+# enabled. Release binaries MUST omit that feature so the WebSocket control
+# server is absent from the binary rather than merely unstarted.
+tauri-plugin-mcp-bridge = { workspace = true, optional = true }
 # Spec 051 shell integration plugins.
 tauri-plugin-single-instance = { workspace = true }
 tauri-plugin-window-state = { workspace = true }
@@ -84,7 +87,11 @@ tempfile = { workspace = true }
 [features]
 # Developer-mode surface (spec 021). Release binaries MUST NOT enable this.
 # Propagates to app_core so the dev_contracts use-case module is compiled in.
-dev-tools = ["app_core/dev-tools"]
+# Also embeds tauri-plugin-mcp-bridge and, via build.rs, widens the capability
+# glob to `capabilities/dev/`, which is where the plugin's permission grant
+# lives. With the feature off the plugin's ACL manifest does not exist, so an
+# ungated grant would fail the build.
+dev-tools = ["app_core/dev-tools", "dep:tauri-plugin-mcp-bridge"]
 # E2E automation gate (spec 037). Embeds tauri-plugin-webdriver so the app
 # binary accepts W3C WebDriver sessions from the tauri-webdriver CLI proxy.
 # The embedded server listens on 127.0.0.1:4445; the tauri-webdriver CLI

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -2,9 +2,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 fn main() {
-    // `mut` is only exercised by the `#[cfg(windows)]` block below.
+    // `mut` is only exercised by the `#[cfg(windows)]` block and the
+    // capability-glob branch below.
     #[allow(unused_mut)]
     let mut attributes = tauri_build::Attributes::new();
+
+    // A capability file cannot be `cfg`-gated, so the dev-only grants live in
+    // `capabilities/dev/` and this narrows the default `./capabilities/**/*`
+    // glob to the top level when `dev-tools` is off. Those grants name
+    // permissions from plugins the same feature gates, and an unknown
+    // permission is a build error, so the two gates cannot drift apart.
+    if std::env::var_os("CARGO_FEATURE_DEV_TOOLS").is_none() {
+        println!("cargo:rerun-if-changed=capabilities");
+        attributes = attributes.capabilities_path_pattern("./capabilities/*.json");
+    }
 
     // Windows-only workaround for a known upstream tauri-build/embed-resource
     // limitation: `tauri_build::build()`'s default app-manifest embedding uses

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -14,7 +14,6 @@
     "dialog:allow-open",
     "opener:allow-open-path",
     "opener:allow-reveal-item-in-dir",
-    "mcp-bridge:default",
     "updater:default",
     "process:default",
     "window-state:default"

--- a/apps/desktop/src-tauri/capabilities/dev/mcp-bridge.json
+++ b/apps/desktop/src-tauri/capabilities/dev/mcp-bridge.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../gen/schemas/desktop-schema.json",
+  "identifier": "dev-mcp-bridge",
+  "description": "Grants the agent-driven UI automation bridge (tauri-plugin-mcp-bridge) to the app windows. build.rs parses this directory only when the `dev-tools` feature is enabled; the plugin's ACL manifest does not exist otherwise.",
+  "windows": ["main", "alm-win-*", "splash"],
+  "permissions": ["mcp-bridge:default"]
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -225,16 +225,21 @@ pub fn build_app() -> tauri::App {
         // plugin's own (skipped) fern dispatch.
         .plugin(tauri_plugin_log::Builder::new().skip_logger().build());
 
-    // Tauri MCP bridge plugin (@hypothesi tauri-plugin-mcp-bridge) — dev/debug
-    // builds only. Runs a WebSocket server on 0.0.0.0:9223 that the
+    // Tauri MCP bridge plugin (@hypothesi tauri-plugin-mcp-bridge) — `dev-tools`
+    // builds only. Runs a WebSocket server from port 9223 that the
     // @hypothesi/tauri-mcp-server MCP server connects to, letting an agent drive
     // the running app for automated UI testing. Requires `withGlobalTauri`, which
     // is enabled only via the dev-only `tauri.dev.conf.json` overlay (never in the
-    // shipped config). `debug_assertions` is off in release builds, so this
-    // surface is absent from shipped binaries.
-    #[cfg(debug_assertions)]
+    // shipped config). The server is unauthenticated and `execute_js` reaches
+    // every command handler, so it binds loopback only: the plugin's default
+    // `Config` binds 0.0.0.0, which would put that surface on the LAN. The
+    // feature also gates the dependency itself, so release binaries do not link
+    // the plugin (`Cargo.toml` `dev-tools`, `capabilities/dev/mcp-bridge.json`).
+    #[cfg(feature = "dev-tools")]
     {
-        tb = tb.plugin(tauri_plugin_mcp_bridge::init());
+        tb = tb.plugin(tauri_plugin_mcp_bridge::init_with_config(
+            tauri_plugin_mcp_bridge::Config::localhost_only(),
+        ));
     }
 
     // E2E gate: embed the WebDriver server only when built with --features e2e.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -231,14 +231,24 @@ pub fn build_app() -> tauri::App {
     // the running app for automated UI testing. Requires `withGlobalTauri`, which
     // is enabled only via the dev-only `tauri.dev.conf.json` overlay (never in the
     // shipped config). The server is unauthenticated and `execute_js` reaches
-    // every command handler, so it binds loopback only: the plugin's default
-    // `Config` binds 0.0.0.0, which would put that surface on the LAN. The
-    // feature also gates the dependency itself, so release binaries do not link
-    // the plugin (`Cargo.toml` `dev-tools`, `capabilities/dev/mcp-bridge.json`).
+    // every command handler, so it binds 127.0.0.1 rather than the plugin's own
+    // 0.0.0.0 default. `PV_MCP_BRIDGE_BIND` opts one run into another address for
+    // cross-host validation (an agent in WSL or on another machine driving a
+    // Windows host); whatever reaches that address controls the app. The feature
+    // also gates the dependency, so release binaries do not link the plugin
+    // (`Cargo.toml` `dev-tools`, `capabilities/dev/mcp-bridge.json`).
     #[cfg(feature = "dev-tools")]
     {
+        let bind = std::env::var("PV_MCP_BRIDGE_BIND").unwrap_or_else(|_| "127.0.0.1".to_string());
+        if bind != "127.0.0.1" {
+            tracing::warn!(
+                bind = %bind,
+                "MCP bridge bound off-loopback: unauthenticated control of this app is reachable \
+                 from that address"
+            );
+        }
         tb = tb.plugin(tauri_plugin_mcp_bridge::init_with_config(
-            tauri_plugin_mcp_bridge::Config::localhost_only(),
+            tauri_plugin_mcp_bridge::Config::new(&bind),
         ));
     }
 

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -54,6 +54,9 @@ export default defineConfig(({ mode, command }) => {
     ],
     clearScreen: false,
     server: {
+      // Loopback only: the dev server is unauthenticated. Declared here so it
+      // holds for every invocation, not just the `--host`-carrying scripts.
+      host: "127.0.0.1",
       port: 5173,
       strictPort: true,
     },

--- a/docs/development/windows-journeys/journey-01-first-run-setup.md
+++ b/docs/development/windows-journeys/journey-01-first-run-setup.md
@@ -56,8 +56,8 @@
 
 ### Tauri MCP bridge (if driving the app programmatically instead of pure vision)
 - Launch with the dev overlay so the bridge is live:
-  `cargo tauri dev --config src-tauri\tauri.dev.conf.json` (bridge is
-  `#[cfg(debug_assertions)]`, WebSocket on `0.0.0.0:9223`).
+  `cargo tauri dev --config src-tauri\tauri.dev.conf.json --features dev-tools` (bridge needs the
+  `dev-tools` feature; WebSocket on `127.0.0.1:9223`).
 - Connect via `driver_session host=localhost port=9223` — WSL runs in
   mirrored networking mode (`networkingMode=mirrored` in `.wslconfig`), so
   `localhost` reaches Windows services directly; the old NAT gateway-IP

--- a/docs/development/windows-journeys/journey-02-inbox-ingest-move.md
+++ b/docs/development/windows-journeys/journey-02-inbox-ingest-move.md
@@ -48,8 +48,8 @@
 - Blank window recovery: restart the dev server; if still blank,
   `pnpm install` with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional, for programmatic driving): launch with
-  `cargo tauri dev --config src-tauri\tauri.dev.conf.json` (bridge on
-  `0.0.0.0:9223`), connect with `driver_session host=localhost port=9223`,
+  `cargo tauri dev --config src-tauri\tauri.dev.conf.json --features dev-tools` (bridge on
+  `127.0.0.1:9223`), connect with `driver_session host=localhost port=9223`,
   invoke commands via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`. Native folder
   pickers still need `VITE_E2E=1` stand-ins (see Journey 1's doc for the

--- a/docs/development/windows-journeys/journey-03-inbox-catalogue-in-place.md
+++ b/docs/development/windows-journeys/journey-03-inbox-catalogue-in-place.md
@@ -38,7 +38,7 @@
 - Blank window recovery: restart dev server; if still blank, `pnpm install`
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
-  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  src-tauri\tauri.dev.conf.json --features dev-tools` (bridge WS on `127.0.0.1:9223`), connect with
   `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 

--- a/docs/development/windows-journeys/journey-04-sessions-review.md
+++ b/docs/development/windows-journeys/journey-04-sessions-review.md
@@ -44,7 +44,7 @@
 - Blank window recovery: restart dev server; if still blank, `pnpm install`
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
-  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  src-tauri\tauri.dev.conf.json --features dev-tools` (bridge WS on `127.0.0.1:9223`), connect with
   `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 

--- a/docs/development/windows-journeys/journey-05-project-lifecycle.md
+++ b/docs/development/windows-journeys/journey-05-project-lifecycle.md
@@ -47,7 +47,7 @@
 - Blank window recovery: restart dev server; if still blank, `pnpm install`
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
-  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  src-tauri\tauri.dev.conf.json --features dev-tools` (bridge WS on `127.0.0.1:9223`), connect with
   `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 

--- a/docs/development/windows-journeys/journey-06-cleanup-scan-apply.md
+++ b/docs/development/windows-journeys/journey-06-cleanup-scan-apply.md
@@ -50,7 +50,7 @@
 - Blank window recovery: restart dev server; if still blank, `pnpm install`
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
-  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  src-tauri\tauri.dev.conf.json --features dev-tools` (bridge WS on `127.0.0.1:9223`), connect with
   `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 

--- a/docs/development/windows-journeys/journey-07-archive-delete.md
+++ b/docs/development/windows-journeys/journey-07-archive-delete.md
@@ -48,7 +48,7 @@
 - Blank window recovery: restart dev server; if still blank, `pnpm install`
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
-  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  src-tauri\tauri.dev.conf.json --features dev-tools` (bridge WS on `127.0.0.1:9223`), connect with
   `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`. Note: as of
   2026-07-05 no shipped UI button generates an archive plan yet — you may

--- a/docs/development/windows-journeys/journey-08-calibration-masters-matching.md
+++ b/docs/development/windows-journeys/journey-08-calibration-masters-matching.md
@@ -47,7 +47,7 @@
 - Blank window recovery: restart dev server; if still blank, `pnpm install`
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
-  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  src-tauri\tauri.dev.conf.json --features dev-tools` (bridge WS on `127.0.0.1:9223`), connect with
   `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 

--- a/docs/development/windows-journeys/journey-09-targets-planning.md
+++ b/docs/development/windows-journeys/journey-09-targets-planning.md
@@ -59,7 +59,7 @@
 - Blank window recovery: restart dev server; if still blank, `pnpm install`
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
-  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  src-tauri\tauri.dev.conf.json --features dev-tools` (bridge WS on `127.0.0.1:9223`), connect with
   `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`. To fake an
   ObserverSite via the bridge instead of the UI, call `settings_update` with

--- a/docs/development/windows-journeys/journey-10-settings-appearance-i18n.md
+++ b/docs/development/windows-journeys/journey-10-settings-appearance-i18n.md
@@ -44,7 +44,7 @@
 - Blank window recovery: restart dev server; if still blank, `pnpm install`
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
-  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  src-tauri\tauri.dev.conf.json --features dev-tools` (bridge WS on `127.0.0.1:9223`), connect with
   `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 

--- a/docs/development/windows-journeys/journey-11-framing-clustering-attribution.md
+++ b/docs/development/windows-journeys/journey-11-framing-clustering-attribution.md
@@ -90,7 +90,7 @@
 - Blank window recovery: restart the dev server; if still blank, `pnpm
   install` with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (required for Tests 2-4): `cargo tauri dev --config
-  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  src-tauri\tauri.dev.conf.json --features dev-tools` (bridge WS on `127.0.0.1:9223`), connect with
   `driver_session host=localhost port=9223`, invoke via `webview_execute_js`
   → `window.__TAURI__.core.invoke('<snake_command>', {args})`. Command
   names below are given in their dotted (`projects.framing.list`) and

--- a/docs/development/windows-native-rust-dev.md
+++ b/docs/development/windows-native-rust-dev.md
@@ -185,8 +185,12 @@ and launch with the dev overlay that enables the MCP bridge:
 cd C:\dev\astro-plan\apps\desktop
 $env:VITE_USE_MOCKS = 'false'                                        # real backend
 $env:PV_DB_URL     = 'sqlite://C:\dev\astro-plan\wizard-test.db?mode=rwc'
-pnpm tauri dev --config src-tauri\tauri.dev.conf.json               # overlay = bridge on
+pnpm tauri dev --config src-tauri\tauri.dev.conf.json --features dev-tools
 ```
+
+The overlay enables `withGlobalTauri`; `--features dev-tools` compiles the MCP
+bridge in. A build without the feature links no bridge, so nothing listens on
+9223.
 
 `scripts\win-native-dev.ps1` launches the same overlay with the real backend;
 add the `PV_DB_URL` line above when you need a disposable DB. Any `run-dev*.bat`
@@ -217,11 +221,14 @@ Get-ChildItem <changed>.rs | ForEach-Object { $_.LastWriteTime = Get-Date }
 Then relaunch (`tauri dev` recompiles). A frontend-only change needs only a hard
 refresh (Ctrl+R). Confirm the binary mtime is newer than the source.
 
-**Connect the MCP bridge.** The bridge is `#[cfg(debug_assertions)]`, WebSocket
-on `0.0.0.0:9223`. This host runs WSL in mirrored networking, so `localhost`
-reaches Windows directly — connect with `driver_session host=localhost
-port=9223`. The old NAT gateway-IP lookup (`ip route show default`) is
-**obsolete**. Invoke a command directly with `webview_execute_js` →
+**Connect the MCP bridge.** The bridge needs `--features dev-tools` and serves a
+WebSocket on `127.0.0.1:9223`. This host runs WSL in mirrored networking, so
+`localhost` reaches Windows loopback directly — connect with `driver_session
+host=localhost port=9223`. The old NAT gateway-IP lookup (`ip route show
+default`) is **obsolete** here; under NAT networking, set
+`PV_MCP_BRIDGE_BIND=0.0.0.0` before launching so the gateway address reaches the
+bridge. Anything that reaches that address controls the app without
+authentication. Invoke a command directly with `webview_execute_js` →
 `window.__TAURI__.core.invoke('<snake_command>', {args})` (`ipc_execute_command`
 rejects many real commands but is fine for scripted backend probes).
 

--- a/docs/development/windows-validation-run-2026-07-09.md
+++ b/docs/development/windows-validation-run-2026-07-09.md
@@ -23,7 +23,9 @@ step. **Interactive protocol:** every test stops for human review before the nex
   stand-ins for the native folder pickers).
 - DB (first-run source of truth): `sqlite://C:\dev\astro-plan\wizard-test.db`.
 - Bridge: WebSocket `0.0.0.0:9223`, connect `driver_session host=localhost
-  port=9223`.
+  port=9223`. Repeating this run needs `--features dev-tools` at launch, and
+  `PV_MCP_BRIDGE_BIND=0.0.0.0` to reproduce that bind; the bridge binds
+  `127.0.0.1` by default and is absent without the feature.
 - Run branch / worktree: `ws3-mcp-validation-run` @
   `/home/sjors/tmp/worktrees/astro-plan/campaign-ws0` (tracks origin/main).
 

--- a/docs/journeys/README.md
+++ b/docs/journeys/README.md
@@ -39,7 +39,9 @@ instead of being repeated per journey:
 PlateVault ships as a Tauri v2 desktop app; the only real-app validation path
 today is the Windows build driven through the Tauri MCP bridge from WSL
 (`driver_session host=localhost port=9223`, mirrored WSL networking reaches
-Windows services via `localhost`). `exclusive: true` because only one
+Windows services via `localhost`). The bridge exists only in a build launched
+with `--features dev-tools`, and it binds `127.0.0.1` unless the launch sets
+`PV_MCP_BRIDGE_BIND`. `exclusive: true` because only one
 validator can hold the Windows checkout/app process at a time. The
 Vite/mockIPC runtime fakes backend responses and MUST NOT be used to
 validate journeys (see `docs/development/testing.md`).

--- a/e2e-agentic-test/003-first-run-source-setup/restart-first-run/scenario.md
+++ b/e2e-agentic-test/003-first-run-source-setup/restart-first-run/scenario.md
@@ -252,8 +252,9 @@ FAIL if:
   cleared, not the DB — delete `wizard-test.db*` and relaunch (see
   Preconditions step 2).
 - **Tauri MCP bridge** (needed only for Test 5): launch with the dev overlay
-  enabled (`cargo tauri dev --config src-tauri\tauri.dev.conf.json`, WS on
-  `0.0.0.0:9223`), connect from WSL via
+  enabled (`cargo tauri dev --config src-tauri\tauri.dev.conf.json
+  --features dev-tools`, WS on `127.0.0.1:9223`, so a gateway connection needs
+  `PV_MCP_BRIDGE_BIND=0.0.0.0` at launch), connect from WSL via
   `driver_session host=<gateway> port=9223` where
   `gateway = ip route show default | awk '{print $3}'`; then use
   `webview_execute_js` to run the JS snippets in Test 5. If you are a

--- a/e2e-agentic-test/019-bottom-log-viewer/event-source-class/scenario.md
+++ b/e2e-agentic-test/019-bottom-log-viewer/event-source-class/scenario.md
@@ -179,8 +179,10 @@ FAIL if:
   first (a failed save wouldn't be expected to log anything).
 - **DOM inspection without a bridge**: if right-click → Inspect is
   unavailable in the packaged dev window, you likely need the Tauri MCP
-  bridge. Launch with `cargo tauri dev --config src-tauri\tauri.dev.conf.json`
-  (WS bridge on `0.0.0.0:9223`), connect from WSL via
+  bridge. Launch with `cargo tauri dev --config src-tauri\tauri.dev.conf.json
+  --features dev-tools` and `PV_MCP_BRIDGE_BIND=0.0.0.0` (the feature compiles the
+  bridge in; the variable widens its `127.0.0.1:9223` bind so the gateway address
+  reaches it), connect from WSL via
   `driver_session host=<gateway> port=9223` (gateway =
   `ip route show default | awk '{print $3}'`), then use
   `webview_dom_snapshot` or `webview_find_element` targeting

--- a/e2e-agentic-test/035-targets-catalog/list-search-aliases-sort/scenario.md
+++ b/e2e-agentic-test/035-targets-catalog/list-search-aliases-sort/scenario.md
@@ -52,6 +52,9 @@
 3. The bundled catalog seed populates targets on first use — no fixture
    files are needed for this scenario.
 4. Connect the Tauri MCP bridge (`driver_session host=<WSL gateway> port=9223`).
+   The gateway address reaches the bridge only when `run-dev.bat` sets
+   `PV_MCP_BRIDGE_BIND=0.0.0.0` and passes `--features dev-tools`
+   (see AGENT-RUNNER.md).
 
 ## Stage 1 — Agent validation via Tauri MCP
 

--- a/e2e-agentic-test/041-inbox-plan-surface/mixed-folder-single-type-subitems/scenario.md
+++ b/e2e-agentic-test/041-inbox-plan-surface/mixed-folder-single-type-subitems/scenario.md
@@ -34,7 +34,8 @@ already (spec 041 iteration 2, PR #315 lineage).
    with 2×light/Ha/300s + 2×light/Ha/120s + 2×dark/300s. Also create the
    empty **RECIPE-DEST** folder (`test-data\library-lights`).
 4. Launch the dev app with the bridge and E2E hooks
-   (`VITE_E2E=1`, dev overlay config, WS bridge on `0.0.0.0:9223`), connect
+   (`VITE_E2E=1`, dev overlay config, `--features dev-tools`, WS bridge on
+   `127.0.0.1:9223` unless `PV_MCP_BRIDGE_BIND` widens it), connect
    `driver_session` from WSL, and set the window to **1100×720** via
    `manage_window`.
 5. Real backend only: confirm `.env` has `VITE_USE_MOCKS=false`; a scenario

--- a/e2e-agentic-test/043-ui-redesign-platevault/shell-left-nav/scenario.md
+++ b/e2e-agentic-test/043-ui-redesign-platevault/shell-left-nav/scenario.md
@@ -47,7 +47,8 @@ Calibration / Targets / Projects can show count badges
    Frontend-only surface — no forced Rust recompile needed.
 2. App launched per AGENT-RUNNER.md with the dev overlay config so the bridge
    is up: `cargo tauri dev --config src-tauri\tauri.dev.conf.json`
-   (bridge WS on `0.0.0.0:9223`; connect from WSL via the NAT gateway IP).
+   (`--features dev-tools`; bridge WS on `127.0.0.1:9223`, so a NAT-gateway
+   connection from WSL needs `PV_MCP_BRIDGE_BIND=0.0.0.0` at launch).
 3. First-run setup completed with at least ONE registered source root (any
    empty folder as Light frames), so the app lands on the shell, not `/setup`.
 4. `.env` has `VITE_USE_MOCKS=false`. Verify: `mcp__tauri__ipc_get_backend_state`

--- a/e2e-agentic-test/AGENT-RUNNER.md
+++ b/e2e-agentic-test/AGENT-RUNNER.md
@@ -36,7 +36,8 @@ Windows repo root holds, each on its own line (no `&&`):
 ```
 cd /d C:\dev\astro-plan
 set PV_DB_URL=sqlite://C:\dev\astro-plan\wizard-test.db?mode=rwc
-cargo tauri dev --config src-tauri\tauri.dev.conf.json
+set PV_MCP_BRIDGE_BIND=0.0.0.0
+cargo tauri dev --config src-tauri\tauri.dev.conf.json --features dev-tools
 ```
 
 Launch command (from WSL):
@@ -45,10 +46,15 @@ Launch command (from WSL):
 powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"
 ```
 
-- The `--config src-tauri\tauri.dev.conf.json` overlay enables
-  `withGlobalTauri` and the MCP bridge WebSocket on `0.0.0.0:9223`
-  (`#[cfg(debug_assertions)]` — dev builds only). Scenarios in this tree
-  REQUIRE the bridge, so always launch with the overlay.
+- The `--config src-tauri\tauri.dev.conf.json` overlay enables `withGlobalTauri`,
+  and `--features dev-tools` compiles the MCP bridge WebSocket server in. Without
+  the feature the plugin is not linked and nothing listens on 9223.
+- The bridge binds `127.0.0.1:9223`. `PV_MCP_BRIDGE_BIND=0.0.0.0` binds all
+  interfaces, which is what a WSL agent connecting through the NAT gateway needs.
+  Anything that reaches that address drives the app without authentication, so set
+  it only for a validation run on a trusted network.
+- Scenarios in this tree REQUIRE the bridge, so always launch with the overlay,
+  the feature, and the bind variable.
 - App process = `desktop_shell.exe`; Vite dev server on `localhost:5173`.
 - `.env` in the Windows checkout must have `VITE_USE_MOCKS=false` (real
   backend). **Verify this before running any scenario** — a scenario executed
@@ -132,8 +138,11 @@ gateway=$(ip route show default | awk '{print $3}')   # e.g. 172.23.112.1
 ```
 
 Connect: `mcp__tauri__driver_session` with `host=<gateway>` `port=9223`.
-The Windows firewall already allows 9223. If the session fails, confirm the
-app was launched with the `tauri.dev.conf.json` overlay.
+The Windows firewall already allows 9223. A gateway connection reaches the bridge
+only when the app was launched with `PV_MCP_BRIDGE_BIND=0.0.0.0`; the default
+`127.0.0.1` bind accepts connections from the Windows host alone. If the session
+fails, confirm the app was launched with the `tauri.dev.conf.json` overlay,
+`--features dev-tools`, and that bind variable.
 
 ## Driving and asserting
 

--- a/justfile
+++ b/justfile
@@ -189,10 +189,10 @@ dev:
     pnpm --filter @astro-plan/desktop dev
 
 # Start the Tauri desktop app in development mode (Rust + frontend).
-# The dev overlay enables `withGlobalTauri`, required by the (debug-only) MCP
-# bridge plugin; it is never applied to release builds.
+# The dev overlay enables `withGlobalTauri`, and the `dev-tools` feature compiles
+# in the MCP bridge plugin that requires it. Release builds carry neither.
 tauri-dev:
-    cd apps/desktop && pnpm tauri dev --config src-tauri/tauri.dev.conf.json
+    cd apps/desktop && pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-tools
 
 # Clean build artifacts
 clean:

--- a/scripts/check-dev-surface-absent.sh
+++ b/scripts/check-dev-surface-absent.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Copyright (C) 2024-2026 Sjors Robroek
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# Asserts the developer-mode and automation surfaces are absent from a
+# default-feature build of the desktop app (Constitution Principle V).
+#
+# Checks, all of which exit non-zero on violation:
+#   1. no `default = [...]` feature list enables `dev-tools` or `e2e`
+#   2. the resolved default feature graph of `desktop_shell` pulls neither
+#      feature and neither gated plugin crate
+#   3. no shipped capability file grants a permission from a gated plugin
+#
+# `cargo tree` failure is a violation, not a pass: a gate that cannot observe
+# the feature graph reports nothing rather than reporting absence.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+FAILED=0
+fail() {
+  echo "FAIL: $*" >&2
+  FAILED=1
+}
+
+MANIFESTS=(apps/desktop/src-tauri/Cargo.toml crates/app/core/Cargo.toml)
+GATED_FEATURES='dev-tools|e2e'
+# Plugin crates whose presence in the graph means the surface is linked in.
+GATED_CRATES='tauri-plugin-mcp-bridge|tauri-plugin-webdriver'
+# Permission prefixes owned by those plugins.
+GATED_PERMISSIONS='mcp-bridge:'
+
+# --- 1. static: no default feature enables a gated feature ---
+if grep -RInE '^[[:space:]]*default[[:space:]]*=[[:space:]]*\[' "${MANIFESTS[@]}" \
+  | grep -qE "$GATED_FEATURES"; then
+  fail "a default feature enables one of: $GATED_FEATURES"
+fi
+
+# --- 2. resolved: the default feature graph of the app crate ---
+TREE=$(cargo tree -p desktop_shell -e features -f '{p} {f}') || {
+  fail "cargo tree could not resolve the desktop_shell feature graph"
+  TREE=""
+}
+if [ -n "$TREE" ]; then
+  if grep -E 'desktop_shell v' <<<"$TREE" | grep -qE "$GATED_FEATURES"; then
+    fail "the default feature graph resolves one of: $GATED_FEATURES"
+  fi
+  if grep -qE "($GATED_CRATES) v" <<<"$TREE"; then
+    fail "the default feature graph links one of: $GATED_CRATES"
+  fi
+fi
+
+# --- 3. capabilities: no shipped grant names a gated plugin ---
+# build.rs narrows the capability glob to `capabilities/*.json` without
+# `dev-tools`, so only top-level files reach a default-feature build.
+if grep -lE "\"($GATED_PERMISSIONS)" apps/desktop/src-tauri/capabilities/*.json 2>/dev/null \
+  | grep -q .; then
+  fail "a shipped capability file grants a gated plugin permission"
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "dev surface gate: BLOCKED" >&2
+  exit 1
+fi
+echo "dev surface gate: pass (no gated feature, crate, or capability in the default build)"

--- a/scripts/check-dev-surface-absent.sh
+++ b/scripts/check-dev-surface-absent.sh
@@ -11,8 +11,11 @@
 #      feature and neither gated plugin crate
 #   3. no shipped capability file grants a permission from a gated plugin
 #
-# `cargo tree` failure is a violation, not a pass: a gate that cannot observe
-# the feature graph reports nothing rather than reporting absence.
+# Exit 0 requires a positive determination from every check. Each one first
+# asserts that its input exists and that its query returned a record it can
+# recognise, and fails when it did not: a missing manifest, an unavailable
+# `cargo`, an empty or unrecognisable `cargo tree` result, and an empty
+# capability directory are violations, not absence.
 
 set -euo pipefail
 
@@ -25,6 +28,8 @@ fail() {
 }
 
 MANIFESTS=(apps/desktop/src-tauri/Cargo.toml crates/app/core/Cargo.toml)
+# Message-only label for the glob expanded in check 3.
+CAPABILITY_GLOB='apps/desktop/src-tauri/capabilities/*.json'
 GATED_FEATURES='dev-tools|e2e'
 # Plugin crates whose presence in the graph means the surface is linked in.
 GATED_CRATES='tauri-plugin-mcp-bridge|tauri-plugin-webdriver'
@@ -32,18 +37,30 @@ GATED_CRATES='tauri-plugin-mcp-bridge|tauri-plugin-webdriver'
 GATED_PERMISSIONS='mcp-bridge:'
 
 # --- 1. static: no default feature enables a gated feature ---
-if grep -RInE '^[[:space:]]*default[[:space:]]*=[[:space:]]*\[' "${MANIFESTS[@]}" \
-  | grep -qE "$GATED_FEATURES"; then
+DEFAULT_LINES=""
+for manifest in "${MANIFESTS[@]}"; do
+  if [ ! -f "$manifest" ]; then
+    fail "manifest $manifest is missing, so its default features were never read"
+    continue
+  fi
+  DEFAULT_LINES+=$(grep -InE '^[[:space:]]*default[[:space:]]*=[[:space:]]*\[' "$manifest" || true)
+done
+if grep -qE "$GATED_FEATURES" <<<"$DEFAULT_LINES"; then
   fail "a default feature enables one of: $GATED_FEATURES"
 fi
 
 # --- 2. resolved: the default feature graph of the app crate ---
-TREE=$(cargo tree -p desktop_shell -e features -f '{p} {f}') || {
+TREE=$(cargo tree -p desktop_shell -e features -f '{p} {f}' 2>&1) || {
   fail "cargo tree could not resolve the desktop_shell feature graph"
   TREE=""
 }
-if [ -n "$TREE" ]; then
-  if grep -E 'desktop_shell v' <<<"$TREE" | grep -qE "$GATED_FEATURES"; then
+# The root package line is the record that proves the query ran and was
+# understood. Its absence means the graph was never observed.
+ROOT_LINES=$(grep -E 'desktop_shell v' <<<"$TREE" || true)
+if [ -z "$ROOT_LINES" ]; then
+  fail "cargo tree returned no desktop_shell entry, so the feature graph was not observed"
+else
+  if grep -qE "$GATED_FEATURES" <<<"$ROOT_LINES"; then
     fail "the default feature graph resolves one of: $GATED_FEATURES"
   fi
   if grep -qE "($GATED_CRATES) v" <<<"$TREE"; then
@@ -54,8 +71,12 @@ fi
 # --- 3. capabilities: no shipped grant names a gated plugin ---
 # build.rs narrows the capability glob to `capabilities/*.json` without
 # `dev-tools`, so only top-level files reach a default-feature build.
-if grep -lE "\"($GATED_PERMISSIONS)" apps/desktop/src-tauri/capabilities/*.json 2>/dev/null \
-  | grep -q .; then
+shopt -s nullglob
+CAPABILITIES=(apps/desktop/src-tauri/capabilities/*.json)
+shopt -u nullglob
+if [ "${#CAPABILITIES[@]}" -eq 0 ]; then
+  fail "no capability file matches $CAPABILITY_GLOB, so no grant was read"
+elif grep -lE "\"($GATED_PERMISSIONS)" "${CAPABILITIES[@]}" | grep -q .; then
   fail "a shipped capability file grants a gated plugin permission"
 fi
 
@@ -63,4 +84,4 @@ if [ "$FAILED" -ne 0 ]; then
   echo "dev surface gate: BLOCKED" >&2
   exit 1
 fi
-echo "dev surface gate: pass (no gated feature, crate, or capability in the default build)"
+echo "dev surface gate: pass (${#CAPABILITIES[@]} capability files, $(grep -c . <<<"$TREE") feature-graph lines observed)"

--- a/scripts/win-native-dev.ps1
+++ b/scripts/win-native-dev.ps1
@@ -58,5 +58,8 @@ Set-Location $desktop
 # Merge the dev-only overlay (src-tauri/tauri.dev.conf.json) which enables
 # withGlobalTauri for the MCP Bridge plugin's webview channel. withGlobalTauri
 # MUST stay out of the base tauri.conf.json (production security surface); it is
-# applied here in dev only — mirrors the `just dev` invocation.
-pnpm tauri dev --config src-tauri/tauri.dev.conf.json
+# applied here in dev only — mirrors the `just tauri-dev` invocation.
+# `--features dev-tools` compiles the MCP bridge in; without it the plugin is
+# not linked and nothing listens on 9223. The bridge binds 127.0.0.1 unless
+# PV_MCP_BRIDGE_BIND overrides it (see docs/development/windows-native-rust-dev.md).
+pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-tools


### PR DESCRIPTION
## What was reachable

The `tauri-plugin-mcp-bridge` control server was compiled into every
`debug_assertions` build of the desktop app and bound `0.0.0.0:9223` without
authentication. Any host that could reach that port on the LAN could call the
bridge's `execute_js`, which, with the dev overlay's `withGlobalTauri`, dispatches
to every Tauri command handler under the app's full capability grant. The plugin
crate was a non-optional dependency, so release binaries linked it as well; the
`init()` call was compiled out, so shipped builds did not bind the port, but the
source comment's claim that the surface was absent held only at the runtime level,
not the linkage level.

## What gates it now

| Surface | Gate |
| --- | --- |
| `tauri-plugin-mcp-bridge` crate | `dev-tools` feature owns the dependency (`dep:` syntax), so a default-feature build does not link it |
| Bridge bind address | `127.0.0.1` rather than the plugin default `0.0.0.0`; `PV_MCP_BRIDGE_BIND` selects another address for one run, and the app warns at startup when bound off-loopback |
| `mcp-bridge:default` capability grant | `capabilities/dev/mcp-bridge.json`, which `build.rs` parses only when `dev-tools` is enabled |
| Vite dev server | `server.host: "127.0.0.1"` in `vite.config.ts`, independent of the invoking script's flags |

The plugin gate and the capability gate cannot drift apart: the dev capability
file names a permission from a plugin the same feature gates, and an unknown
permission fails the build.

## Effect on the Windows validation workflow

A WSL agent reaches the Windows host's bridge through the NAT gateway, which a
loopback bind refuses. `PV_MCP_BRIDGE_BIND=0.0.0.0` restores that path per run.
`scripts/win-native-dev.ps1`, `e2e-agentic-test/AGENT-RUNNER.md`,
`docs/development/windows-native-rust-dev.md`, `docs/journeys/README.md`, eleven
`docs/development/windows-journeys/` documents, and five scenario documents carry
the `--features dev-tools` requirement and the loopback default. Under mirrored
WSL networking `host=localhost` reaches the loopback bind unchanged.

## The check that proves absence

`scripts/check-dev-surface-absent.sh` asserts three things about a
default-feature build:

1. No `default = [...]` feature list enables `dev-tools` or `e2e`.
2. The resolved feature graph of `desktop_shell` resolves neither feature and
   links neither gated plugin crate.
3. No shipped capability file grants a gated plugin's permissions.

Exit 0 requires a positive determination from each one. Every check asserts that
its input exists and that its query returned a record it recognises, so a missing
manifest, an unavailable `cargo`, a `cargo tree` result without a
`desktop_shell v` line, and an empty capability directory each exit 1.

It replaces the release gate's `devtools_off` step, whose
`cargo tree -p desktop_shell --release` invocation cargo 1.97+ rejects with
`unexpected argument '--release' found`. That step discarded the error with
`2>/dev/null` and reported `pass` having observed nothing. The script treats a
`cargo tree` failure as a violation, and it runs in `ci.yml` on every Rust pull
request, whereas `release-gate.yml` runs only on `release-please--*` branches and
release tags.

Enumerated failure modes, each exit 1:

| Injected condition | Result |
| --- | --- |
| `default = ["dev-tools"]` in the app manifest | 3 failures: default feature, resolved graph, linked crate |
| `"mcp-bridge:default"` restored to `capabilities/default.json` | capability grant failure |
| stub `cargo` exits 0 with empty output | feature graph not observed |
| stub `cargo` exits 127 | cargo tree could not resolve the graph |
| stub `cargo` prints a graph without a `desktop_shell` line | feature graph not observed |
| stub `cargo` prints `desktop_shell ... dev-tools` and the bridge crate | both resolved checks fire |
| `apps/desktop/src-tauri/Cargo.toml` renamed | manifest missing |
| `capabilities/default.json` renamed | no capability file read |

Baseline exits 0. Run from a directory that does not contain the script, bash
exits 127.

## Verification

| Command | Result |
| --- | --- |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo clippy -p desktop_shell --features dev-tools --all-targets -- -D warnings` | 0 |
| `cargo nextest run --workspace` | 0, 3094 tests |
| `cargo nextest run -p desktop_shell` (after round 2) | 0, 126 tests |
| `cargo fmt --all --check` | 0 |
| `cd apps/desktop && pnpm lint` | 0 |
| `cargo build --release -p desktop_shell --lib` | 0 |
| `bash scripts/check-dev-surface-absent.sh` | 0 |
| `shellcheck scripts/check-dev-surface-absent.sh` | 0 |

The release artifact `libdesktop_shell.a` holds 1116 archive members, of which 0
belong to `tauri_plugin_mcp_bridge` or to `tungstenite`, the bridge's WebSocket
stack, and it contains 0 occurrences of the string `0.0.0.0`.

Merge-Bead: astro-plan-g58dp
Tracks-Bead: astro-plan-p2hs1
