### PR TITLE
fix: a write that matched no row reported success

### DIFF
--- a/crates/app/core/tests/calibration_missing_flag_integration.rs
+++ b/crates/app/core/tests/calibration_missing_flag_integration.rs
@@ -290,3 +290,19 @@ async fn source_sub_frame_missing_flags_match_and_clears_on_recovery() {
     let entries: Vec<_> = std::fs::read_dir(dir.path()).unwrap().collect();
     assert_eq!(entries.len(), 1, "app must never create/delete/move files during reconcile");
 }
+
+/// A recovery call naming an artifact id that no longer has a row must not
+/// publish `artifact.recovered`: the event would assert an outcome the store
+/// contradicts.
+#[tokio::test]
+async fn recovery_of_an_unknown_artifact_publishes_nothing() {
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+
+    let err = mark_recovered(pool, &bus, "proj-a", "art-gone", "output/MasterDark.xisf", 4096)
+        .await
+        .expect_err("a recovery that matches no row must not report success");
+
+    assert!(err.contains("art-gone"), "error must name the artifact: {err}");
+    assert_eq!(event_count(pool, "artifact.recovered").await, 0);
+}

--- a/crates/app/projects/src/update_view/apply.rs
+++ b/crates/app/projects/src/update_view/apply.rs
@@ -16,6 +16,7 @@ use sqlx::SqlitePool;
 
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use domain_core::ids::Timestamp;
+use persistence_core::DbError;
 use persistence_plans::repositories::update_view as repo;
 use persistence_sessions::repositories::{change_sequence, tx};
 
@@ -123,10 +124,6 @@ async fn apply_inner(
 /// absolute source path and destination root path for a plan item. The Tauri
 /// adapter supplies these from the registered library-root and destination-root
 /// paths. Tests may supply a closure that returns real temp-dir paths.
-#[expect(
-    clippy::cognitive_complexity,
-    reason = "linear per-item apply loop with failure taxonomy and lease checks"
-)]
 pub async fn run_apply_loop(
     pool: &SqlitePool,
     plan_id: &str,
@@ -202,13 +199,7 @@ pub async fn run_apply_loop(
                 installed.push((entry.row_id, entry_row_id, entry.relative_path.clone(), fp));
             }
             Err(e) => {
-                let mut c =
-                    pool.acquire().await.map_err(|e2| app_core_errors::db_err(e2.into()))?;
-                tx::enable_foreign_keys(&mut c).await.map_err(app_core_errors::db_err)?;
-                tx::begin_immediate(&mut c).await.map_err(app_core_errors::db_err)?;
-                let _ =
-                    repo::transition_plan_state(&mut *c, plan.row_id, "applying", "stopped").await;
-                let _ = tx::commit(&mut c).await;
+                leave_applying(pool, plan.row_id, "stopped").await;
                 return Err(e);
             }
         }
@@ -228,14 +219,45 @@ pub async fn run_apply_loop(
         }
         Err(e) => {
             tx::rollback(&mut conn).await;
-            let mut c = pool.acquire().await.map_err(|e2| app_core_errors::db_err(e2.into()))?;
-            tx::enable_foreign_keys(&mut c).await.map_err(app_core_errors::db_err)?;
-            tx::begin_immediate(&mut c).await.map_err(app_core_errors::db_err)?;
-            let _ = repo::transition_plan_state(&mut *c, plan.row_id, "applying", "failed").await;
-            let _ = tx::commit(&mut c).await;
+            leave_applying(pool, plan.row_id, "failed").await;
             Err(e)
         }
     }
