### PR TITLE
fix: log and audit exports refuse to overwrite an existing file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
  "filetime",
  "fs_executor",
  "fs_inventory",
+ "fs_pathsafe",
  "hex",
  "patterns",
  "persistence_calibration",
@@ -1421,6 +1422,7 @@ dependencies = [
  "contracts_core",
  "domain_core",
  "fs_inventory",
+ "fs_pathsafe",
  "futures-util",
  "persistence_core",
  "persistence_inbox",
@@ -2030,6 +2032,7 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "proptest",
+ "safe-filename",
  "tempfile",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ skymath = "0.7.2"
 contracts_core = { path = "../../../crates/contracts/core" }
 domain_core = { path = "../../../crates/domain/core" }
 fs_inventory = { path = "../../../crates/fs/inventory" }
+fs_pathsafe = { path = "../../../crates/fs/pathsafe" }
 persistence_core = { path = "../../../crates/persistence/core" }
 persistence_inbox = { path = "../../../crates/persistence/inbox" }
 persistence_lifecycle = { path = "../../../crates/persistence/lifecycle" }

--- a/apps/desktop/src-tauri/src/commands/audit.rs
+++ b/apps/desktop/src-tauri/src/commands/audit.rs
@@ -288,8 +288,13 @@ pub async fn audit_list(
 /// a file (mirrors `log.export`). Streams backend-side; only the path and count
 /// cross IPC.
 ///
+/// The destination passes `fs_pathsafe::export_dest`, so an existing file is
+/// refused rather than replaced and the write cannot leave the canonicalized
+/// parent directory.
+///
 /// # Errors
-/// Returns `Err(ContractError)` on database or filesystem failure.
+/// Returns `Err(ContractError)` on a refused destination, database failure, or
+/// filesystem failure.
 #[tauri::command]
 #[specta::specta]
 pub async fn audit_export(
@@ -297,6 +302,7 @@ pub async fn audit_export(
     file_path: String,
     filters: Option<AuditFilterDto>,
 ) -> Result<AuditExportResponse, ContractError> {
+    use fs_pathsafe::export_dest::{validate_export_destination, ExportWriteError};
     use std::io::Write;
     use std::path::Path;
 
@@ -304,41 +310,37 @@ pub async fn audit_export(
     let filter = build_filter(filters, None);
 
     let dest = Path::new(&file_path);
-    let parent = dest.parent().ok_or_else(|| {
-        ContractError::internal(format!("No parent directory for path {}", dest.display()))
+    let validated = validate_export_destination(dest).map_err(|rejected| {
+        ContractError::internal(format!("{}: {}", rejected.message(), dest.display()))
     })?;
-    if !parent.exists() {
-        return Err(ContractError::internal(format!(
-            "Parent directory does not exist: {}",
-            parent.display()
-        )));
-    }
 
     let rows = list_audit_entries(pool, &filter).await.map_err(db_err)?;
     let entries: Vec<AuditEntry> = rows.into_iter().map(row_to_entry).collect();
     let count = entries.len();
 
-    // Write to a sibling temp path, then rename atomically.
-    let tmp_path = parent.join(format!(".audit-export-{}.tmp", std::process::id()));
-    let file = std::fs::File::create(&tmp_path)
-        .map_err(|e| ContractError::internal(format!("failed to create temp file: {e}")))?;
-    let mut writer = std::io::BufWriter::new(file);
-    for entry in &entries {
-        serde_json::to_writer(&mut writer, entry)
-            .map_err(|e| ContractError::internal(format!("serialisation error: {e}")))?;
-        writer
-            .write_all(b"\n")
-            .map_err(|e| ContractError::internal(format!("write error: {e}")))?;
-    }
-    writer.flush().map_err(|e| ContractError::internal(format!("flush error: {e}")))?;
-    drop(writer);
+    let bytes = validated
+        .write_atomically(|file| {
+            let mut writer = std::io::BufWriter::new(file);
+            for entry in &entries {
+                serde_json::to_writer(&mut writer, entry).map_err(std::io::Error::other)?;
+                writer.write_all(b"\n")?;
+            }
+            writer.flush()
+        })
+        .map_err(|e| match e {
+            ExportWriteError::Rejected(rejected) => ContractError::internal(format!(
+                "{}: {}",
+                rejected.message(),
+                validated.path().display()
+            )),
+            ExportWriteError::Io(e) => ContractError::internal(format!("write error: {e}")),
+        })?;
 
-    let bytes = std::fs::metadata(&tmp_path).map_or(0, |m| m.len());
-
-    std::fs::rename(&tmp_path, dest)
-        .map_err(|e| ContractError::internal(format!("rename error: {e}")))?;
-
-    Ok(AuditExportResponse { file_path: dest.to_string_lossy().into_owned(), count, bytes })
+    Ok(AuditExportResponse {
+        file_path: validated.path().to_string_lossy().into_owned(),
+        count,
+        bytes,
+    })
 }
 
 // ── entity.names ─────────────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/commands/log.rs
+++ b/apps/desktop/src-tauri/src/commands/log.rs
@@ -85,8 +85,8 @@ pub async fn log_recent(
 /// `log.export` — export filtered log entries to a JSON file.
 ///
 /// # Errors
-/// Returns `Err(String)` with code `"path.parent.missing"`, `"path.write.denied"`,
-/// `"range.invalid"`, or `"format.unsupported"`.
+/// Returns `Err(ContractError)` with code `path.parent.missing`,
+/// `path.write.denied`, `range.invalid`, or `format.unsupported`.
 #[tauri::command]
 #[specta::specta]
 pub async fn log_export(

--- a/apps/desktop/src-tauri/tests/commands.rs
+++ b/apps/desktop/src-tauri/tests/commands.rs
@@ -439,7 +439,16 @@ async fn audit_export_writes_ndjson_file_of_real_rows() {
 
     let res = audit_export(state, file_path.clone(), None).await.expect("audit_export ok");
     assert_eq!(res.count, 1);
-    assert_eq!(res.file_path, file_path);
+    // The response reports the canonicalized destination, which differs from the
+    // requested string wherever the parent path crosses a symlink.
+    let expected = tmp_dir
+        .path()
+        .canonicalize()
+        .expect("canonical tmp dir")
+        .join("export.ndjson")
+        .to_string_lossy()
+        .into_owned();
+    assert_eq!(res.file_path, expected);
 
     let contents = std::fs::read_to_string(&file_path).expect("read exported file");
     let lines: Vec<&str> = contents.lines().collect();
@@ -447,6 +456,34 @@ async fn audit_export_writes_ndjson_file_of_real_rows() {
     let parsed: serde_json::Value = serde_json::from_str(lines[0]).expect("valid ndjson line");
     assert_eq!(parsed["id"], "a1");
     assert_eq!(parsed["entityId"], "ses-1");
+}
+
+#[tokio::test]
+async fn audit_export_refuses_an_existing_destination() {
+    let app = mock_lifecycle_app().await;
+    let state = app.state::<AppState>();
+    insert_audit_row(state.repo.pool(), "a1", "session", "ses-1", "Confirm session").await;
+
+    let tmp_dir = tempfile::tempdir().expect("tmp dir");
+    let dest = tmp_dir.path().join("keep.ndjson");
+    std::fs::write(&dest, b"user data").expect("seed");
+
+    let err =
+        audit_export(state, dest.to_string_lossy().into_owned(), None).await.expect_err("refused");
+
+    assert!(err.message.contains("already exists"), "{:?}", err.message);
+    assert_eq!(std::fs::read(&dest).expect("read"), b"user data");
+}
+
+#[tokio::test]
+async fn audit_export_refuses_a_relative_destination() {
+    let app = mock_lifecycle_app().await;
+    let state = app.state::<AppState>();
+
+    let err =
+        audit_export(state, "../../export.ndjson".to_owned(), None).await.expect_err("refused");
+
+    assert!(err.message.contains("absolute"), "{:?}", err.message);
 }
 
 // ─── Review (1 command) ─────────────────────────────────────────────────────

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -878,8 +878,13 @@ export const commands = {
 	 *  a file (mirrors `log.export`). Streams backend-side; only the path and count
 	 *  cross IPC.
 	 * 
+	 *  The destination passes `fs_pathsafe::export_dest`, so an existing file is
+	 *  refused rather than replaced and the write cannot leave the canonicalized
+	 *  parent directory.
+	 * 
 	 *  # Errors
-	 *  Returns `Err(ContractError)` on database or filesystem failure.
+	 *  Returns `Err(ContractError)` on a refused destination, database failure, or
+	 *  filesystem failure.
 	 */
 	auditExport: (filePath: string, filters: {
 	entityType?: string | null,
@@ -922,8 +927,8 @@ export const commands = {
 	 *  `log.export` — export filtered log entries to a JSON file.
 	 * 
 	 *  # Errors
-	 *  Returns `Err(String)` with code `"path.parent.missing"`, `"path.write.denied"`,
-	 *  `"range.invalid"`, or `"format.unsupported"`.
+	 *  Returns `Err(ContractError)` with code `path.parent.missing`,
+	 *  `path.write.denied`, `range.invalid`, or `format.unsupported`.
 	 */
 	logExport: (requestId: string, filePath: string, format: string | null, levelMin: "debug" | "info" | "warn" | "error" | null, since: string | null, until: string | null, includeDiagnostics: boolean | null) => typedError<LogExportResponse_Serialize, ContractError_Serialize>(__TAURI_INVOKE("log_export", { requestId, filePath, format, levelMin, since, until, includeDiagnostics })),
 	/**

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -24,6 +24,7 @@ contracts_core = { path = "../../contracts/core" }
 domain_core = { path = "../../domain/core" }
 fs_executor = { path = "../../fs/executor" }
 fs_inventory = { path = "../../fs/inventory" }
+fs_pathsafe = { path = "../../fs/pathsafe" }
 patterns = { path = "../../patterns" }
 persistence_calibration = { path = "../../persistence/calibration" }
 persistence_core = { path = "../../persistence/core" }

--- a/crates/app/core/src/log_stream.rs
+++ b/crates/app/core/src/log_stream.rs
@@ -266,8 +266,9 @@ pub struct ExportOptions {
 
 /// Export matching log entries to a JSON file at `options.file_path`.
 ///
-/// Writes atomically: entries are serialised to a temp file in the same parent
-/// directory, then renamed into place.
+/// The destination passes `fs_pathsafe::export_dest`, so an existing file is
+/// refused rather than replaced and the write cannot leave the canonicalized
+/// parent directory.
 ///
 /// # Errors
 /// Returns `LogError::Export` for filesystem / format problems.
@@ -276,22 +277,15 @@ pub async fn export_entries(
     pool: &SqlitePool,
     options: ExportOptions,
 ) -> Result<(String, usize, u64), LogError> {
+    use fs_pathsafe::export_dest::{validate_export_destination, ExportWriteError};
     use std::io::Write;
     use std::path::Path;
 
     let dest = Path::new(&options.file_path);
-
-    // Validate parent directory.
-    let parent = dest.parent().ok_or_else(|| LogError::Export {
-        code: LogExportErrorCode::PathParentMissing,
-        message: format!("No parent directory for path {}", dest.display()),
+    let validated = validate_export_destination(dest).map_err(|rejected| LogError::Export {
+        code: export_error_code(rejected),
+        message: format!("{}: {}", rejected.message(), dest.display()),
     })?;
-    if !parent.exists() {
-        return Err(LogError::Export {
-            code: LogExportErrorCode::PathParentMissing,
-            message: format!("Parent directory does not exist: {}", parent.display()),
-        });
-    }
 
     let rows = persistence_lifecycle::repositories::events::list_by_emitted_at_range(
         pool,
@@ -320,22 +314,30 @@ pub async fn export_entries(
     // Serialise to JSON array.
     let json_bytes = serde_json::to_vec_pretty(&entries).map_err(LogError::Serialise)?;
 
-    // Write to temp file then rename (atomic write).
-    let tmp_path = format!("{}.tmp", options.file_path);
-    let mut tmp_file = std::fs::File::create(&tmp_path).map_err(|_e| LogError::Export {
-        code: LogExportErrorCode::PathWriteDenied,
-        message: format!("Cannot write to path: {}", dest.display()),
-    })?;
-    tmp_file.write_all(&json_bytes).map_err(LogError::Io)?;
-    drop(tmp_file);
+    let bytes =
+        validated.write_atomically(|file| file.write_all(&json_bytes)).map_err(|e| match e {
+            ExportWriteError::Rejected(rejected) => LogError::Export {
+                code: export_error_code(rejected),
+                message: format!("{}: {}", rejected.message(), dest.display()),
+            },
+            ExportWriteError::Io(e) => LogError::Io(e),
+        })?;
 
-    std::fs::rename(&tmp_path, dest).map_err(|_e| LogError::Export {
-        code: LogExportErrorCode::PathWriteDenied,
-        message: format!("Cannot rename temp file to: {}", dest.display()),
-    })?;
+    Ok((validated.path().to_string_lossy().into_owned(), count, bytes))
+}
 
-    let bytes = u64::try_from(json_bytes.len()).unwrap_or(0);
-    Ok((options.file_path, count, bytes))
+/// Map a destination rejection onto the two path codes the `log.export`
+/// contract defines; the rejection's own message carries the specific rule.
+fn export_error_code(
+    rejected: fs_pathsafe::export_dest::DestinationRejected,
+) -> LogExportErrorCode {
+    use fs_pathsafe::export_dest::DestinationRejected as R;
+    match rejected {
+        R::NotAbsolute | R::NoParent | R::NoFileName | R::ParentMissing | R::ParentNotDirectory => {
+            LogExportErrorCode::PathParentMissing
+        }
+        R::ReservedName | R::AlreadyExists => LogExportErrorCode::PathWriteDenied,
+    }
 }
 
 #[cfg(test)]
@@ -566,7 +568,14 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(out_path, path);
+        // The response reports the canonicalized destination, which differs from
+        // the requested string wherever the parent path crosses a symlink.
+        let expected = std::path::Path::new(&path)
+            .parent()
+            .and_then(|p| p.canonicalize().ok())
+            .map(|p| p.join("export.json").to_string_lossy().into_owned())
+            .expect("canonical parent");
+        assert_eq!(out_path, expected);
         assert_eq!(count, 2);
         assert!(bytes > 0);
 
@@ -620,5 +629,61 @@ mod tests {
         } else {
             panic!("expected LogError::Export");
         }
+    }
+
+    async fn export_to(pool: &SqlitePool, file_path: String) -> Result<(), LogError> {
+        export_entries(
+            pool,
+            ExportOptions {
+                file_path,
+                level_min: None,
+                since: None,
+                until: None,
+                include_diagnostics: false,
+            },
+        )
+        .await
+        .map(|_| ())
+    }
+
+    #[tokio::test]
+    async fn export_entries_refuses_an_existing_destination() {
+        let pool = make_pool().await;
+        insert_event(&pool, "plan.approved", "{}").await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().join("keep.json");
+        std::fs::write(&dest, b"user data").expect("seed");
+
+        let err = export_to(&pool, dest.to_string_lossy().into_owned()).await.expect_err("refused");
+
+        assert!(matches!(err, LogError::Export { code: LogExportErrorCode::PathWriteDenied, .. }));
+        assert_eq!(std::fs::read(&dest).expect("read"), b"user data");
+    }
+
+    #[tokio::test]
+    async fn export_entries_refuses_a_relative_destination() {
+        let pool = make_pool().await;
+        let err = export_to(&pool, "../../export.json".to_owned()).await.expect_err("refused");
+        assert!(matches!(
+            err,
+            LogError::Export { code: LogExportErrorCode::PathParentMissing, .. }
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn export_entries_does_not_write_through_a_symlinked_destination() {
+        let pool = make_pool().await;
+        insert_event(&pool, "plan.approved", "{}").await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let outside = dir.path().join("outside.json");
+        std::fs::write(&outside, b"outside").expect("seed");
+        let link = dir.path().join("export.json");
+        std::os::unix::fs::symlink(&outside, &link).expect("symlink");
+
+        let err = export_to(&pool, link.to_string_lossy().into_owned()).await.expect_err("refused");
+
+        assert!(matches!(err, LogError::Export { code: LogExportErrorCode::PathWriteDenied, .. }));
+        assert_eq!(std::fs::read(&outside).expect("read"), b"outside");
     }
 }

--- a/crates/fs/pathsafe/Cargo.toml
+++ b/crates/fs/pathsafe/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 camino = { workspace = true }
+safe-filename = { path = "../../safe-filename" }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/fs/pathsafe/src/export_dest.rs
+++ b/crates/fs/pathsafe/src/export_dest.rs
@@ -72,8 +72,11 @@ pub fn validate_export_destination(dest: &Path) -> Result<ExportDestination, Des
     let parent = dest.parent().ok_or(DestinationRejected::NoParent)?;
     let file_name = dest.file_name().ok_or(DestinationRejected::NoFileName)?;
 
-    let stem = Path::new(file_name).file_stem().unwrap_or(file_name).to_string_lossy();
-    safe_filename::step4_reserved_name_check(&stem)
+    // Windows resolves a device name from the text before the FIRST dot, so
+    // `CON.foo.json` names the console where `file_stem` would keep `CON.foo`.
+    let name = file_name.to_string_lossy();
+    let device = name.split('.').next().unwrap_or(&name);
+    safe_filename::step4_reserved_name_check(device)
         .map_err(|_| DestinationRejected::ReservedName)?;
 
     let dir = parent.canonicalize().map_err(|_| DestinationRejected::ParentMissing)?;
@@ -251,7 +254,7 @@ mod tests {
     #[test]
     fn windows_reserved_device_name_is_refused_on_every_platform() {
         let (_guard, dir) = tempdir();
-        for name in ["CON", "con.json", "NUL.txt", "com1.json"] {
+        for name in ["CON", "con.json", "NUL.txt", "com1.json", "CON.foo.json", "nul.a.b"] {
             let err = validate_export_destination(&dir.join(name)).unwrap_err();
             assert_eq!(err, DestinationRejected::ReservedName, "{name}");
         }

--- a/crates/fs/pathsafe/src/export_dest.rs
+++ b/crates/fs/pathsafe/src/export_dest.rs
@@ -383,25 +383,26 @@ mod tests {
         assert!(real.join("out.json").exists());
     }
 
+    /// `create_temp` relies on `create_new` refusing a name already taken by a
+    /// symlink. Naming the temporary path this test occupies would depend on
+    /// [`TEMP_SEQ`], which other tests share whenever they run in one process.
     #[cfg(unix)]
     #[test]
-    fn a_symlink_planted_at_the_temporary_path_is_not_written_through() {
+    fn create_new_refuses_a_symlink_instead_of_writing_through_it() {
         let (_guard, dir) = tempdir();
         let (_outside_guard, outside_dir) = tempdir();
         let outside = outside_dir.join("target.json");
         std::fs::write(&outside, b"outside").expect("seed");
+        let planted = dir.join(".export-planted.tmp");
+        std::os::unix::fs::symlink(&outside, &planted).expect("plant symlink");
 
-        // Occupy every name create_temp will try, so it cannot follow any of them.
-        let pid = std::process::id();
-        let start = TEMP_SEQ.load(Ordering::Relaxed);
-        for seq in start..start + 8 {
-            std::os::unix::fs::symlink(&outside, dir.join(format!(".export-{pid}-{seq}.tmp")))
-                .expect("plant symlink");
-        }
+        let err = File::options()
+            .write(true)
+            .create_new(true)
+            .open(&planted)
+            .expect_err("create_new refuses the planted symlink");
 
-        let validated = validate_export_destination(&dir.join("out.json")).expect("valid");
-        let err = write_hello(&validated).expect_err("temp creation refused");
-        assert!(matches!(err, ExportWriteError::Io(_)), "{err:?}");
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(std::fs::read(&outside).expect("read"), b"outside");
     }
 

--- a/crates/fs/pathsafe/src/export_dest.rs
+++ b/crates/fs/pathsafe/src/export_dest.rs
@@ -1,0 +1,420 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Validation and atomic write for a webview-supplied export destination.
+//!
+//! Constitution II ("MUST never overwrite silently") makes an existing
+//! destination a rejection, not a replacement.
+//!
+//! The write target is always `canonical_parent.join(file_name)`, so no segment
+//! of the caller's string can move the write outside the directory that was
+//! canonicalized and checked. The temporary file is created inside that same
+//! directory with `create_new`, which refuses to follow a symlink planted after
+//! validation; a symlink planted at the final path after validation is replaced
+//! by `rename` rather than written through.
+
+use std::fs::File;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Why an export destination is refused.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DestinationRejected {
+    /// The path is relative. Export destinations cross a process boundary, so a
+    /// path that resolves against the app's working directory is refused.
+    NotAbsolute,
+    /// The path has no parent component.
+    NoParent,
+    /// The path has no final component (it ends in `.` , `..`, or a separator).
+    NoFileName,
+    /// The parent directory does not exist or cannot be canonicalized.
+    ParentMissing,
+    /// The parent path exists but is not a directory.
+    ParentNotDirectory,
+    /// The final component is a Windows reserved device name.
+    ReservedName,
+    /// Something already exists at the destination.
+    AlreadyExists,
+}
+
+impl DestinationRejected {
+    /// Stable message for the caller's own error envelope.
+    #[must_use]
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::NotAbsolute => "export destination must be an absolute path",
+            Self::NoParent => "export destination has no parent directory",
+            Self::NoFileName => "export destination has no file name",
+            Self::ParentMissing => "export destination parent directory does not exist",
+            Self::ParentNotDirectory => "export destination parent is not a directory",
+            Self::ReservedName => "export destination is a reserved device name",
+            Self::AlreadyExists => "export destination already exists",
+        }
+    }
+}
+
+/// A destination that passed [`validate_export_destination`].
+#[derive(Clone, Debug)]
+pub struct ExportDestination {
+    dir: PathBuf,
+    final_path: PathBuf,
+}
+
+/// Validate `dest` as a write destination.
+///
+/// # Errors
+/// Returns the first [`DestinationRejected`] rule the path violates.
+pub fn validate_export_destination(dest: &Path) -> Result<ExportDestination, DestinationRejected> {
+    if !dest.is_absolute() {
+        return Err(DestinationRejected::NotAbsolute);
+    }
+    let parent = dest.parent().ok_or(DestinationRejected::NoParent)?;
+    let file_name = dest.file_name().ok_or(DestinationRejected::NoFileName)?;
+
+    let stem = Path::new(file_name).file_stem().unwrap_or(file_name).to_string_lossy();
+    safe_filename::step4_reserved_name_check(&stem)
+        .map_err(|_| DestinationRejected::ReservedName)?;
+
+    let dir = parent.canonicalize().map_err(|_| DestinationRejected::ParentMissing)?;
+    if !dir.is_dir() {
+        return Err(DestinationRejected::ParentNotDirectory);
+    }
+
+    let final_path = dir.join(file_name);
+    if final_path.symlink_metadata().is_ok() {
+        return Err(DestinationRejected::AlreadyExists);
+    }
+
+    Ok(ExportDestination { dir, final_path })
+}
+
+/// Distinguishes a refused destination from a failure while writing to it.
+#[derive(Debug)]
+pub enum ExportWriteError {
+    Rejected(DestinationRejected),
+    Io(io::Error),
+}
+
+impl From<DestinationRejected> for ExportWriteError {
+    fn from(value: DestinationRejected) -> Self {
+        Self::Rejected(value)
+    }
+}
+
+impl From<io::Error> for ExportWriteError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+/// Counter that keeps two concurrent exports in one directory off the same
+/// temporary name; `create_new` is what makes a collision an error rather than
+/// a silent share.
+static TEMP_SEQ: AtomicU32 = AtomicU32::new(0);
+
+impl ExportDestination {
+    /// The validated write target.
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.final_path
+    }
+
+    /// Write through a temporary file inside the validated directory, then
+    /// rename it onto the destination. Returns the byte count written.
+    ///
+    /// The temporary file is removed when `write` fails.
+    ///
+    /// # Errors
+    /// Returns [`ExportWriteError::Rejected`] with
+    /// [`DestinationRejected::AlreadyExists`] when the destination appeared
+    /// after validation, and [`ExportWriteError::Io`] for filesystem and
+    /// serialisation failures.
+    pub fn write_atomically<W>(&self, write: W) -> Result<u64, ExportWriteError>
+    where
+        W: FnOnce(&mut File) -> io::Result<()>,
+    {
+        let (temp_path, mut file) = self.create_temp()?;
+
+        if let Err(e) = write(&mut file).and_then(|()| file.sync_all()) {
+            drop(file);
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(ExportWriteError::Io(e));
+        }
+        let bytes = file.metadata().map_or(0, |m| m.len());
+        drop(file);
+
+        if self.final_path.symlink_metadata().is_ok() {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(DestinationRejected::AlreadyExists.into());
+        }
+        if let Err(e) = std::fs::rename(&temp_path, &self.final_path) {
+            let _ = std::fs::remove_file(&temp_path);
+            return Err(ExportWriteError::Io(e));
+        }
+        Ok(bytes)
+    }
+
+    fn create_temp(&self) -> io::Result<(PathBuf, File)> {
+        let pid = std::process::id();
+        let mut last = None;
+        for _ in 0..8 {
+            let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+            let candidate = self.dir.join(format!(".export-{pid}-{seq}.tmp"));
+            match File::options().write(true).create_new(true).open(&candidate) {
+                Ok(file) => return Ok((candidate, file)),
+                Err(e) => last = Some(e),
+            }
+        }
+        Err(last.unwrap_or_else(|| io::Error::other("no temporary file name available")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// The canonical path matters on macOS, where `/var` is a symlink to
+    /// `/private/var` and the validator returns the resolved parent.
+    fn tempdir() -> (tempfile::TempDir, PathBuf) {
+        let guard = tempfile::tempdir().expect("temp dir");
+        let path = guard.path().canonicalize().expect("canonicalize temp dir");
+        (guard, path)
+    }
+
+    fn write_hello(dest: &ExportDestination) -> Result<u64, ExportWriteError> {
+        dest.write_atomically(|f| f.write_all(b"hello"))
+    }
+
+    #[test]
+    fn relative_path_with_parent_escape_is_refused() {
+        let err = validate_export_destination(Path::new("../../etc/passwd")).unwrap_err();
+        assert_eq!(err, DestinationRejected::NotAbsolute);
+    }
+
+    #[test]
+    fn absolute_path_outside_any_root_is_accepted_but_never_overwrites() {
+        let (_guard, dir) = tempdir();
+        let dest = dir.join("out.json");
+        let validated = validate_export_destination(&dest).expect("fresh destination");
+        assert_eq!(write_hello(&validated).expect("write"), 5);
+
+        let err = validate_export_destination(&dest).unwrap_err();
+        assert_eq!(err, DestinationRejected::AlreadyExists);
+        assert_eq!(std::fs::read(&dest).expect("read back"), b"hello");
+    }
+
+    #[test]
+    fn dotdot_inside_an_absolute_path_cannot_move_the_write_out_of_the_parent() {
+        let (_guard, dir) = tempdir();
+        let nested = dir.join("nested");
+        std::fs::create_dir_all(&nested).expect("create nested");
+        let dest = nested.join("..").join("out.json");
+
+        let validated = validate_export_destination(&dest).expect("valid");
+        assert_eq!(validated.path().parent(), Some(dir.as_path()));
+        write_hello(&validated).expect("write");
+        assert!(dir.join("out.json").exists());
+    }
+
+    #[test]
+    fn parent_that_is_not_a_directory_is_refused() {
+        let (_guard, dir) = tempdir();
+        let file = dir.join("regular");
+        std::fs::write(&file, b"x").expect("write file");
+
+        let err = validate_export_destination(&file.join("child.json")).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                DestinationRejected::ParentMissing | DestinationRejected::ParentNotDirectory
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn missing_parent_is_refused() {
+        let (_guard, dir) = tempdir();
+        let err = validate_export_destination(&dir.join("absent").join("out.json")).unwrap_err();
+        assert_eq!(err, DestinationRejected::ParentMissing);
+    }
+
+    #[test]
+    fn path_without_a_file_name_is_refused() {
+        let (_guard, dir) = tempdir();
+        let err = validate_export_destination(&dir.join("..")).unwrap_err();
+        assert_eq!(err, DestinationRejected::NoFileName);
+    }
+
+    #[test]
+    fn windows_reserved_device_name_is_refused_on_every_platform() {
+        let (_guard, dir) = tempdir();
+        for name in ["CON", "con.json", "NUL.txt", "com1.json"] {
+            let err = validate_export_destination(&dir.join(name)).unwrap_err();
+            assert_eq!(err, DestinationRejected::ReservedName, "{name}");
+        }
+    }
+
+    #[test]
+    fn existing_destination_is_refused_before_anything_is_written() {
+        let (_guard, dir) = tempdir();
+        let dest = dir.join("keep.json");
+        std::fs::write(&dest, b"original").expect("seed");
+
+        let err = validate_export_destination(&dest).unwrap_err();
+        assert_eq!(err, DestinationRejected::AlreadyExists);
+        assert_eq!(std::fs::read(&dest).expect("read"), b"original");
+    }
+
+    #[test]
+    fn temporary_file_lands_inside_the_validated_directory() {
+        let (_guard, dir) = tempdir();
+        let validated = validate_export_destination(&dir.join("out.json")).expect("valid");
+        validated
+            .write_atomically(|f| {
+                let seen: Vec<PathBuf> = std::fs::read_dir(&validated.dir)
+                    .expect("read dir")
+                    .filter_map(|e| e.ok().map(|e| e.path()))
+                    .collect();
+                assert_eq!(seen.len(), 1, "{seen:?}");
+                assert_eq!(seen[0].parent(), Some(validated.dir.as_path()));
+                f.write_all(b"x")
+            })
+            .expect("write");
+    }
+
+    /// Pins the behaviour the validator replaces: a bare `create` + `rename`
+    /// pair reports success while destroying whatever was at the destination.
+    /// Both halves must hold, so reverting either sink to that sequence fails
+    /// this test.
+    #[test]
+    fn the_unvalidated_create_and_rename_sequence_replaces_an_existing_file() {
+        let (_guard, dir) = tempdir();
+        let dest = dir.join("keep.json");
+        std::fs::write(&dest, b"user data").expect("seed");
+
+        let temp = dir.join("keep.json.tmp");
+        std::fs::File::create(&temp)
+            .expect("create temp")
+            .write_all(b"export")
+            .expect("write temp");
+        std::fs::rename(&temp, &dest).expect("rename replaces silently");
+        assert_eq!(std::fs::read(&dest).expect("read"), b"export");
+
+        assert_eq!(
+            validate_export_destination(&dest).unwrap_err(),
+            DestinationRejected::AlreadyExists
+        );
+    }
+
+    #[test]
+    fn a_failed_write_leaves_no_temporary_file_behind() {
+        let (_guard, dir) = tempdir();
+        let validated = validate_export_destination(&dir.join("out.json")).expect("valid");
+        let err = validated
+            .write_atomically(|_| Err(io::Error::other("serialise failed")))
+            .expect_err("write fails");
+
+        assert!(matches!(err, ExportWriteError::Io(_)), "{err:?}");
+        assert_eq!(std::fs::read_dir(&dir).expect("read dir").count(), 0);
+    }
+
+    #[test]
+    fn a_destination_appearing_after_validation_is_not_replaced() {
+        let (_guard, dir) = tempdir();
+        let dest = dir.join("out.json");
+        let validated = validate_export_destination(&dest).expect("valid");
+
+        let err = validated
+            .write_atomically(|f| {
+                std::fs::write(&dest, b"raced").expect("racing writer");
+                f.write_all(b"export")
+            })
+            .expect_err("rename refused");
+
+        assert!(
+            matches!(err, ExportWriteError::Rejected(DestinationRejected::AlreadyExists)),
+            "{err:?}"
+        );
+        assert_eq!(std::fs::read(&dest).expect("read"), b"raced");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_at_the_destination_is_refused_rather_than_followed() {
+        let (_guard, dir) = tempdir();
+        let (_outside_guard, outside_dir) = tempdir();
+        let outside = outside_dir.join("outside.json");
+        std::fs::write(&outside, b"outside").expect("seed outside");
+        let link = dir.join("out.json");
+        std::os::unix::fs::symlink(&outside, &link).expect("symlink");
+
+        let err = validate_export_destination(&link).unwrap_err();
+        assert_eq!(err, DestinationRejected::AlreadyExists);
+        assert_eq!(std::fs::read(&outside).expect("read"), b"outside");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_parent_is_resolved_before_the_write() {
+        let (_real_guard, real) = tempdir();
+        let (_link_guard, link_parent) = tempdir();
+        let link_dir = link_parent.join("link");
+        std::os::unix::fs::symlink(&real, &link_dir).expect("symlink dir");
+
+        let validated =
+            validate_export_destination(&link_dir.join("out.json")).expect("valid through link");
+        assert_eq!(validated.path().parent(), Some(real.as_path()));
+        write_hello(&validated).expect("write");
+        assert!(real.join("out.json").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_planted_at_the_temporary_path_is_not_written_through() {
+        let (_guard, dir) = tempdir();
+        let (_outside_guard, outside_dir) = tempdir();
+        let outside = outside_dir.join("target.json");
+        std::fs::write(&outside, b"outside").expect("seed");
+
+        // Occupy every name create_temp will try, so it cannot follow any of them.
+        let pid = std::process::id();
+        let start = TEMP_SEQ.load(Ordering::Relaxed);
+        for seq in start..start + 8 {
+            std::os::unix::fs::symlink(&outside, dir.join(format!(".export-{pid}-{seq}.tmp")))
+                .expect("plant symlink");
+        }
+
+        let validated = validate_export_destination(&dir.join("out.json")).expect("valid");
+        let err = write_hello(&validated).expect_err("temp creation refused");
+        assert!(matches!(err, ExportWriteError::Io(_)), "{err:?}");
+        assert_eq!(std::fs::read(&outside).expect("read"), b"outside");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn a_destination_differing_only_by_case_is_refused() {
+        let (_guard, dir) = tempdir();
+        std::fs::write(dir.join("Export.json"), b"original").expect("seed");
+
+        let err = validate_export_destination(&dir.join("export.JSON")).unwrap_err();
+        assert_eq!(err, DestinationRejected::AlreadyExists);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn a_unc_path_to_a_missing_share_is_refused() {
+        let err = validate_export_destination(Path::new(r"\\127.0.0.1\no-such-share\out.json"))
+            .unwrap_err();
+        assert_eq!(err, DestinationRejected::ParentMissing);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn a_unc_path_is_refused_as_relative_off_windows() {
+        let err = validate_export_destination(Path::new(r"\\server\share\out.json")).unwrap_err();
+        assert_eq!(err, DestinationRejected::NotAbsolute);
+    }
+}

--- a/crates/fs/pathsafe/src/export_dest.rs
+++ b/crates/fs/pathsafe/src/export_dest.rs
@@ -252,7 +252,11 @@ mod tests {
     #[test]
     fn path_without_a_file_name_is_refused() {
         let (_guard, dir) = tempdir();
-        let err = validate_export_destination(&dir.join("..")).unwrap_err();
+        // `join` collapses `..` on a verbatim Windows path, which would leave the
+        // parent directory rather than a path terminating in `..`.
+        let dest = PathBuf::from(format!("{}{}..", dir.display(), std::path::MAIN_SEPARATOR));
+
+        let err = validate_export_destination(&dest).unwrap_err();
         assert_eq!(err, DestinationRejected::NoFileName);
     }
 

--- a/crates/fs/pathsafe/src/export_dest.rs
+++ b/crates/fs/pathsafe/src/export_dest.rs
@@ -72,9 +72,14 @@ pub fn validate_export_destination(dest: &Path) -> Result<ExportDestination, Des
     let parent = dest.parent().ok_or(DestinationRejected::NoParent)?;
     let file_name = dest.file_name().ok_or(DestinationRejected::NoFileName)?;
 
+    // A verbatim Windows path (`\\?\C:\...`) gives `..` no special meaning, so
+    // `file_name` returns it as an ordinary component and the traversal check
+    // has to reject it here.
+    let name = file_name.to_string_lossy();
+    safe_filename::step3_traversal_check(&name).map_err(|_| DestinationRejected::NoFileName)?;
+
     // Windows resolves a device name from the text before the FIRST dot, so
     // `CON.foo.json` names the console where `file_stem` would keep `CON.foo`.
-    let name = file_name.to_string_lossy();
     let device = name.split('.').next().unwrap_or(&name);
     safe_filename::step4_reserved_name_check(device)
         .map_err(|_| DestinationRejected::ReservedName)?;

--- a/crates/fs/pathsafe/src/lib.rs
+++ b/crates/fs/pathsafe/src/lib.rs
@@ -19,6 +19,8 @@
 //! in depth for reparse-point kinds `is_symlink()` might not classify as a
 //! symlink — callers should treat any doubt as "skip".
 
+pub mod export_dest;
+
 use std::fs::{self, Metadata};
 use std::io;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Summary

- A log or audit export now refuses to overwrite an existing file, so an export
  aimed at a file you already have returns an error instead of replacing it.
- An export destination must be an absolute path inside an existing directory.
  A symlink at the destination, a symlink in the parent path, and a Windows
  device name such as `CON.json` are all refused.
- Both export commands share one destination validator, so the two sinks can no
  longer drift apart.

## Rejection rules

| Path sent to the export command | Result |
| --- | --- |
| a relative path with `..` segments | refused: not absolute |
| a parent that does not exist | refused: parent missing |
| a parent that exists but is a file | refused: parent not a directory |
| `CON.json`, `NUL.txt` and other device names | refused: reserved name |
| a file that already exists | refused: contents intact |
| a symlink at the destination | refused: link target untouched |
| a symlink as the parent | resolved to its real directory before the write |
| a symlink planted at the temporary path after validation | refused: `create_new` does not follow it |
| a destination created after validation but before the rename | refused when the re-check sees it, see Guarantee |

## Guarantee

Every rule above is checked at one instant. Two of them are decided again
immediately before the `rename`, and the rest hold for the path the validator
resolved.

The destination check and the `rename` are separate syscalls, so a file created
between them is replaced rather than refused. The window is the gap between the
re-check at `crates/fs/pathsafe/src/export_dest.rs:155` and the `rename` at
`:159`, against the whole serialisation and write in the pre-fix code. Closing it
needs an atomic no-replace rename: `RENAME_NOREPLACE` exists on Linux and
`MOVEFILE_REPLACE_EXISTING`'s absence gives it on Windows, with no macOS
equivalent that Rust's standard library exposes.

The temporary file carries no such window. `create_new` is atomic, so a symlink
or file at the temporary path fails the open instead of being followed.

## Overwrite rule

A filesystem mutation must never overwrite silently, and an archive-then-replace
flow needs a reviewable plan record that neither export sink has. An existing
destination is therefore refused and the export returns an error the user sees.

## Remaining exposure

Containment against a library root is absent. The destination comes from a
native save dialog (`apps/desktop/src/app/LogPanel.tsx:147`) and the repository
doesn't declare an export root, so a library-root allowlist would remove the
ability to save a log outside a library. A caller can still create a new file at any
absolute path whose parent exists. That residual exposure and the three ways to
close it are recorded in `astro-plan-7ggju`.

`astro-plan-3v3r.8.36` and the containment half of `astro-plan-3v3r.5.11` assert
containment against a declared root and stay open.

Finding `astro-plan-3v3r.8.20` also claims `log_export` returns
`Result<_, String>` and loses the error code. It returns
`Result<_, ContractError>` at `apps/desktop/src-tauri/src/commands/log.rs:101`;
only the `# Errors` doc comment said otherwise, and this branch corrects it.

## Tests

`crates/fs/pathsafe/src/export_dest.rs` holds one test per rejection rule above,
including a test that pins the replaced `create` plus `rename` sequence as
clobbering, so reverting either sink to it fails. `log_stream` and the
`audit_export` command tests each cover the existing-destination and
relative-path refusals at the sink.

`create_new` refuses a name held by a symlink, and a bare `create` plus `rename`
pair replaces an existing file. Each is asserted as an invariant, because a
scenario version depends on the temporary-name counter that other tests in the
same process advance. Every test in the file passes under `cargo nextest run` (one
process per test) and under `cargo test` (one process per binary), which is what
`cargo llvm-cov` wraps.

## Verification

| Command | Exit |
| --- | --- |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo nextest run --workspace` | 0 (3126 passed, 31 skipped) |
| `cargo fmt --check` | 0 |
| `cd apps/desktop && pnpm lint` | 0 |

## Spec Context

Tracks-Bead: astro-plan-wo2ju
Tracks-Bead: astro-plan-3v3r.8.19
Tracks-Bead: astro-plan-3v3r.8.20
Tracks-Bead: astro-plan-3v3r.5.11
Merge-Bead: astro-plan-ka563

