### PR TITLE
fix: a reported plan lifecycle state is a written one

### DIFF
--- a/crates/app/core/src/plan_apply/apply.rs
+++ b/crates/app/core/src/plan_apply/apply.rs
@@ -245,24 +245,32 @@ pub(super) struct SpawnExecutorParams {
 /// run. Falls back to `segment_counts` if the fetch fails (best-effort,
 /// matching this function's existing `let _ = ...` error-swallowing
 /// elsewhere).
+///
+/// The second element is the plan row's remaining `items_pending`, or `None`
+/// when the row could not be read. `pause_run` persists that count, and there
+/// is no sound way to derive it from `segment_counts` alone: a caller that
+/// needs it must treat `None` as a failed read rather than substitute a guess.
 pub(super) async fn cumulative_counts(
     pool: &SqlitePool,
     plan_id: &str,
     segment_counts: &TerminalCounts,
-) -> TerminalCounts {
+) -> (TerminalCounts, Option<i64>) {
     match plans_repo::get_plan(pool, plan_id, false).await {
-        Ok(row) => TerminalCounts {
-            succeeded: row.items_applied,
-            failed: row.items_failed,
-            skipped: row.items_skipped,
-            cancelled: row.items_cancelled,
-        },
+        Ok(row) => (
+            TerminalCounts {
+                succeeded: row.items_applied,
+                failed: row.items_failed,
+                skipped: row.items_skipped,
+                cancelled: row.items_cancelled,
+            },
+            Some(row.items_pending),
+        ),
         Err(e) => {
             tracing::error!(
                 %plan_id, error=%e,
                 "failed to fetch cumulative plan counters; using segment-local counts"
             );
-            segment_counts.clone()
+            (segment_counts.clone(), None)
         }
     }
 }

--- a/crates/app/core/src/plan_apply/apply.rs
+++ b/crates/app/core/src/plan_apply/apply.rs
@@ -245,32 +245,24 @@ pub(super) struct SpawnExecutorParams {
 /// run. Falls back to `segment_counts` if the fetch fails (best-effort,
 /// matching this function's existing `let _ = ...` error-swallowing
 /// elsewhere).
-///
-/// The second element is the plan row's remaining `items_pending`, or `None`
-/// when the row could not be read. `pause_run` persists that count, and there
-/// is no sound way to derive it from `segment_counts` alone: a caller that
-/// needs it must treat `None` as a failed read rather than substitute a guess.
 pub(super) async fn cumulative_counts(
     pool: &SqlitePool,
     plan_id: &str,
     segment_counts: &TerminalCounts,
-) -> (TerminalCounts, Option<i64>) {
+) -> TerminalCounts {
     match plans_repo::get_plan(pool, plan_id, false).await {
-        Ok(row) => (
-            TerminalCounts {
-                succeeded: row.items_applied,
-                failed: row.items_failed,
-                skipped: row.items_skipped,
-                cancelled: row.items_cancelled,
-            },
-            Some(row.items_pending),
-        ),
+        Ok(row) => TerminalCounts {
+            succeeded: row.items_applied,
+            failed: row.items_failed,
+            skipped: row.items_skipped,
+            cancelled: row.items_cancelled,
+        },
         Err(e) => {
             tracing::error!(
                 %plan_id, error=%e,
                 "failed to fetch cumulative plan counters; using segment-local counts"
             );
-            (segment_counts.clone(), None)
+            segment_counts.clone()
         }
     }
 }

--- a/crates/app/core/src/plan_apply/lifecycle.rs
+++ b/crates/app/core/src/plan_apply/lifecycle.rs
@@ -53,12 +53,19 @@ pub async fn list_crash_interrupted_plans(
 ///
 /// When the plan is `paused` (no live executor), transitions DB state
 /// directly and emits per-item audit rows matching the executor's Cancelled
-/// path (GF-5).
+/// path (GF-5). A cancel is a Tier-1 user decision, so every write in that
+/// branch gates the response: a failed item cancel, orphan sweep, or plan
+/// transition is returned as an error with the plan left `paused` and its items
+/// left `pending`. Each of those writes is idempotent, so the user can cancel
+/// again. Nothing is in flight on this branch, which is what makes refusing
+/// safe: the live-executor branch below signals the cancellation token and the
+/// executor performs the writes (`terminal::handle_cancelled`).
 ///
 /// # Errors
 ///
 /// - `plan.not_found` — plan not found.
 /// - `plan.not_in_apply` — plan is not in applying or paused state.
+/// - `internal.database` — a paused plan's cancel could not be persisted.
 #[expect(
     clippy::cognitive_complexity,
     reason = "plan cancel state machine over plan and run status combinations"
@@ -117,31 +124,26 @@ pub async fn cancel_plan(
                     error = %e,
                     "paused-cancel: list_pending_items failed; retrying once"
                 );
-                apply_repo::list_pending_items(pool, plan_id).await.unwrap_or_default()
+                apply_repo::list_pending_items(pool, plan_id).await.map_err(db_err)?
             }
         };
-        if let Err(e) = apply_repo::batch_cancel_pending_items(pool, plan_id).await {
-            tracing::error!(error = %e, "paused-cancel: batch_cancel_pending_items failed");
-        }
+        let cancelled_count =
+            apply_repo::batch_cancel_pending_items(pool, plan_id).await.map_err(db_err)?;
         for item_id in &pending_ids {
             audit_item_cancelled(pool, bus, &run_id, plan_id, item_id, "pending", &at).await;
         }
 
         // Sweep orphaned applying items (from retry_plan_item during pause).
-        match apply_repo::cancel_orphaned_applying_items(pool, plan_id).await {
-            Ok(orphaned) => {
-                for item_id in &orphaned {
-                    audit_item_cancelled(pool, bus, &run_id, plan_id, item_id, "applying", &at)
-                        .await;
-                }
-            }
-            Err(e) => {
-                tracing::error!(error = %e, "paused-cancel: cancel_orphaned_applying_items failed");
-            }
+        let orphaned =
+            apply_repo::cancel_orphaned_applying_items(pool, plan_id).await.map_err(db_err)?;
+        for item_id in &orphaned {
+            audit_item_cancelled(pool, bus, &run_id, plan_id, item_id, "applying", &at).await;
         }
 
+        let cancelled_total = cancelled_count + i64::try_from(orphaned.len()).unwrap_or(i64::MAX);
+
         // Transition plan state to cancelled (TIER-1 durability write).
-        if let Err(e) = apply_repo::complete_run(
+        apply_repo::complete_run(
             pool,
             plan_id,
             &run_id,
@@ -149,18 +151,16 @@ pub async fn cancel_plan(
             plan_row.items_applied,
             plan_row.items_failed,
             plan_row.items_skipped,
-            plan_row.items_pending + plan_row.items_cancelled,
+            plan_row.items_cancelled + cancelled_total,
         )
         .await
-        {
-            return Err(db_err(e));
-        }
+        .map_err(db_err)?;
 
         return Ok(PlanCancelResponse {
             plan_id: plan_id.to_owned(),
             cancelled_at: at,
             items_applied: plan_row.items_applied,
-            items_cancelled: plan_row.items_pending,
+            items_cancelled: cancelled_total,
         });
     }
 
@@ -514,16 +514,19 @@ pub async fn resume_plan(
 
 /// Skip a pending item within an active apply (US4, T039).
 ///
-/// The item must be `pending` and the plan must be `applying`.
-/// The skip is registered in the in-memory SkipSet; the executor picks it
-/// up before starting the next item.
+/// The item must be `pending` and the plan must be `applying`. The item row is
+/// transitioned to `skipped` and the id is registered in the in-memory SkipSet,
+/// which is what stops the live executor before it starts that item.
 ///
 /// # Errors
 ///
 /// - `plan.not_found` — plan not found.
 /// - `plan.not_in_apply` — plan is not applying.
 /// - `item.not_found` — item not found.
-/// - `item.not_pending` — item is not in pending state.
+/// - `item.not_pending` — item is not in pending state, including a race where
+///   the executor reached it between the check and the write.
+/// - `internal.database` — the skip could not be persisted, so the item is left
+///   `pending` and eligible to run.
 pub async fn skip_plan_item(
     pool: &SqlitePool,
     plan_id: &str,
@@ -566,8 +569,15 @@ pub async fn skip_plan_item(
     // GF-29: Require a live ActiveRun before injecting the skip — mirrors
     // retry_plan_item's guard. Without this, a skip against a plan whose run
     // already finished fabricates new_state=skipped with nothing to execute it.
-    let registry = active_runs();
-    let run_ref = registry.get(plan_id).ok_or_else(|| {
+    // The SkipSet handle is cloned out so no registry guard is held across the
+    // write below.
+    let skip_set = {
+        let registry = active_runs();
+        let handle = registry.get(plan_id).map(|run| run.skip_set.clone());
+        drop(registry);
+        handle
+    }
+    .ok_or_else(|| {
         ContractError::new(
             ErrorCode::RunNotFound,
             format!("no active run found for plan {plan_id}; the run may have already finished"),
@@ -575,9 +585,24 @@ pub async fn skip_plan_item(
             false,
         )
     })?;
-    run_ref.skip_set.insert(item_id);
-    drop(run_ref);
-    drop(registry);
+
+    // Commit the skip before the item stops being eligible to run. The
+    // SkipSet is what stops the live executor, but it is process memory that
+    // `resume_plan` rebuilds empty, so a pause or a crash between here and the
+    // executor reaching the item would otherwise put a deliberately skipped
+    // destructive item back on the forward pass. `resume_plan` and the
+    // executor's forward loop both treat a `skipped` row as terminal.
+    let persisted = apply_repo::skip_pending_item(pool, plan_id, item_id).await.map_err(db_err)?;
+    if !persisted {
+        return Err(ContractError::new(
+            ErrorCode::ItemNotPending,
+            format!("item {item_id} is no longer pending; it was not skipped"),
+            ErrorSeverity::Blocking,
+            false,
+        ));
+    }
+
+    skip_set.insert(item_id);
 
     Ok(PlanItemSkipResponse { item_id: item_id.to_owned(), new_state: "skipped".to_owned() })
 }

--- a/crates/app/core/src/plan_apply/terminal.rs
+++ b/crates/app/core/src/plan_apply/terminal.rs
@@ -18,6 +18,43 @@ use super::{
 
 use super::apply::cumulative_counts;
 
+/// Surface a terminal-state write that did not commit, in place of the state it
+/// would have announced.
+///
+/// The plan row keeps whatever state the failed transaction left, so the run
+/// stays `applying` and `sweep_crashed_applying_plans` with
+/// `list_crash_interrupted_plans` claim it at the next boot. Callers must return
+/// after this instead of publishing the intended state.
+fn report_unwritten_state(
+    plan_id: &str,
+    run_id: &str,
+    intended_state: &str,
+    reason: Option<&str>,
+    error: &str,
+    op_emitter: Option<&OpEventEmitter>,
+    at: &str,
+) {
+    tracing::error!(
+        plan_id, run_id, intended_state, pause_reason = reason, %error,
+        "a terminal plan state was not persisted; the plan row is left for boot recovery"
+    );
+    if let Some(emitter) = op_emitter.as_ref() {
+        let handle = emitter.handle(OperationStatus::Failed);
+        emitter.emit(
+            OperationEventType::Failed,
+            json!({
+                "handle": handle,
+                "planId": plan_id,
+                "runId": run_id,
+                "intendedState": intended_state,
+                "pauseReason": reason,
+                "error": error,
+                "at": at,
+            }),
+        );
+    }
+}
+
 /// Handle `ApplyOutcome::Completed`: finalize origin-specific side-effects,
 /// persist the terminal state, emit audit + bus + long-op events.
 #[expect(
@@ -53,7 +90,7 @@ pub(super) async fn handle_completed(
         }
     }
 
-    let (counts, _) = cumulative_counts(pool, plan_id, &counts).await;
+    let counts = cumulative_counts(pool, plan_id, &counts).await;
     let terminal = counts.terminal_state(false).to_owned();
 
     // Origin-specific lifecycle side-effects (only on clean terminals).
@@ -106,7 +143,7 @@ pub(super) async fn handle_completed(
         }
     }
 
-    let _ = apply_repo::complete_run(
+    if let Err(e) = apply_repo::complete_run(
         pool,
         plan_id,
         run_id,
@@ -116,7 +153,11 @@ pub(super) async fn handle_completed(
         counts.skipped,
         counts.cancelled,
     )
-    .await;
+    .await
+    {
+        report_unwritten_state(plan_id, run_id, &terminal, None, &e.to_string(), op_emitter, &at);
+        return;
+    }
 
     let _ = apply_repo::append_event(
         pool,
@@ -203,9 +244,9 @@ pub(super) async fn handle_cancelled(
     }
 
     // Fetch cumulative counters AFTER batch-cancel so cancelled items are counted.
-    let (counts, _) = cumulative_counts(pool, plan_id, &counts).await;
+    let counts = cumulative_counts(pool, plan_id, &counts).await;
 
-    let _ = apply_repo::complete_run(
+    if let Err(e) = apply_repo::complete_run(
         pool,
         plan_id,
         run_id,
@@ -215,7 +256,11 @@ pub(super) async fn handle_cancelled(
         counts.skipped,
         counts.cancelled,
     )
-    .await;
+    .await
+    {
+        report_unwritten_state(plan_id, run_id, "cancelled", None, &e.to_string(), op_emitter, &at);
+        return;
+    }
 
     let _ = apply_repo::append_event(
         pool,
@@ -286,47 +331,50 @@ pub(super) async fn handle_paused(
     counts: TerminalCounts,
 ) {
     let at = Timestamp::now_iso();
-    let (counts, pending) = cumulative_counts(pool, plan_id, &counts).await;
+    let counts = cumulative_counts(pool, plan_id, &counts).await;
 
-    let write_failure = match pending {
-        // `pause_run`'s last argument is the count of items still to run, the
-        // complement of the settled counters above.
-        Some(items_pending) => apply_repo::pause_run(
-            pool,
-            plan_id,
-            run_id,
-            reason,
-            counts.succeeded,
-            counts.failed,
-            counts.skipped,
-            counts.cancelled,
-            items_pending,
-        )
-        .await
-        .err()
-        .map(|e| e.to_string()),
-        None => Some("the plan's item counters could not be read".to_owned()),
+    // `pause_run`'s last argument is the count of items still to run. It comes
+    // from the item rows rather than `plans.items_pending`, which lags a skip
+    // the run never reached (`skip_pending_item`) and would inflate this
+    // Tier-1 record by one item per such skip.
+    let items_pending = match apply_repo::list_pending_items(pool, plan_id).await {
+        Ok(ids) => i64::try_from(ids.len()).unwrap_or(i64::MAX),
+        Err(e) => {
+            report_unwritten_state(
+                plan_id,
+                run_id,
+                "paused",
+                Some(reason),
+                &e.to_string(),
+                op_emitter,
+                &at,
+            );
+            return;
+        }
     };
 
-    if let Some(error) = write_failure {
-        tracing::error!(
-            plan_id, run_id, pause_reason = reason, %error,
-            "the pause was not persisted; the plan stays 'applying' for boot recovery"
+    if let Err(e) = apply_repo::pause_run(
+        pool,
+        plan_id,
+        run_id,
+        reason,
+        counts.succeeded,
+        counts.failed,
+        counts.skipped,
+        counts.cancelled,
+        items_pending,
+    )
+    .await
+    {
+        report_unwritten_state(
+            plan_id,
+            run_id,
+            "paused",
+            Some(reason),
+            &e.to_string(),
+            op_emitter,
+            &at,
         );
-        if let Some(emitter) = op_emitter.as_ref() {
-            let handle = emitter.handle(OperationStatus::Failed);
-            emitter.emit(
-                OperationEventType::Failed,
-                json!({
-                    "handle": handle,
-                    "planId": plan_id,
-                    "runId": run_id,
-                    "pauseReason": reason,
-                    "error": error,
-                    "at": at,
-                }),
-            );
-        }
         return;
     }
 

--- a/crates/app/core/src/plan_apply/terminal.rs
+++ b/crates/app/core/src/plan_apply/terminal.rs
@@ -53,7 +53,7 @@ pub(super) async fn handle_completed(
         }
     }
 
-    let counts = cumulative_counts(pool, plan_id, &counts).await;
+    let (counts, _) = cumulative_counts(pool, plan_id, &counts).await;
     let terminal = counts.terminal_state(false).to_owned();
 
     // Origin-specific lifecycle side-effects (only on clean terminals).
@@ -203,7 +203,7 @@ pub(super) async fn handle_cancelled(
     }
 
     // Fetch cumulative counters AFTER batch-cancel so cancelled items are counted.
-    let counts = cumulative_counts(pool, plan_id, &counts).await;
+    let (counts, _) = cumulative_counts(pool, plan_id, &counts).await;
 
     let _ = apply_repo::complete_run(
         pool,
@@ -268,6 +268,14 @@ pub(super) async fn handle_cancelled(
 }
 
 /// Handle `ApplyOutcome::Paused`: persist pause state, emit events.
+///
+/// The pause row is a Tier-1 record: `pause_reason` is what
+/// `revalidate_pause_condition` re-checks on resume, and a boot sweep can only
+/// re-derive the generic `crash` reason. So the paused events are emitted only
+/// after `pause_run` commits. When the write fails the plan row stays
+/// `applying`, which `sweep_crashed_applying_plans` and
+/// `list_crash_interrupted_plans` classify at the next boot, and the long-op
+/// event carries the failure instead of a pause.
 pub(super) async fn handle_paused(
     pool: &SqlitePool,
     bus: &EventBus,
@@ -278,20 +286,49 @@ pub(super) async fn handle_paused(
     counts: TerminalCounts,
 ) {
     let at = Timestamp::now_iso();
-    let counts = cumulative_counts(pool, plan_id, &counts).await;
+    let (counts, pending) = cumulative_counts(pool, plan_id, &counts).await;
 
-    let _ = apply_repo::pause_run(
-        pool,
-        plan_id,
-        run_id,
-        reason,
-        counts.succeeded,
-        counts.failed,
-        counts.skipped,
-        counts.cancelled,
-        counts.succeeded + counts.failed + counts.skipped + counts.cancelled,
-    )
-    .await;
+    let write_failure = match pending {
+        // `pause_run`'s last argument is the count of items still to run, the
+        // complement of the settled counters above.
+        Some(items_pending) => apply_repo::pause_run(
+            pool,
+            plan_id,
+            run_id,
+            reason,
+            counts.succeeded,
+            counts.failed,
+            counts.skipped,
+            counts.cancelled,
+            items_pending,
+        )
+        .await
+        .err()
+        .map(|e| e.to_string()),
+        None => Some("the plan's item counters could not be read".to_owned()),
+    };
+
+    if let Some(error) = write_failure {
+        tracing::error!(
+            plan_id, run_id, pause_reason = reason, %error,
+            "the pause was not persisted; the plan stays 'applying' for boot recovery"
+        );
+        if let Some(emitter) = op_emitter.as_ref() {
+            let handle = emitter.handle(OperationStatus::Failed);
+            emitter.emit(
+                OperationEventType::Failed,
+                json!({
+                    "handle": handle,
+                    "planId": plan_id,
+                    "runId": run_id,
+                    "pauseReason": reason,
+                    "error": error,
+                    "at": at,
+                }),
+            );
+        }
+        return;
+    }
 
     let _ = apply_repo::append_event(
         pool,

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -2518,3 +2518,173 @@ async fn a_skip_that_cannot_be_written_is_refused() {
 
     active_runs().remove("p-skip-refuse");
 }
+
+/// A cancelled run whose terminal write fails is not announced as cancelled:
+/// finding .5.17 on the live-executor branch, where `handle_cancelled` performs
+/// the write (review FIX 1).
+#[tokio::test]
+async fn a_cancelled_run_whose_terminal_write_fails_is_not_reported_as_cancelled() {
+    use std::sync::Mutex;
+
+    let (db, bus) = setup().await;
+    insert_approved_plan_with_items(&db, "p-cancel-write", 1).await;
+    apply_repo::cas_approved_to_applying(
+        db.pool(),
+        "p-cancel-write",
+        "run-cancel-write",
+        "test-token",
+        1,
+        1,
+    )
+    .await
+    .unwrap();
+    sqlx::query("DROP TABLE plan_apply_runs").execute(db.pool()).await.unwrap();
+
+    let captured: Arc<Mutex<Vec<OperationEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_store = captured.clone();
+    let sink: OperationEventSink = Arc::new(move |event: OperationEvent| {
+        sink_store.lock().unwrap().push(event);
+    });
+    let emitter = OpEventEmitter::new(OperationId("run-cancel-write".to_owned()), sink);
+
+    terminal::handle_cancelled(
+        db.pool(),
+        &bus,
+        "p-cancel-write",
+        "run-cancel-write",
+        Some(&emitter),
+        TerminalCounts::default(),
+    )
+    .await;
+
+    let events = captured.lock().unwrap().clone();
+    assert_eq!(events.len(), 1, "exactly one long-op event for a failed terminal write");
+    assert_eq!(events[0].event_type, OperationEventType::Failed);
+
+    let state: String = sqlx::query_scalar("SELECT state FROM plans WHERE id = ?")
+        .bind("p-cancel-write")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(state, "applying", "the plan is left for the boot sweep to classify");
+}
+
+/// The same gate on the completed path: a terminal state the plan row denies is
+/// reported as a failure, not as the terminal the run computed.
+#[tokio::test]
+async fn a_completed_run_whose_terminal_write_fails_is_not_reported_as_terminal() {
+    use std::sync::Mutex;
+
+    let (db, bus) = setup().await;
+    insert_approved_plan_with_items(&db, "p-complete-write", 1).await;
+    apply_repo::cas_approved_to_applying(
+        db.pool(),
+        "p-complete-write",
+        "run-complete-write",
+        "test-token",
+        1,
+        1,
+    )
+    .await
+    .unwrap();
+    // The item is flushed succeeded so the computed terminal is `applied`. An
+    // all-zero counter set computes `failed`, which the emitter reports as a
+    // Failed event of its own accord.
+    {
+        let mut conn = db.pool().acquire().await.unwrap();
+        apply_repo::batch_flush_item_states(
+            &mut conn,
+            "p-complete-write",
+            &[apply_repo::BatchItemState {
+                item_id: "p-complete-write-item-0",
+                new_state: "succeeded",
+                failure_reason: None,
+                is_stale: false,
+            }],
+            1,
+            0,
+            0,
+        )
+        .await
+        .unwrap();
+    }
+    sqlx::query("DROP TABLE plan_apply_runs").execute(db.pool()).await.unwrap();
+
+    let captured: Arc<Mutex<Vec<OperationEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_store = captured.clone();
+    let sink: OperationEventSink = Arc::new(move |event: OperationEvent| {
+        sink_store.lock().unwrap().push(event);
+    });
+    let emitter = OpEventEmitter::new(OperationId("run-complete-write".to_owned()), sink);
+
+    terminal::handle_completed(
+        db.pool(),
+        &bus,
+        "p-complete-write",
+        "run-complete-write",
+        "cleanup",
+        None,
+        Some(&emitter),
+        TerminalCounts { succeeded: 1, ..TerminalCounts::default() },
+    )
+    .await;
+
+    let events = captured.lock().unwrap().clone();
+    assert_eq!(events.len(), 1, "exactly one long-op event for a failed terminal write");
+    assert_eq!(events[0].event_type, OperationEventType::Failed);
+
+    let state: String = sqlx::query_scalar("SELECT state FROM plans WHERE id = ?")
+        .bind("p-complete-write")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(state, "applying");
+}
+
+/// The pause record counts the item rows still `pending`, so a skip the run
+/// never reached cannot inflate it through the lagging plan counter
+/// (astro-plan-ajy4v).
+#[tokio::test]
+async fn a_pause_after_a_skip_counts_the_rows_not_the_lagging_plan_counter() {
+    let (db, bus) = setup().await;
+    insert_approved_plan_with_items(&db, "p-pause-skip", 3).await;
+    apply_repo::cas_approved_to_applying(
+        db.pool(),
+        "p-pause-skip",
+        "run-pause-skip",
+        "test-token",
+        3,
+        3,
+    )
+    .await
+    .unwrap();
+    register_fake_active_run("p-pause-skip");
+    skip_plan_item(db.pool(), "p-pause-skip", "p-pause-skip-item-0").await.unwrap();
+
+    let counter: i64 = sqlx::query_scalar("SELECT items_pending FROM plans WHERE id = ?")
+        .bind("p-pause-skip")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(counter, 3, "the plan counter still carries the skipped item");
+
+    terminal::handle_paused(
+        db.pool(),
+        &bus,
+        "p-pause-skip",
+        "run-pause-skip",
+        "disk.full",
+        None,
+        TerminalCounts::default(),
+    )
+    .await;
+
+    let pending: i64 = sqlx::query_scalar("SELECT items_pending FROM plan_apply_runs WHERE id = ?")
+        .bind("run-pause-skip")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(pending, 2, "the skipped item is not part of the work still to run");
+
+    active_runs().remove("p-pause-skip");
+}

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -2297,3 +2297,224 @@ async fn reconcile_crashed_plans_classifies_all_three_verdicts() {
         "ambiguous item is flagged failed for review"
     );
 }
+
+// ── G-RUNSTATE-TRUTH: a reported lifecycle state is a written one ────────────
+
+/// `pause_run`'s last argument is `items_pending`. It received the settled sum
+/// (succeeded + failed + skipped + cancelled), so a pause recorded the count of
+/// items that had finished as the count still to run.
+#[tokio::test]
+async fn a_pause_records_the_items_still_to_run_not_the_settled_ones() {
+    let (db, bus) = setup().await;
+    insert_approved_plan_with_items(&db, "p-pause-count", 3).await;
+    apply_repo::cas_approved_to_applying(
+        db.pool(),
+        "p-pause-count",
+        "run-pause-count",
+        "test-token",
+        3,
+        3,
+    )
+    .await
+    .unwrap();
+    {
+        let mut conn = db.pool().acquire().await.unwrap();
+        apply_repo::batch_flush_item_states(
+            &mut conn,
+            "p-pause-count",
+            &[apply_repo::BatchItemState {
+                item_id: "p-pause-count-item-0",
+                new_state: "succeeded",
+                failure_reason: None,
+                is_stale: false,
+            }],
+            1,
+            0,
+            0,
+        )
+        .await
+        .unwrap();
+    }
+
+    terminal::handle_paused(
+        db.pool(),
+        &bus,
+        "p-pause-count",
+        "run-pause-count",
+        "item.stale",
+        None,
+        TerminalCounts { succeeded: 1, ..TerminalCounts::default() },
+    )
+    .await;
+
+    let pending: i64 = sqlx::query_scalar("SELECT items_pending FROM plan_apply_runs WHERE id = ?")
+        .bind("run-pause-count")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(pending, 2, "1 of 3 items settled, so 2 remain pending");
+
+    let state: String = sqlx::query_scalar("SELECT state FROM plans WHERE id = ?")
+        .bind("p-pause-count")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(state, "paused");
+}
+
+/// A pause whose write fails leaves the plan `applying` for boot recovery, so
+/// the long-op stream carries the failure rather than a pause the row denies.
+#[tokio::test]
+async fn a_pause_that_cannot_be_written_is_not_reported_as_paused() {
+    use std::sync::Mutex;
+
+    let (db, bus) = setup().await;
+    insert_approved_plan_with_items(&db, "p-pause-fail", 1).await;
+    apply_repo::cas_approved_to_applying(
+        db.pool(),
+        "p-pause-fail",
+        "run-pause-fail",
+        "test-token",
+        1,
+        1,
+    )
+    .await
+    .unwrap();
+    sqlx::query("DROP TABLE plan_apply_runs").execute(db.pool()).await.unwrap();
+
+    let captured: Arc<Mutex<Vec<OperationEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let sink_store = captured.clone();
+    let sink: OperationEventSink = Arc::new(move |event: OperationEvent| {
+        sink_store.lock().unwrap().push(event);
+    });
+    let emitter = OpEventEmitter::new(OperationId("run-pause-fail".to_owned()), sink);
+
+    terminal::handle_paused(
+        db.pool(),
+        &bus,
+        "p-pause-fail",
+        "run-pause-fail",
+        "disk.full",
+        Some(&emitter),
+        TerminalCounts::default(),
+    )
+    .await;
+
+    let events = captured.lock().unwrap().clone();
+    assert_eq!(events.len(), 1, "exactly one long-op event for a failed pause");
+    assert_eq!(events[0].event_type, OperationEventType::Failed);
+
+    let state: String = sqlx::query_scalar("SELECT state FROM plans WHERE id = ?")
+        .bind("p-pause-fail")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(state, "applying", "the plan is left for the boot sweep to classify");
+}
+
+/// Cancelling a paused plan whose item write fails is refused. The plan stays
+/// `paused` with its items `pending` instead of reporting a cancellation the
+/// items contradict.
+#[tokio::test]
+async fn a_paused_cancel_whose_item_write_fails_is_refused() {
+    let (db, bus) = setup().await;
+    insert_approved_plan_with_items(&db, "p-cancel-refuse", 2).await;
+    apply_repo::cas_approved_to_applying(
+        db.pool(),
+        "p-cancel-refuse",
+        "run-cancel-refuse",
+        "test-token",
+        2,
+        2,
+    )
+    .await
+    .unwrap();
+    apply_repo::pause_run(
+        db.pool(),
+        "p-cancel-refuse",
+        "run-cancel-refuse",
+        "disk.full",
+        0,
+        0,
+        0,
+        0,
+        2,
+    )
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE TRIGGER block_item_cancel BEFORE UPDATE OF item_state ON plan_items \
+         WHEN NEW.item_state = 'cancelled' BEGIN SELECT RAISE(ABORT, 'write refused'); END",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let err = cancel_plan(db.pool(), &bus, "p-cancel-refuse").await.unwrap_err();
+    assert_eq!(err.code, ErrorCode::InternalDatabase);
+
+    let state: String = sqlx::query_scalar("SELECT state FROM plans WHERE id = ?")
+        .bind("p-cancel-refuse")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(state, "paused", "a refused cancel leaves the plan cancellable again");
+
+    let pending = apply_repo::list_pending_items(db.pool(), "p-cancel-refuse").await.unwrap();
+    assert_eq!(pending.len(), 2, "both items are still pending");
+}
+
+/// The user's skip is committed before the item stops being eligible to run, so
+/// a pause or crash cannot put a deliberately skipped item back on the forward
+/// pass (`resume_plan` re-reads `pending`/`failed` rows only).
+#[tokio::test]
+async fn a_skip_is_persisted_before_the_item_is_bypassed() {
+    let (db, _bus) = setup().await;
+    insert_approved_plan_with_items(&db, "p-skip-persist", 2).await;
+    plans_repo::update_plan_state(db.pool(), "p-skip-persist", "applying").await.unwrap();
+    register_fake_active_run("p-skip-persist");
+
+    let resp = skip_plan_item(db.pool(), "p-skip-persist", "p-skip-persist-item-0").await.unwrap();
+    assert_eq!(resp.new_state, "skipped");
+
+    let state: String = sqlx::query_scalar("SELECT item_state FROM plan_items WHERE id = ?")
+        .bind("p-skip-persist-item-0")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(state, "skipped", "the reported state is the stored state");
+
+    let pending = apply_repo::list_pending_items(db.pool(), "p-skip-persist").await.unwrap();
+    assert_eq!(pending, vec!["p-skip-persist-item-1".to_owned()]);
+
+    active_runs().remove("p-skip-persist");
+}
+
+/// A skip whose write fails is refused with the item left `pending`, rather
+/// than answered `skipped` from an in-memory set the next resume discards.
+#[tokio::test]
+async fn a_skip_that_cannot_be_written_is_refused() {
+    let (db, _bus) = setup().await;
+    insert_approved_plan_with_items(&db, "p-skip-refuse", 1).await;
+    plans_repo::update_plan_state(db.pool(), "p-skip-refuse", "applying").await.unwrap();
+    register_fake_active_run("p-skip-refuse");
+    sqlx::query(
+        "CREATE TRIGGER block_item_skip BEFORE UPDATE OF item_state ON plan_items \
+         WHEN NEW.item_state = 'skipped' BEGIN SELECT RAISE(ABORT, 'write refused'); END",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let err = skip_plan_item(db.pool(), "p-skip-refuse", "p-skip-refuse-item-0").await.unwrap_err();
+    assert_eq!(err.code, ErrorCode::InternalDatabase);
+
+    let state: String = sqlx::query_scalar("SELECT item_state FROM plan_items WHERE id = ?")
+        .bind("p-skip-refuse-item-0")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(state, "pending", "a refused skip leaves the item eligible to run");
+
+    active_runs().remove("p-skip-refuse");
+}

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -450,11 +450,16 @@ pub async fn list_pending_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Ve
 /// Record a user's skip of one still-`pending` item, returning `false` when the
 /// row was no longer `pending`.
 ///
-/// Plan counters are deliberately untouched: the executor's skip branch emits
-/// the item's terminal progress event, and `batch_flush_item_states` applies the
-/// `items_skipped` / `items_pending` delta for it. That flush is not gated on
-/// the prior item state, so it stays correct over a row already reading
-/// `skipped` and the delta lands exactly once.
+/// Plan counters are deliberately untouched, and they can lag this row. The
+/// live executor's skip branch emits the item's terminal progress event, and
+/// `batch_flush_item_states` applies the `items_skipped` / `items_pending` delta
+/// then, at most once, since that flush is not gated on the prior item state.
+/// A run that pauses or ends before reaching the item never emits that event,
+/// and `resume_plan` rebuilds its item set from `pending` and `failed` rows
+/// only, so the delta is never applied for such a skip: `plans.items_skipped`
+/// understates and `plans.items_pending` overstates by one item each time
+/// (astro-plan-ajy4v). A caller that needs the count of items still to run must
+/// derive it from the item rows, as `terminal::handle_paused` does.
 ///
 /// # Errors
 ///

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -447,6 +447,30 @@ pub async fn list_pending_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Ve
     Ok(ids)
 }
 
+/// Record a user's skip of one still-`pending` item, returning `false` when the
+/// row was no longer `pending`.
+///
+/// Plan counters are deliberately untouched: the executor's skip branch emits
+/// the item's terminal progress event, and `batch_flush_item_states` applies the
+/// `items_skipped` / `items_pending` delta for it. That flush is not gated on
+/// the prior item state, so it stays correct over a row already reading
+/// `skipped` and the delta lands exactly once.
+///
+/// # Errors
+///
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
+pub async fn skip_pending_item(pool: &SqlitePool, plan_id: &str, item_id: &str) -> DbResult<bool> {
+    let rows = sqlx::query(
+        "UPDATE plan_items SET item_state = 'skipped' \
+         WHERE id = ? AND plan_id = ? AND item_state = 'pending'",
+    )
+    .bind(item_id)
+    .bind(plan_id)
+    .execute(pool)
+    .await?;
+    Ok(rows.rows_affected() == 1)
+}
+
 /// Batch-transition all `pending` items to `cancelled`; update plan counters.
 ///
 /// # Errors


### PR DESCRIPTION
## What changed for the user

| Situation | Before | After |
| --- | --- | --- |
| A run pauses and the pause write fails | the app reported the plan paused, and the plan row stayed `applying` | the long-op stream carries a failure, and the boot recovery prompt claims the `applying` row |
| A paused run pauses successfully | the run row recorded the number of finished items as the number still to run | the run row records the items still to run |
| Cancelling a paused plan whose item write fails | the app reported the items cancelled and flipped the plan to `cancelled` with those items still `pending` | the cancel is refused, the plan stays `paused`, and the user can cancel again |
| Cancelling a paused plan that succeeds | `itemsCancelled` came from a plan row read before any write | `itemsCancelled` counts the rows cancelled plus the orphaned `applying` items swept |
| A run reaches a terminal state and the write fails | the app announced the terminal state the run computed, with the plan row still `applying` | the long-op stream carries a failure and no terminal state is announced |
| Skipping an item, then pausing or crashing | the skip existed only in process memory, so the item was executed on the next pass | the skipped row is durable and the next pass treats it as terminal |

## The decision

A pause, a cancel, and a per-item skip are Tier-1 records: none can be
re-derived from the filesystem, so the write precedes the claim.

| Action | Tier | Not re-derivable because |
| --- | --- | --- |
| pause | 1 | `pause_reason` is what `revalidate_pause_condition` re-checks on resume; a boot sweep can only supply the generic `crash` reason |
| cancel | 1 | it is the user's lifecycle decision for the run |
| skip | 1 | it is the user's override on one item, and `plan.item.skip` promises `pending` to `skipped` |

### A cancel that cannot be persisted

The refusal applies only to the branch where nothing is in flight. `cancel_plan`
splits on whether an `ActiveRun` is registered:

- Paused plan, no executor: the cancel is refused with the database error. The
  plan stays `paused`, its items stay `pending`, and each write in the branch is
  idempotent, so the cost is one retry.
- Live executor: the cancellation token is signalled and
  `terminal::handle_cancelled` performs the writes. The run is mid-flight there,
  so that branch is not refused. Its announcement is gated instead: a failed
  `complete_run` emits a long-op failure rather than a cancelled terminal, and
  the plan row keeps the state the failed transaction left.

## Findings

- `astro-plan-3v3r.5.16`: `handle_paused` passed the settled item sum as
  `pause_run`'s `items_pending` argument and discarded the result with `let _`.
- `astro-plan-3v3r.5.17`: `cancel_plan`'s paused branch logged a failed
  `batch_cancel_pending_items` and continued to `complete_run`.
- `astro-plan-3v3r.5.21`: `skip_plan_item` recorded the skip only in the
  in-process `SkipSet`, which `resume_plan` rebuilds empty.

## Tests

Each test fails on the parent commit, exercising the failed-write path:

| Test | Pins |
| --- | --- |
| `a_pause_records_the_items_still_to_run_not_the_settled_ones` | `.5.16` counter argument |
| `a_pause_that_cannot_be_written_is_not_reported_as_paused` | `.5.16` discarded result |
| `a_paused_cancel_whose_item_write_fails_is_refused` | `.5.17` |
| `a_skip_is_persisted_before_the_item_is_bypassed` | `.5.21` durability |
| `a_skip_that_cannot_be_written_is_refused` | `.5.21` failed write |
| `a_cancelled_run_whose_terminal_write_fails_is_not_reported_as_cancelled` | `.5.17` on the live-executor branch |
| `a_completed_run_whose_terminal_write_fails_is_not_reported_as_terminal` | the same gate on the completed path |
| `a_pause_after_a_skip_counts_the_rows_not_the_lagging_plan_counter` | the pause record counts item rows |

The failed-write cancel and skip tests install a SQLite `BEFORE UPDATE`
trigger that aborts the state write, which fails one repository call while
leaving the surrounding reads working.

## Verification

| Command | Result |
| --- | --- |
| `cargo clippy --workspace --all-targets -- -D warnings` | exit 0 |
| `cargo nextest run --workspace` | exit 0, 3113 passed, 31 skipped |
| `cargo fmt --check` | exit 0 |

## Beads

Work bead: `astro-plan-4z2dm`. Merge bead: `astro-plan-qyp2s`. Follow-up:
`astro-plan-ajy4v` records that `plans.items_skipped` and `plans.items_pending`
lag a skip the run never reaches, since the executor flush that carries the delta
never runs for it. `terminal::handle_paused` counts the item rows instead of that
counter, so the pause record is exact.

Tracks-Bead: astro-plan-4z2dm
Tracks-Bead: astro-plan-3v3r.5.16
Tracks-Bead: astro-plan-3v3r.5.17
Tracks-Bead: astro-plan-3v3r.5.21
Merge-Bead: astro-plan-qyp2s