+}
+
+/// Move a plan out of `applying` on an error path, reporting failure to do so.
+///
+/// The caller owes the user the original failure, so this cannot return an error
+/// of its own. `transition_plan_state` is the only mechanism that moves a plan
+/// out of `applying`: when it or its commit fails, the row stays `applying` with
+/// nothing left to move it, and boot reconciliation cannot tell that state from
+/// a mutation still in flight. The log line is the only remaining signal.
+async fn leave_applying(pool: &SqlitePool, plan_row_id: i64, new_state: &str) {
+    if let Err(e) = try_leave_applying(pool, plan_row_id, new_state).await {
+        tracing::error!(
+            plan_row_id,
+            new_state,
+            error = %e,
+            "plan is stuck in 'applying': nothing remains that will move it"
+        );
+    }
+}
+
+async fn try_leave_applying(
+    pool: &SqlitePool,
+    plan_row_id: i64,
+    new_state: &str,
+) -> Result<(), DbError> {
+    let mut conn = pool.acquire().await?;
+    tx::enable_foreign_keys(&mut conn).await?;
+    tx::begin_immediate(&mut conn).await?;
+    if let Err(e) =
+        repo::transition_plan_state(&mut *conn, plan_row_id, "applying", new_state).await
+    {
+        tx::rollback(&mut conn).await;
+        return Err(e);
+    }
+    tx::commit(&mut conn).await
 }
 
 async fn finalize_snapshot(
@@ -345,4 +367,20 @@ async fn finalize_snapshot(
         .map_err(app_core_errors::db_err)?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use persistence_core::{test_support::setup_db, DbError};
+
+    #[tokio::test]
+    async fn leaving_applying_surfaces_a_transition_that_matched_no_row() {
+        let db = setup_db().await;
+
+        let err = super::try_leave_applying(db.pool(), 999, "stopped")
+            .await
+            .expect_err("a transition that matched no row must not read as success");
+
+        assert!(matches!(err, DbError::CasFailed(_)), "expected a CAS failure, got {err}");
+    }
 }

--- a/crates/app/projects/src/update_view/apply.rs
+++ b/crates/app/projects/src/update_view/apply.rs
@@ -225,21 +225,75 @@ pub async fn run_apply_loop(
     }
 }
 
-/// Move a plan out of `applying` on an error path, reporting failure to do so.
+/// Where a plan ended up after an error path tried to move it out of `applying`.
+#[derive(Debug, PartialEq, Eq)]
+enum LeftApplying {
+    /// The transition committed.
+    Transitioned,
+    /// Another writer moved the plan out of `applying` first, so there is
+    /// nothing to correct. `cancel_update_view` does this to a running plan.
+    /// `observed` is the state now on the row, or `None` when the row is gone.
+    AlreadyLeft { observed: Option<String> },
+    /// The row is still `applying` and nothing remains that will move it.
+    Stuck,
+}
+
+/// Move a plan out of `applying` on an error path.
 ///
 /// The caller owes the user the original failure, so this cannot return an error
 /// of its own. `transition_plan_state` is the only mechanism that moves a plan
-/// out of `applying`: when it or its commit fails, the row stays `applying` with
-/// nothing left to move it, and boot reconciliation cannot tell that state from
-/// a mutation still in flight. The log line is the only remaining signal.
-async fn leave_applying(pool: &SqlitePool, plan_row_id: i64, new_state: &str) {
-    if let Err(e) = try_leave_applying(pool, plan_row_id, new_state).await {
-        tracing::error!(
+/// out of `applying`, so a plan left in that state after this call is
+/// indistinguishable at boot from a mutation still in flight, and the log line
+/// is its only trace. The returned value is what tests assert on.
+async fn leave_applying(pool: &SqlitePool, plan_row_id: i64, new_state: &str) -> LeftApplying {
+    let Err(e) = try_leave_applying(pool, plan_row_id, new_state).await else {
+        return LeftApplying::Transitioned;
+    };
+
+    let outcome = classify_failure_to_leave(pool, plan_row_id, &e).await;
+    match &outcome {
+        LeftApplying::AlreadyLeft { observed } => tracing::info!(
+            plan_row_id,
+            new_state,
+            observed = observed.as_deref().unwrap_or("<row gone>"),
+            "another writer moved the plan out of 'applying' first"
+        ),
+        LeftApplying::Stuck => tracing::error!(
             plan_row_id,
             new_state,
             error = %e,
             "plan is stuck in 'applying': nothing remains that will move it"
-        );
+        ),
+        LeftApplying::Transitioned => {}
+    }
+    outcome
+}
+
+/// A failure to transition is only a stuck plan when the row is still
+/// `applying`; a lost race against `cancel_update_view` is not.
+async fn classify_failure_to_leave(
+    pool: &SqlitePool,
+    plan_row_id: i64,
+    error: &DbError,
+) -> LeftApplying {
+    let Ok(mut conn) = pool.acquire().await else {
+        return LeftApplying::Stuck;
+    };
+    match repo::plan_state(&mut conn, plan_row_id).await {
+        Ok(None) => LeftApplying::AlreadyLeft { observed: None },
+        Ok(Some(state)) if state != "applying" => {
+            LeftApplying::AlreadyLeft { observed: Some(state) }
+        }
+        Ok(Some(_)) => LeftApplying::Stuck,
+        Err(read_error) => {
+            tracing::error!(
+                plan_row_id,
+                transition_error = %error,
+                read_error = %read_error,
+                "could not read plan state after a failed transition out of 'applying'"
+            );
+            LeftApplying::Stuck
+        }
     }
 }
 
@@ -371,10 +425,94 @@ async fn finalize_snapshot(
 
 #[cfg(test)]
 mod tests {
-    use persistence_core::{test_support::setup_db, DbError};
+    use super::LeftApplying;
+    use persistence_core::{test_support::setup_db, Database, DbError};
+    use persistence_topology::test_support as support;
+
+    /// Insert a `materialization_update_plan` row in `state`, returning its row id.
+    async fn plan_in_state(db: &Database, state: &str) -> i64 {
+        let pool = db.pool();
+        let project_row_id = support::insert_spec062_project(pool, "proj-leave").await;
+        let actor_row_id = support::insert_actor(pool, "actor-leave").await;
+        let seq = support::insert_sequence(pool).await;
+
+        let revision_row_id: i64 = sqlx::query_scalar(
+            "INSERT INTO project_membership_revision
+                 (public_id, project_row_id, revision_number, actor_row_id,
+                  created_sequence, created_at)
+             VALUES ('rev-leave', ?, 1, ?, ?, '2026-07-22T00:00:00.000000Z')
+             RETURNING row_id",
+        )
+        .bind(project_row_id)
+        .bind(actor_row_id)
+        .bind(seq)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+
+        sqlx::query_scalar(
+            "INSERT INTO materialization_update_plan
+                 (public_id, project_row_id, target_membership_revision_row_id, state,
+                  content_digest, session_count, item_count, source_frame_count,
+                  source_byte_count, remaining_session_count, actor_row_id,
+                  created_sequence, created_at)
+             VALUES ('plan-leave', ?, ?, ?, 'digest', 0, 0, 0, 0, 0, ?, ?, \
+                     '2026-07-22T00:00:00.000000Z')
+             RETURNING row_id",
+        )
+        .bind(project_row_id)
+        .bind(revision_row_id)
+        .bind(state)
+        .bind(actor_row_id)
+        .bind(seq)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
 
     #[tokio::test]
-    async fn leaving_applying_surfaces_a_transition_that_matched_no_row() {
+    async fn leaving_applying_transitions_a_plan_that_is_still_applying() {
+        let db = setup_db().await;
+        let plan_row_id = plan_in_state(&db, "applying").await;
+
+        assert_eq!(
+            super::leave_applying(db.pool(), plan_row_id, "stopped").await,
+            LeftApplying::Transitioned
+        );
+
+        let mut conn = db.pool().acquire().await.unwrap();
+        assert_eq!(
+            super::repo::plan_state(&mut conn, plan_row_id).await.unwrap().as_deref(),
+            Some("stopped")
+        );
+    }
+
+    /// `cancel_update_view` moves a running plan out of `applying` while the
+    /// loop is still working, so the loop's own transition loses the race. That
+    /// plan is not stuck and must not be reported as stuck.
+    #[tokio::test]
+    async fn a_plan_another_writer_already_moved_is_not_stuck() {
+        let db = setup_db().await;
+        let plan_row_id = plan_in_state(&db, "stopped").await;
+
+        assert_eq!(
+            super::leave_applying(db.pool(), plan_row_id, "stopped").await,
+            LeftApplying::AlreadyLeft { observed: Some("stopped".to_owned()) }
+        );
+    }
+
+    #[tokio::test]
+    async fn a_plan_row_that_is_gone_is_not_stuck() {
+        let db = setup_db().await;
+
+        assert_eq!(
+            super::leave_applying(db.pool(), 999, "stopped").await,
+            LeftApplying::AlreadyLeft { observed: None }
+        );
+    }
+
+    #[tokio::test]
+    async fn the_transition_result_is_not_discarded() {
         let db = setup_db().await;
 
         let err = super::try_leave_applying(db.pool(), 999, "stopped")

--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -205,9 +205,10 @@ impl Database {
         let dest_str = dest.display().to_string().replace('\'', "''");
         let stmt = sqlx::AssertSqlSafe(format!("VACUUM INTO '{dest_str}'"));
         sqlx::query(stmt).execute(&self.pool).await?;
-        // A URI in-memory source database makes `VACUUM INTO` report success and
-        // write nothing, so the statement result alone does not establish that the
-        // backup exists. The caller relies on this file as rollback material.
+        // Observed with a `Database::in_memory()` source on this workspace's sqlx
+        // build: `VACUUM INTO` reports success and writes nothing. The statement
+        // result therefore does not establish that the backup exists, and the
+        // caller relies on this file as rollback material.
         if !dest.is_file() {
             return Err(DbError::Database(sqlx::Error::Io(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
@@ -397,8 +398,8 @@ mod tests {
         assert!(err.to_string().contains("no-such-dir"), "error must name the destination: {err}");
     }
 
-    /// `VACUUM INTO` reports success and writes nothing when the source is a URI
-    /// in-memory database, so success is decided by the file, not the statement.
+    /// With a `Database::in_memory()` source, `VACUUM INTO` reports success and
+    /// writes nothing, so success is decided by the file, not the statement.
     #[tokio::test]
     async fn backup_to_fails_when_the_statement_writes_no_file() {
         let db = super::Database::in_memory().await.expect("in-memory connect");

--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -199,11 +199,21 @@ impl Database {
     /// # Errors
     ///
     /// Returns `persistence_core::DbError::Database` if the statement fails (e.g. destination
-    /// already exists, or disk full).
+    /// already exists, the destination directory does not exist, or disk full), or if the
+    /// statement reports success without leaving a file at `dest`.
     pub async fn backup_to(&self, dest: &std::path::Path) -> DbResult<()> {
         let dest_str = dest.display().to_string().replace('\'', "''");
         let stmt = sqlx::AssertSqlSafe(format!("VACUUM INTO '{dest_str}'"));
         sqlx::query(stmt).execute(&self.pool).await?;
+        // A URI in-memory source database makes `VACUUM INTO` report success and
+        // write nothing, so the statement result alone does not establish that the
+        // backup exists. The caller relies on this file as rollback material.
+        if !dest.is_file() {
+            return Err(DbError::Database(sqlx::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("VACUUM INTO reported success but wrote no file at {}", dest.display()),
+            ))));
+        }
         Ok(())
     }
 
@@ -353,5 +363,55 @@ mod tests {
 
         let pending = db.has_pending_migrations().await.expect("has_pending_migrations");
         assert!(pending, "one migration removed: must report pending");
+    }
+
+    async fn file_backed_db(dir: &std::path::Path) -> super::Database {
+        let src = dir.join("src.sqlite3");
+        let db = super::Database::connect(&format!("sqlite://{}?mode=rwc", src.display()))
+            .await
+            .expect("file-backed connect");
+        db.migrate().await.expect("migrate");
+        db
+    }
+
+    #[tokio::test]
+    async fn backup_to_writes_the_requested_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = file_backed_db(dir.path()).await;
+        let dest = dir.path().join("plain.sqlite3");
+
+        db.backup_to(&dest).await.expect("backup");
+
+        assert!(dest.is_file(), "a successful backup must leave a file at {}", dest.display());
+    }
+
+    #[tokio::test]
+    async fn backup_to_rejects_an_absent_destination_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = file_backed_db(dir.path()).await;
+        let dest = dir.path().join("no-such-dir").join("backup.sqlite3");
+
+        let err = db.backup_to(&dest).await.expect_err("absent parent must fail");
+
+        assert!(!dest.exists(), "no file may be created for a rejected backup");
+        assert!(err.to_string().contains("no-such-dir"), "error must name the destination: {err}");
+    }
+
+    /// `VACUUM INTO` reports success and writes nothing when the source is a URI
+    /// in-memory database, so success is decided by the file, not the statement.
+    #[tokio::test]
+    async fn backup_to_fails_when_the_statement_writes_no_file() {
+        let db = super::Database::in_memory().await.expect("in-memory connect");
+        db.migrate().await.expect("migrate");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("plain.sqlite3");
+
+        let err = db.backup_to(&dest).await.expect_err("an unwritten backup must fail");
+
+        assert!(!dest.exists());
+        assert!(
+            err.to_string().contains("wrote no file"),
+            "error must say nothing was written: {err}"
+        );
     }
 }

--- a/crates/persistence/plans/src/repositories/artifacts.rs
+++ b/crates/persistence/plans/src/repositories/artifacts.rs
@@ -19,7 +19,7 @@
 use domain_core::ids::Timestamp;
 use sqlx::{SqliteConnection, SqlitePool};
 
-use persistence_core::DbResult;
+use persistence_core::{DbError, DbResult};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -282,8 +282,13 @@ pub async fn mark_artifacts_missing(pool: &SqlitePool, artifact_ids: &[String]) 
 
 /// Transition an artifact from `missing` back to `present` and refresh size/hash.
 ///
+/// A `content_hash` of `None` leaves the stored hash in place: it is the only
+/// record of which bytes were processed, and the recovery caller does not
+/// re-hash the file.
+///
 /// # Errors
-/// Returns [`persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::NotFound`] when no artifact carries
+/// `artifact_id`, and [`persistence_core::DbError::Database`] on query failure.
 pub async fn mark_artifact_recovered(
     pool: &SqlitePool,
     artifact_id: &str,
@@ -291,10 +296,11 @@ pub async fn mark_artifact_recovered(
     content_hash: Option<&str>,
 ) -> DbResult<()> {
     let now = Timestamp::now_iso();
-    sqlx::query(
+    let result = sqlx::query(
         "\
         UPDATE processing_artifacts
-           SET state = 'present', last_seen_at = ?, size_bytes = ?, content_hash = ?
+           SET state = 'present', last_seen_at = ?, size_bytes = ?,
+               content_hash = COALESCE(?, content_hash)
          WHERE id = ?
         ",
     )
@@ -304,6 +310,9 @@ pub async fn mark_artifact_recovered(
     .bind(artifact_id)
     .execute(pool)
     .await?;
+    if result.rows_affected() == 0 {
+        return Err(DbError::NotFound(format!("processing_artifact {artifact_id}")));
+    }
     Ok(())
 }
 
@@ -651,6 +660,43 @@ mod tests {
         let row2 = get_artifact_by_path(pool, "p1", "out/img.xisf").await.unwrap().unwrap();
         assert_eq!(row2.state, "present");
         assert_eq!(row2.size_bytes, 2048);
+    }
+
+    #[tokio::test]
+    async fn mark_artifact_recovered_reports_an_unknown_id() {
+        let db = Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+
+        let err = mark_artifact_recovered(db.pool(), "gone", 2048, None)
+            .await
+            .expect_err("a recovery that matches no row must not report success");
+
+        assert!(
+            matches!(err, DbError::NotFound(ref m) if m.contains("gone")),
+            "error must name the missing artifact: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_artifact_recovered_keeps_the_stored_content_hash() {
+        let db = Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        let pool = db.pool();
+
+        insert_artifact_if_absent(pool, art("a1", "p1", "out/img.xisf", "intermediate"))
+            .await
+            .unwrap();
+        mark_artifact_recovered(pool, "a1", 1024, Some("abc123")).await.unwrap();
+        mark_artifacts_missing(pool, &["a1".to_owned()]).await.unwrap();
+
+        mark_artifact_recovered(pool, "a1", 2048, None).await.unwrap();
+
+        let row = get_artifact_by_path(pool, "p1", "out/img.xisf").await.unwrap().unwrap();
+        assert_eq!(
+            row.content_hash.as_deref(),
+            Some("abc123"),
+            "recovery without a fresh hash must not erase the stored one"
+        );
     }
 
     #[tokio::test]

--- a/crates/persistence/plans/src/repositories/plans.rs
+++ b/crates/persistence/plans/src/repositories/plans.rs
@@ -484,17 +484,22 @@ pub async fn set_reopened(pool: &SqlitePool, plan_id: &str) -> DbResult<()> {
 ///
 /// # Errors
 ///
-/// Returns [`persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::NotFound`] when no plan carries
+/// `plan_id`, and [`persistence_core::DbError::Database`] on connection failure.
 pub async fn set_chosen_framing_id(
     pool: &SqlitePool,
     plan_id: &str,
     framing_id: &str,
 ) -> DbResult<()> {
-    sqlx::query("UPDATE plans SET chosen_framing_id = ? WHERE id = ?")
+    let rows = sqlx::query("UPDATE plans SET chosen_framing_id = ? WHERE id = ?")
         .bind(framing_id)
         .bind(plan_id)
         .execute(pool)
         .await?;
+
+    if rows.rows_affected() == 0 {
+        return Err(DbError::NotFound(format!("plan {plan_id}")));
+    }
     Ok(())
 }
 
@@ -591,6 +596,20 @@ mod tests {
     }
 
     // ── chosen_framing_id (F-Framing-10) ────────────────────────────────────
+
+    #[tokio::test]
+    async fn set_chosen_framing_id_reports_a_plan_that_is_gone() {
+        let db = setup_db().await;
+
+        let err = set_chosen_framing_id(db.pool(), "plan-gone", "framing-1")
+            .await
+            .expect_err("an attribution write that matches no plan must not report success");
+
+        assert!(
+            matches!(err, DbError::NotFound(ref m) if m.contains("plan-gone")),
+            "error must name the missing plan: {err}"
+        );
+    }
 
     #[tokio::test]
     async fn chosen_framing_id_defaults_to_none_and_round_trips() {

--- a/crates/persistence/plans/src/repositories/update_view.rs
+++ b/crates/persistence/plans/src/repositories/update_view.rs
@@ -563,6 +563,17 @@ async fn fetch_plan(
     })
 }
 
+/// Read a plan's state by row id. `None` when no such row exists.
+///
+/// # Errors
+/// Returns [`DbError::Database`] on query failure.
+pub async fn plan_state(conn: &mut SqliteConnection, plan_row_id: i64) -> DbResult<Option<String>> {
+    Ok(sqlx::query_scalar("SELECT state FROM materialization_update_plan WHERE row_id = ?")
+        .bind(plan_row_id)
+        .fetch_optional(&mut *conn)
+        .await?)
+}
+
 /// CAS state transition.
 pub async fn transition_plan_state(
     conn: &mut SqliteConnection,


### PR DESCRIPTION
## Summary

A write path that dropped the result of its `UPDATE` returned `Ok` for a
statement that matched no row, and the caller responded as though the database
had changed. This affected five writes. Zero rows affected is a legitimate
idempotent no-op in some of them, so each locus is classified individually
rather than blanket-converted into a failure.

## What changed

| Write | Silently succeeded | Now |
| --- | --- | --- |
| `mark_artifact_recovered` | A recovery for an unknown artifact id reported success, and `mark_recovered` published `artifact.recovered` for a row the store does not hold. | Returns `DbError::NotFound`. The publish is unreachable for a zero-row recovery. |
| `mark_artifact_recovered` | `content_hash` was set to NULL whenever the caller passed no fresh hash, erasing the only record of which bytes were processed. | `COALESCE(?, content_hash)` keeps the stored hash. |
| `set_chosen_framing_id` | An attribution decision written to a plan id absent from the table reported success and persisted nothing. | Returns `DbError::NotFound`. |
| `update_view` apply error paths | The compare-and-swap out of `applying` and the commit that would record it were both discarded, so a lost race or a failed commit left the plan pinned at `applying` with nothing to move it. | Both results are inspected. The failure is classified by re-reading the row: only a row still in `applying` is reported as stuck, at error level with the plan row id. A row another writer already moved or deleted is reported as an ordinary event. |
| `Database::backup_to` | The statement result decided success, so a run that produced no file reported a backup the caller did not hold. | Success is decided by the destination file. |

The apply error paths owe the caller the original install failure, so they
cannot surface the transition failure as an error return. A plan left in
`applying` is indistinguishable at boot from a mutation still in flight, which
makes the log line its only trace. `cancel_update_view` moves a running plan out
of `applying` by design, so that case is classified apart from a stuck plan.

## Durability tier per locus

| Locus | Tier | Basis |
| --- | --- | --- |
| `mark_artifact_recovered` state and size | 2 | Re-derivable by rescanning the file. |
| `mark_artifact_recovered` content hash | 2, guarded | Re-derivable only by re-hashing bytes the recovery caller does not read. |
| `set_chosen_framing_id` | 1 | Frame-to-target attribution is a user decision that cannot be re-derived from the filesystem. |
| `update_view` plan state | 1 | Lifecycle state of an in-progress filesystem mutation. |
| `Database::backup_to` | 1 | Rollback material for a schema migration. |

## Correction to the reported evidence

`astro-plan-3v3r.12.21` reports that `backup_to` writes nothing and that it
succeeds into a destination directory that does not exist. Both claims rest on
a confound its author flagged and left unresolved: the harness source database
is `Database::in_memory()`. Against a file-backed source, `VACUUM INTO` writes
the requested file and rejects an absent destination directory with
`SQLITE_CANTOPEN`. This is a missing post-condition, not data loss on the
production path.

The silent no-op is reported for the condition observed, a
`Database::in_memory()` source on this workspace's sqlx build. The `sqlite3`
CLI writes the destination for the same URI form, so the mechanism is not URI
in-memory SQLite and is not established here. The post-condition check covers
that case and any other run that produces no file.

## Verification

| Check | Exit |
| --- | --- |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo nextest run --workspace --no-fail-fast` | 0, 3105 passed |
| `cargo fmt --check` | 0 |

`pnpm lint` is not run: nothing under `apps/desktop` changed.

Each test asserts the zero-rows path and fails against the pre-fix code.
The `update_view` tests are the exception: the pre-fix shape discarded its
result, so it exposed no value to assert on. They pin the outcome
`leave_applying` now returns, including the cancelled-plan case that a stuck
plan must not be confused with.

## Spec Context

Tracks-Bead: astro-plan-mum3b
Tracks-Bead: astro-plan-3v3r.4.17
Tracks-Bead: astro-plan-3v3r.4.18
Tracks-Bead: astro-plan-3v3r.6.24
Tracks-Bead: astro-plan-3v3r.9.21
Tracks-Bead: astro-plan-3v3r.12.21
Merge-Bead: astro-plan-0fp7a
