### PR TITLE
fix: refuse project paths and plan destinations outside the chosen folder

### DIFF
--- a/crates/app/core/src/plan_apply/apply.rs
+++ b/crates/app/core/src/plan_apply/apply.rs
@@ -99,9 +99,18 @@ pub async fn apply_plan(
         }
     }
 
+    let plan_destination_root: Option<Utf8PathBuf> =
+        plan_row.destination_root.as_deref().map(Utf8PathBuf::from);
     let executor_items: Vec<ExecutorItem> = item_rows
         .iter()
-        .map(|r| item_row_to_executor_item(r, &root_map, &plan_row.destructive_destination))
+        .map(|r| {
+            item_row_to_executor_item(
+                r,
+                &root_map,
+                &plan_row.destructive_destination,
+                plan_destination_root.as_deref(),
+            )
+        })
         .collect();
 
     // Overlap check + active-run registration (FR-017, R-Concur-1): the

--- a/crates/app/core/src/plan_apply/lifecycle.rs
+++ b/crates/app/core/src/plan_apply/lifecycle.rs
@@ -422,10 +422,19 @@ pub async fn resume_plan(
     // audit record (review fix, resume+retry item-set mismatch).
     // succeeded/skipped/cancelled items are still excluded: they are truly
     // terminal and never eligible for retry.
+    let plan_destination_root: Option<Utf8PathBuf> =
+        plan_row.destination_root.as_deref().map(Utf8PathBuf::from);
     let executor_items: Vec<ExecutorItem> = item_rows
         .iter()
         .filter(|r| matches!(r.item_state.as_str(), "pending" | "failed"))
-        .map(|r| item_row_to_executor_item(r, &root_map, &plan_row.destructive_destination))
+        .map(|r| {
+            item_row_to_executor_item(
+                r,
+                &root_map,
+                &plan_row.destructive_destination,
+                plan_destination_root.as_deref(),
+            )
+        })
         .collect();
 
     // Re-register the ActiveRun (R-Concur-1). A paused run has no registry

--- a/crates/app/core/src/plan_apply/paths.rs
+++ b/crates/app/core/src/plan_apply/paths.rs
@@ -178,7 +178,8 @@ pub(super) fn materialization_from_provenance(
 /// cross-root move joins `to_relative_path` against the *picked* destination
 /// root instead of silently reusing the source root (#765). Precedence:
 /// `to_root_id` → `plan_destination_root` (`plans.destination_root`) →
-/// `library_root`.
+/// `library_root`, and the last step is skipped for an absolute destination,
+/// which belongs to no root the item names.
 ///
 /// `plan_destructive_destination` is the *plan-level* `plans.destructive_destination`
 /// choice ("archive" | "trash"), not a per-item column: both `cleanup_generator`
@@ -247,22 +248,6 @@ pub(super) fn item_row_to_executor_item(
     let library_root: Option<Utf8PathBuf> =
         row.from_root_id.as_deref().and_then(|rid| root_map.get(rid)).cloned();
 
-    // #765: destination_root resolves independently from to_root_id, falling
-    // back to library_root — NOT reusing from_root_id's resolution outright —
-    // so a cross-root move/link/mkdir joins to_relative_path against the
-    // destination root the user actually picked.
-    // astro-plan-d8cyr: `plans.destination_root` outranks the `library_root`
-    // fallback. A source-view item stores an absolute destination with no
-    // `to_root_id`, so falling straight back to the SOURCE root left the
-    // executor gating the destination against a root it never belonged to.
-    let destination_root: Option<Utf8PathBuf> = row
-        .to_root_id
-        .as_deref()
-        .and_then(|rid| root_map.get(rid))
-        .cloned()
-        .or_else(|| plan_destination_root.map(Utf8Path::to_path_buf))
-        .or_else(|| library_root.clone());
-
     // Paths are stored as relative to the library root.
     let source_path = if row.from_relative_path.is_empty() {
         None
@@ -275,6 +260,25 @@ pub(super) fn item_row_to_executor_item(
     } else {
         Some(Utf8PathBuf::from(&row.to_relative_path))
     };
+
+    // #765: destination_root resolves independently from to_root_id, falling
+    // back to library_root — NOT reusing from_root_id's resolution outright —
+    // so a cross-root move/link/mkdir joins to_relative_path against the
+    // destination root the user actually picked.
+    // astro-plan-d8cyr: `plans.destination_root` outranks that fallback, and an
+    // ABSOLUTE destination takes no fallback at all. Source-view generation
+    // stores an absolute destination with `to_root_id=None` and
+    // `from_root_id=Some`, so falling back to the source root would gate such a
+    // destination against a root it never belonged to and refuse every item of
+    // a plan written before migration 0003 with a non-retryable `root_escape`.
+    let destination_is_absolute = destination_path.as_ref().is_some_and(|p| p.is_absolute());
+    let destination_root: Option<Utf8PathBuf> = row
+        .to_root_id
+        .as_deref()
+        .and_then(|rid| root_map.get(rid))
+        .cloned()
+        .or_else(|| plan_destination_root.map(Utf8Path::to_path_buf))
+        .or_else(|| if destination_is_absolute { None } else { library_root.clone() });
 
     let is_protected = row.protection == "protected";
 

--- a/crates/app/core/src/plan_apply/paths.rs
+++ b/crates/app/core/src/plan_apply/paths.rs
@@ -174,11 +174,11 @@ pub(super) fn materialization_from_provenance(
 /// `from_root_id` or id absent from the map), `library_root` is `None` and
 /// the gate is skipped (legacy/test mode).
 ///
-/// `destination_root` is resolved independently from `to_root_id` (falling
-/// back to `library_root` when `to_root_id` is absent or unresolvable, same
-/// as `compute_plan_path_set`'s `to_root` fallback) so a cross-root move
-/// joins `to_relative_path` against the *picked* destination root instead of
-/// silently reusing the source root (#765).
+/// `destination_root` is resolved independently from `to_root_id` so a
+/// cross-root move joins `to_relative_path` against the *picked* destination
+/// root instead of silently reusing the source root (#765). Precedence:
+/// `to_root_id` → `plan_destination_root` (`plans.destination_root`) →
+/// `library_root`.
 ///
 /// `plan_destructive_destination` is the *plan-level* `plans.destructive_destination`
 /// choice ("archive" | "trash"), not a per-item column: both `cleanup_generator`
@@ -191,6 +191,7 @@ pub(super) fn item_row_to_executor_item(
     row: &plans_repo::PlanItemRow,
     root_map: &HashMap<String, Utf8PathBuf>,
     plan_destructive_destination: &str,
+    plan_destination_root: Option<&Utf8Path>,
 ) -> ExecutorItem {
     // DB path columns are stored as `String` (unchanged DB representation,
     // Local-First custody §I). Rust strings are already UTF-8, so building a
@@ -250,11 +251,16 @@ pub(super) fn item_row_to_executor_item(
     // back to library_root — NOT reusing from_root_id's resolution outright —
     // so a cross-root move/link/mkdir joins to_relative_path against the
     // destination root the user actually picked.
+    // astro-plan-d8cyr: `plans.destination_root` outranks the `library_root`
+    // fallback. A source-view item stores an absolute destination with no
+    // `to_root_id`, so falling straight back to the SOURCE root left the
+    // executor gating the destination against a root it never belonged to.
     let destination_root: Option<Utf8PathBuf> = row
         .to_root_id
         .as_deref()
         .and_then(|rid| root_map.get(rid))
         .cloned()
+        .or_else(|| plan_destination_root.map(Utf8Path::to_path_buf))
         .or_else(|| library_root.clone());
 
     // Paths are stored as relative to the library root.

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -1507,6 +1507,59 @@ fn n765_destination_root_falls_back_to_library_root_when_to_root_id_absent() {
     assert_eq!(item.destination_root, Some(Utf8PathBuf::from("/mnt/library")));
 }
 
+/// astro-plan-d8cyr FIX 1: a `source_view_generation` plan row written before
+/// migration 0003 has `to_root_id=None`, `from_root_id=Some` and an ABSOLUTE
+/// `to_relative_path`. Falling back to `library_root` (the SOURCE root) gates
+/// that destination against a root it never belonged to, so every item of the
+/// user's existing plan is refused `root_escape`, which is non-retryable.
+/// `destination_root` must stay `None` so the destination gate is inactive and
+/// the plan applies as it did before the column existed.
+#[test]
+fn absolute_destination_takes_no_library_root_fallback() {
+    let row = plans_repo::PlanItemRow {
+        id: "item-abs-dest".to_owned(),
+        plan_id: "plan-pre-0003".to_owned(),
+        item_index: 1,
+        name: "frame.fits".to_owned(),
+        action: "link".to_owned(),
+        from_root_id: Some("root-001".to_owned()),
+        from_relative_path: "raw/frame.fits".to_owned(),
+        to_root_id: None,
+        to_relative_path: "/mnt/projects/m101/source-views/plan-pre-0003/lights/frame.fits"
+            .to_owned(),
+        reason: "view_generation".to_owned(),
+        protection: "normal".to_owned(),
+        linked_entity: None,
+        item_state: "pending".to_owned(),
+        failure_reason: None,
+        provenance: None,
+        approved_mtime: None,
+        approved_size_bytes: None,
+        archive_path: None,
+        created_at: "2026-06-17T00:00:00Z".to_owned(),
+        source_id: None,
+        category: None,
+        requires_destructive_confirm: Some(0),
+        resolved_pattern: None,
+        destructive_confirmed: 0,
+    };
+
+    let mut root_map = HashMap::new();
+    root_map.insert("root-001".to_owned(), Utf8PathBuf::from("/mnt/library"));
+
+    let item = item_row_to_executor_item(&row, &root_map, "archive", None);
+    assert_eq!(item.library_root, Some(Utf8PathBuf::from("/mnt/library")));
+    assert_eq!(
+        item.destination_root, None,
+        "an absolute destination must not inherit the source root"
+    );
+
+    // The same row in a plan that DOES record its destination root is gated.
+    let recorded = Utf8PathBuf::from("/mnt/projects/m101/source-views/plan-pre-0003");
+    let gated = item_row_to_executor_item(&row, &root_map, "archive", Some(&recorded));
+    assert_eq!(gated.destination_root, Some(recorded));
+}
+
 /// T023a: root-escaping relative path is refused by the gate when library_root is set.
 /// This proves the gate is active on real plan items (not inert).
 #[test]

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -1374,7 +1374,7 @@ fn t023a_library_root_resolved_from_map() {
     let mut root_map = HashMap::new();
     root_map.insert("root-001".to_owned(), Utf8PathBuf::from("/mnt/library"));
 
-    let item = item_row_to_executor_item(&row, &root_map, "archive");
+    let item = item_row_to_executor_item(&row, &root_map, "archive", None);
     assert_eq!(
         item.library_root,
         Some(Utf8PathBuf::from("/mnt/library")),
@@ -1413,7 +1413,7 @@ fn t023a_no_root_id_gives_none_library_root() {
     };
 
     let root_map: HashMap<String, Utf8PathBuf> = HashMap::new();
-    let item = item_row_to_executor_item(&row, &root_map, "archive");
+    let item = item_row_to_executor_item(&row, &root_map, "archive", None);
     assert_eq!(item.library_root, None);
 }
 
@@ -1454,7 +1454,7 @@ fn n765_destination_root_resolves_independently_from_to_root_id() {
     root_map.insert("inbox-root".to_owned(), Utf8PathBuf::from("/mnt/inbox"));
     root_map.insert("lights-root".to_owned(), Utf8PathBuf::from("/mnt/lights/1"));
 
-    let item = item_row_to_executor_item(&row, &root_map, "archive");
+    let item = item_row_to_executor_item(&row, &root_map, "archive", None);
     assert_eq!(
         item.library_root,
         Some(Utf8PathBuf::from("/mnt/inbox")),
@@ -1502,7 +1502,7 @@ fn n765_destination_root_falls_back_to_library_root_when_to_root_id_absent() {
     let mut root_map = HashMap::new();
     root_map.insert("root-001".to_owned(), Utf8PathBuf::from("/mnt/library"));
 
-    let item = item_row_to_executor_item(&row, &root_map, "archive");
+    let item = item_row_to_executor_item(&row, &root_map, "archive", None);
     assert_eq!(item.destination_root, item.library_root);
     assert_eq!(item.destination_root, Some(Utf8PathBuf::from("/mnt/library")));
 }
@@ -1555,7 +1555,7 @@ fn t023a_destructive_confirmed_reads_from_db_column() {
     };
 
     let root_map: HashMap<String, Utf8PathBuf> = HashMap::new();
-    let item = item_row_to_executor_item(&row, &root_map, "archive");
+    let item = item_row_to_executor_item(&row, &root_map, "archive", None);
     assert!(item.destructive_confirmed, "destructive_confirmed=1 in DB must be read as true");
     assert!(item.requires_destructive_confirm, "delete action must require destructive confirm");
 }

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -1507,16 +1507,24 @@ fn n765_destination_root_falls_back_to_library_root_when_to_root_id_absent() {
     assert_eq!(item.destination_root, Some(Utf8PathBuf::from("/mnt/library")));
 }
 
-/// astro-plan-d8cyr FIX 1: a `source_view_generation` plan row written before
-/// migration 0003 has `to_root_id=None`, `from_root_id=Some` and an ABSOLUTE
-/// `to_relative_path`. Falling back to `library_root` (the SOURCE root) gates
-/// that destination against a root it never belonged to, so every item of the
-/// user's existing plan is refused `root_escape`, which is non-retryable.
-/// `destination_root` must stay `None` so the destination gate is inactive and
-/// the plan applies as it did before the column existed.
-#[test]
-fn absolute_destination_takes_no_library_root_fallback() {
-    let row = plans_repo::PlanItemRow {
+/// A path that `Utf8Path::is_absolute` accepts on the platform running the test.
+///
+/// A POSIX literal such as `/mnt/x` is root-relative on Windows, where
+/// absoluteness needs a drive or UNC prefix. Hardcoding one makes an
+/// absolute-destination test silently exercise the relative branch there
+/// (astro-plan-d8cyr round 4: run 32580340909 job 97048640912).
+/// `std::env::temp_dir` is prefixed on every platform and touches no disk,
+/// which keeps these row-mapping tests pure.
+fn absolute_test_path(tail: &str) -> Utf8PathBuf {
+    let base =
+        Utf8PathBuf::from_path_buf(std::env::temp_dir()).expect("temp dir path is UTF-8 in tests");
+    let path = base.join(tail);
+    assert!(path.is_absolute(), "test fixture must be absolute on this platform: {path}");
+    path
+}
+
+fn source_view_item_row(to_relative_path: &str) -> plans_repo::PlanItemRow {
+    plans_repo::PlanItemRow {
         id: "item-abs-dest".to_owned(),
         plan_id: "plan-pre-0003".to_owned(),
         item_index: 1,
@@ -1525,8 +1533,7 @@ fn absolute_destination_takes_no_library_root_fallback() {
         from_root_id: Some("root-001".to_owned()),
         from_relative_path: "raw/frame.fits".to_owned(),
         to_root_id: None,
-        to_relative_path: "/mnt/projects/m101/source-views/plan-pre-0003/lights/frame.fits"
-            .to_owned(),
+        to_relative_path: to_relative_path.to_owned(),
         reason: "view_generation".to_owned(),
         protection: "normal".to_owned(),
         linked_entity: None,
@@ -1542,22 +1549,50 @@ fn absolute_destination_takes_no_library_root_fallback() {
         requires_destructive_confirm: Some(0),
         resolved_pattern: None,
         destructive_confirmed: 0,
-    };
+    }
+}
+
+/// astro-plan-d8cyr FIX 1: a `source_view_generation` plan row written before
+/// migration 0003 has `to_root_id=None`, `from_root_id=Some` and an ABSOLUTE
+/// `to_relative_path`. Falling back to `library_root` (the SOURCE root) gates
+/// that destination against a root it never belonged to, so every item of the
+/// user's existing plan is refused `root_escape`, which is non-retryable.
+/// `destination_root` must stay `None` so the destination gate is inactive and
+/// the plan applies as it did before the column existed.
+#[test]
+fn absolute_destination_takes_no_library_root_fallback() {
+    let view_root = absolute_test_path("projects/m101/source-views/plan-pre-0003");
+    let row = source_view_item_row(view_root.join("lights/frame.fits").as_str());
 
     let mut root_map = HashMap::new();
-    root_map.insert("root-001".to_owned(), Utf8PathBuf::from("/mnt/library"));
+    root_map.insert("root-001".to_owned(), absolute_test_path("library"));
 
     let item = item_row_to_executor_item(&row, &root_map, "archive", None);
-    assert_eq!(item.library_root, Some(Utf8PathBuf::from("/mnt/library")));
+    assert_eq!(item.library_root, Some(absolute_test_path("library")));
     assert_eq!(
         item.destination_root, None,
         "an absolute destination must not inherit the source root"
     );
 
     // The same row in a plan that DOES record its destination root is gated.
-    let recorded = Utf8PathBuf::from("/mnt/projects/m101/source-views/plan-pre-0003");
-    let gated = item_row_to_executor_item(&row, &root_map, "archive", Some(&recorded));
-    assert_eq!(gated.destination_root, Some(recorded));
+    let gated = item_row_to_executor_item(&row, &root_map, "archive", Some(&view_root));
+    assert_eq!(gated.destination_root, Some(view_root));
+}
+
+/// The sibling of the case above: a RELATIVE destination still takes the #765
+/// `library_root` fallback, so the no-fallback rule is scoped to absolute
+/// destinations rather than having disabled the fallback outright. Both cases
+/// run on every platform.
+#[test]
+fn relative_destination_still_takes_library_root_fallback() {
+    let library = absolute_test_path("library");
+    let row = source_view_item_row("archive/frame.fits");
+
+    let mut root_map = HashMap::new();
+    root_map.insert("root-001".to_owned(), library.clone());
+
+    let item = item_row_to_executor_item(&row, &root_map, "archive", None);
+    assert_eq!(item.destination_root, Some(library));
 }
 
 /// T023a: root-escaping relative path is refused by the gate when library_root is set.

--- a/crates/app/projects/src/project_setup/create.rs
+++ b/crates/app/projects/src/project_setup/create.rs
@@ -40,6 +40,8 @@ use super::{
 /// Rules:
 /// - `..` components are rejected (`path.invalid`) — a project path must not
 ///   escape its anchor;
+/// - a path with no `Normal` component is rejected (`path.invalid`) — a
+///   filesystem or device root cannot be a destination root;
 /// - an absolute path is used as-is (validated downstream by containment);
 /// - a relative path is joined onto the registered project folder;
 /// - a relative path with no registered project folder is rejected
@@ -50,6 +52,21 @@ async fn anchor_project_path(pool: &SqlitePool, raw: &str) -> Result<String, Con
 
     if candidate.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
         let message = "Project path must not contain '..' components.";
+        return Err(ContractError::new(
+            ErrorCode::PathInvalid,
+            message,
+            ErrorSeverity::Blocking,
+            false,
+        )
+        .with_field_error(super::field_error("path", ErrorCode::PathInvalid, message)));
+    }
+
+    // A path whose components are only a root and/or a device prefix (`/`,
+    // `C:\`, `\\server\share`) or only `.` names no folder, so downstream
+    // readers would take the filesystem root itself as the project's
+    // destination root and scaffold directly into it.
+    if !candidate.components().any(|c| matches!(c, std::path::Component::Normal(_))) {
+        let message = "Project path must name a folder, not a filesystem or device root.";
         return Err(ContractError::new(
             ErrorCode::PathInvalid,
             message,

--- a/crates/app/projects/src/project_setup/tests.rs
+++ b/crates/app/projects/src/project_setup/tests.rs
@@ -249,6 +249,23 @@ async fn create_parent_dir_components_rejected() {
     assert_eq!(err.field_errors[0].code, "path.invalid");
 }
 
+/// astro-plan-3v3r.9.12: an accepted `/` becomes the source-view destination
+/// root, so scaffolding and generated links land directly under the filesystem
+/// root.
+#[tokio::test]
+async fn create_filesystem_root_path_rejected() {
+    let (pool, bus) = setup().await;
+    for path in [abs("/"), ".".to_owned()] {
+        let req = ProjectCreateRequest {
+            path: path.clone(),
+            ..make_create_req("Root Attempt", ProjectTool::PixInsight)
+        };
+        let err = create(&pool, &bus, &empty_cache(), &req).await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::PathInvalid, "path {path} must be refused");
+        assert_eq!(err.field_errors[0].field, "path");
+    }
+}
+
 #[tokio::test]
 async fn create_project_empty_name_rejected() {
     let (pool, bus) = setup().await;

--- a/crates/app/projects/src/source_view_generate/generate.rs
+++ b/crates/app/projects/src/source_view_generate/generate.rs
@@ -549,6 +549,12 @@ async fn persist_plan(
     .await
     .map_err(|e| db_internal_ctx(e, "insert source view generation plan"))?;
 
+    // Item destinations below are stored absolute with no `to_root_id`, so the
+    // executor's destination gate takes its containment root from here.
+    plans_repo::set_destination_root(pool, plan_id, destination_root.as_str())
+        .await
+        .map_err(|e| db_internal_ctx(e, "record source view generation destination root"))?;
+
     // Mkdir actions for each distinct destination directory.
     let mut item_index: i64 = 0;
     let mut mkdir_dirs: BTreeSet<Utf8PathBuf> = BTreeSet::new();

--- a/crates/fs/executor/src/ops/path_gate.rs
+++ b/crates/fs/executor/src/ops/path_gate.rs
@@ -38,6 +38,10 @@ impl ResolvedPath {
 
 /// Resolve `relative` against `root` and validate the result.
 ///
+/// `relative` may already be absolute (source-view plan items store an absolute
+/// destination); joining it onto `root` yields the path itself, so containment
+/// is decided by the same root-prefix check.
+///
 /// Returns `Ok(ResolvedPath)` when the path:
 /// - resolves under `root` (no escape via `..`)
 /// - contains no symlink or junction component
@@ -69,11 +73,17 @@ pub fn resolve_and_validate(
     }
 
     // Step 3: per-component lstat for symlinks/junctions.
-    // Walk each component of the relative portion only (the root itself may
-    // legitimately be a symlink at the mount level — we do not follow further).
-    let relative_components: Utf8PathBuf = relative.components().collect();
+    // Walk the normalized path's portion below the root only (the root itself
+    // may legitimately be a symlink at the mount level — we do not follow
+    // further). Taking it from `normalized` rather than from `relative` keeps
+    // the walk anchored when `relative` is already absolute: pushing its root
+    // component onto `current` would otherwise restart the walk at `/` and
+    // refuse every ancestor symlink above the root (`/var` on macOS).
+    // Cannot fail: the root-prefix check above already ran. An empty walk is
+    // the conservative answer rather than a panic inside a safety gate.
+    let below_root = normalized.strip_prefix(root).unwrap_or_else(|_| Utf8Path::new(""));
     let mut current = root.to_path_buf();
-    for component in relative_components.components() {
+    for component in below_root.components() {
         current.push(component);
         // If the path doesn't exist yet (e.g. new destination dir), stop checking —
         // there can be no symlink for a non-existent path component.
@@ -242,5 +252,32 @@ mod tests {
         let err = result.unwrap_err();
         assert_eq!(err.code, FailureCode::SymlinkComponent);
         assert!(err.message.contains("symlink"));
+    }
+
+    /// astro-plan-d8cyr: source-view plan items store an absolute destination,
+    /// and the symlink walk must stay below the root. Walking the absolute path
+    /// from `/` refuses any ancestor symlink above the root, which on macOS is
+    /// every temp dir (`/var` -> `private/var`).
+    #[test]
+    fn resolve_and_validate_absolute_path_under_root_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = utf8_root(dir.path());
+        let absolute = root.join("views/frame.fits");
+
+        let resolved = resolve_and_validate(&root, &absolute).expect("absolute path under root");
+        assert_eq!(resolved.as_path(), absolute);
+    }
+
+    #[test]
+    fn resolve_and_validate_absolute_path_outside_root_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = utf8_root(dir.path());
+        let outside = Utf8PathBuf::from_path_buf(
+            dir.path().parent().expect("temp parent").join("outside.fits"),
+        )
+        .expect("temp dir path is UTF-8");
+
+        let err = resolve_and_validate(&root, &outside).unwrap_err();
+        assert_eq!(err.code, FailureCode::RootEscape);
     }
 }

--- a/crates/fs/executor/src/run/loop_.rs
+++ b/crates/fs/executor/src/run/loop_.rs
@@ -147,6 +147,28 @@ async fn drive_plan<C: ExecutorCallbacks>(
     ApplyOutcome::Completed(counts)
 }
 
+/// Path-resolution gate (FR-001/002, D8, T018): resolve and validate both sides
+/// of an item against the roots `dispatch::execute_item` joins them onto, before
+/// any filesystem CAS or mutation.
+///
+/// The destination side (astro-plan-d8cyr) is checked against the same root
+/// precedence `dispatch::execute_item` uses, so a refusal here means the
+/// mutation would have landed outside the root the plan declared. Gating the
+/// source alone left a traversing or absolute destination to reach
+/// `mkdir`/`link`/`move` unchecked. A side with no root stays ungated, which is
+/// the legacy mode for items carrying pre-resolved absolute paths.
+fn gate_item_paths(item: &ExecutorItem) -> Result<(), PlanItemFailure> {
+    if let (Some(src_rel), Some(root)) = (&item.source_path, &item.library_root) {
+        path_gate::resolve_and_validate(root, src_rel)?;
+    }
+    if let (Some(dst_rel), Some(root)) =
+        (&item.destination_path, item.destination_root.as_ref().or(item.library_root.as_ref()))
+    {
+        path_gate::resolve_and_validate(root, dst_rel)?;
+    }
+    Ok(())
+}
+
 /// Outcome of one retry-queue drain pass.
 enum DrainOutcome {
     Continue,
@@ -386,32 +408,23 @@ async fn process_single_item<C: ExecutorCallbacks>(
         callbacks.on_item_start(&item.id).await;
     }
 
-    // Path-resolution gate (FR-001/002, D8, T018): resolve + validate source path
-    // against the library root before any filesystem CAS or mutation.
-    if let (Some(ref src_rel), Some(ref root)) = (&item.source_path, &item.library_root) {
-        match path_gate::resolve_and_validate(root, src_rel) {
-            Err(gate_failure) => {
-                let audit_reason = gate_failure.code.as_str().to_owned();
-                let triggers_pause = gate_failure.code.triggers_pause();
-                callbacks
-                    .on_item_progress(ItemProgressEvent::terminal(
-                        item.id.clone(),
-                        "applying",
-                        "refused",
-                        Some(gate_failure),
-                        Some(audit_reason),
-                    ))
-                    .await;
-                counts.failed += 1;
-                if triggers_pause {
-                    return ItemOutcome::Pause("path.invalid".to_owned());
-                }
-                return ItemOutcome::Continue;
-            }
-            Ok(_resolved) => {
-                // Path is safe; the resolved absolute path will be used by execute_item.
-            }
+    if let Err(gate_failure) = gate_item_paths(item) {
+        let audit_reason = gate_failure.code.as_str().to_owned();
+        let triggers_pause = gate_failure.code.triggers_pause();
+        callbacks
+            .on_item_progress(ItemProgressEvent::terminal(
+                item.id.clone(),
+                "applying",
+                "refused",
+                Some(gate_failure),
+                Some(audit_reason),
+            ))
+            .await;
+        counts.failed += 1;
+        if triggers_pause {
+            return ItemOutcome::Pause("path.invalid".to_owned());
         }
+        return ItemOutcome::Continue;
     }
 
     // Per-item FS CAS revalidation (R-FS-1).

--- a/crates/fs/executor/src/run/loop_.rs
+++ b/crates/fs/executor/src/run/loop_.rs
@@ -151,19 +151,18 @@ async fn drive_plan<C: ExecutorCallbacks>(
 /// of an item against the roots `dispatch::execute_item` joins them onto, before
 /// any filesystem CAS or mutation.
 ///
-/// The destination side (astro-plan-d8cyr) is checked against the same root
-/// precedence `dispatch::execute_item` uses, so a refusal here means the
-/// mutation would have landed outside the root the plan declared. Gating the
-/// source alone left a traversing or absolute destination to reach
-/// `mkdir`/`link`/`move` unchecked. A side with no root stays ungated, which is
+/// The destination side (astro-plan-d8cyr) is checked against
+/// `destination_root` alone. Gating the source alone left a traversing or
+/// absolute destination to reach `mkdir`/`link`/`move` unchecked. Falling back
+/// to `library_root` here would put a second fallback behind the one in
+/// `app_core::plan_apply::paths`, and the two would disagree about which root
+/// governs an absolute destination. A side with no root stays ungated, which is
 /// the legacy mode for items carrying pre-resolved absolute paths.
 fn gate_item_paths(item: &ExecutorItem) -> Result<(), PlanItemFailure> {
     if let (Some(src_rel), Some(root)) = (&item.source_path, &item.library_root) {
         path_gate::resolve_and_validate(root, src_rel)?;
     }
-    if let (Some(dst_rel), Some(root)) =
-        (&item.destination_path, item.destination_root.as_ref().or(item.library_root.as_ref()))
-    {
+    if let (Some(dst_rel), Some(root)) = (&item.destination_path, &item.destination_root) {
         path_gate::resolve_and_validate(root, dst_rel)?;
     }
     Ok(())

--- a/crates/fs/executor/src/run/tests.rs
+++ b/crates/fs/executor/src/run/tests.rs
@@ -88,6 +88,88 @@ async fn happy_path_all_succeed() {
     assert!(!src.exists());
 }
 
+/// astro-plan-3v3r.9.29: the source gate cannot see a destination that escapes
+/// its own root, so this is the last line of defence -- it must refuse even
+/// when handed an escaping destination directly, with layers 1 and 2 bypassed.
+#[tokio::test]
+async fn destination_outside_destination_root_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = utf8(dir.path());
+    let view_root = root.join("source-views/plan-1");
+    std::fs::create_dir_all(&view_root).unwrap();
+    let src = view_root.join("frame.fits");
+    std::fs::write(&src, b"data").unwrap();
+    let escaping = Utf8PathBuf::from("../../../outside.fits");
+
+    let mut item = make_move_item("item-1", Utf8Path::new("frame.fits"), &escaping);
+    item.library_root = Some(view_root.clone());
+    item.destination_root = Some(view_root.clone());
+
+    let callbacks = FakeCallbacks::default();
+    let outcome = execute_plan(
+        vec![item],
+        &callbacks,
+        &CancellationToken::new(),
+        &SkipSet::new(),
+        &RetryQueue::new(),
+    )
+    .await;
+
+    let events = callbacks.events.lock().await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].new_state, "refused");
+    assert_eq!(
+        events[0].failure.as_ref().map(|f| f.code),
+        Some(crate::failure::FailureCode::RootEscape)
+    );
+    drop(events);
+
+    match outcome {
+        ApplyOutcome::Completed(counts) => assert_eq!(counts.failed, 1),
+        other => panic!("expected Completed, got {other:?}"),
+    }
+    assert!(src.exists(), "the source must be untouched");
+    assert!(!root.join("outside.fits").exists());
+    assert!(!dir.path().parent().unwrap().join("outside.fits").exists());
+}
+
+/// The destination root outranks the source root: a source-view item joins its
+/// destination against the picked root, not the root its frames came from.
+#[tokio::test]
+async fn destination_under_destination_root_is_allowed() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = utf8(dir.path());
+    let source_root = root.join("library");
+    let view_root = root.join("views");
+    std::fs::create_dir_all(&source_root).unwrap();
+    std::fs::create_dir_all(&view_root).unwrap();
+    std::fs::write(source_root.join("frame.fits"), b"data").unwrap();
+
+    let mut item =
+        make_move_item("item-1", Utf8Path::new("frame.fits"), Utf8Path::new("lights/frame.fits"));
+    item.library_root = Some(source_root);
+    item.destination_root = Some(view_root.clone());
+
+    let callbacks = FakeCallbacks::default();
+    let outcome = execute_plan(
+        vec![item],
+        &callbacks,
+        &CancellationToken::new(),
+        &SkipSet::new(),
+        &RetryQueue::new(),
+    )
+    .await;
+
+    let events = callbacks.events.lock().await;
+    assert_eq!(events[0].new_state, "succeeded", "failure: {:?}", events[0].failure);
+    drop(events);
+    match outcome {
+        ApplyOutcome::Completed(counts) => assert_eq!(counts.succeeded, 1),
+        other => panic!("expected Completed, got {other:?}"),
+    }
+    assert!(view_root.join("lights/frame.fits").exists());
+}
+
 #[tokio::test]
 async fn item_in_failed_state_is_skipped_by_executor() {
     let item = ExecutorItem {

--- a/crates/patterns/src/resolver.rs
+++ b/crates/patterns/src/resolver.rs
@@ -178,35 +178,8 @@ pub fn resolve(
     // 3. Assemble relative path.
     let relative_path: String = parts.concat();
 
-    // 4a. Traversal guard on assembled path: check each `/`-delimited segment.
-    for segment in relative_path.split('/') {
-        if segment == ".." || segment == "." {
-            return Err(ResolveError::PathTraversal { segment: segment.to_owned() });
-        }
-    }
-
-    // 4b. Per-segment byte-length check and reserved-name check.
-    for segment in relative_path.split('/') {
-        if segment.is_empty() {
-            continue; // Leading/trailing slash produces empty segments — skip.
-        }
-        let byte_len = segment.len();
-        if byte_len > config.max_segment_bytes() {
-            return Err(ResolveError::PathTooLong {
-                resolved_length: relative_path.chars().count(),
-                segment_length_bytes: byte_len,
-            });
-        }
-    }
-
-    // 4c. Total length check.
-    let total_chars = relative_path.chars().count();
-    if total_chars > config.max_path_chars() {
-        return Err(ResolveError::PathTooLong {
-            resolved_length: total_chars,
-            segment_length_bytes: 0,
-        });
-    }
+    // 4. Traversal guard and length caps on the assembled path.
+    check_assembled_path(&relative_path, config)?;
 
     Ok(ResolveResult { relative_path, missing_tokens, warnings: validation.warnings })
 }
@@ -295,10 +268,26 @@ fn resolve_pattern_str_with(
 
     let relative_path = segments.join("/");
 
-    // Length caps — identical policy to resolve().
+    check_assembled_path(&relative_path, config)?;
+
+    Ok(ResolveResult { relative_path, missing_tokens, warnings: Vec::new() })
+}
+
+/// Traversal guard and length caps applied to an assembled relative path.
+///
+/// Per-piece sanitization cannot see traversal that only appears once the
+/// pieces are joined: a segment of `{filter}.` whose token value sanitizes to
+/// `.` assembles to `..`. Both resolvers therefore re-check the assembled
+/// string, and they must apply the same policy -- a resolver that skips this
+/// hands its caller a destination that escapes the root it was resolved
+/// against.
+fn check_assembled_path(relative_path: &str, config: &ResolverConfig) -> Result<(), ResolveError> {
     for segment in relative_path.split('/') {
+        if segment == ".." || segment == "." {
+            return Err(ResolveError::PathTraversal { segment: segment.to_owned() });
+        }
         if segment.is_empty() {
-            continue;
+            continue; // Leading/trailing slash produces empty segments — skip.
         }
         let byte_len = segment.len();
         if byte_len > config.max_segment_bytes() {
@@ -308,6 +297,7 @@ fn resolve_pattern_str_with(
             });
         }
     }
+
     let total_chars = relative_path.chars().count();
     if total_chars > config.max_path_chars() {
         return Err(ResolveError::PathTooLong {
@@ -316,7 +306,7 @@ fn resolve_pattern_str_with(
         });
     }
 
-    Ok(ResolveResult { relative_path, missing_tokens, warnings: Vec::new() })
+    Ok(())
 }
 
 /// Resolve one `/`-delimited segment that may interleave `{token}` placeholders
@@ -837,6 +827,28 @@ mod tests {
         let bundle = meta(&[]);
         let err = resolve_pattern_str("masters/./x/", &bundle).unwrap_err();
         assert!(matches!(err, ResolveError::PathTraversal { .. }));
+    }
+
+    /// astro-plan-3v3r.9.10: `sanitize_token_value` leaves `/` alone by design
+    /// (`safe-filename` defers separators to the resolver), so a token value
+    /// carrying `../` only fails on the assembled-path check that `resolve`
+    /// always had and `resolve_pattern_str` skipped.
+    #[test]
+    fn pattern_str_token_value_traversal_rejected() {
+        let bundle = meta(&[("filter", "Ha/../../etc")]);
+        let err = resolve_pattern_str("flats/{filter}/", &bundle).unwrap_err();
+        assert!(matches!(err, ResolveError::PathTraversal { .. }));
+    }
+
+    /// The same value through `resolve`, pinning that both resolvers now answer
+    /// alike -- the defect was the divergence.
+    #[test]
+    fn assembled_traversal_rejected_alike_by_both_resolvers() {
+        let bundle = meta(&[("filter", "Ha/../../etc")]);
+        let via_parts = resolve_v1(&[tok("f", "filter")], &bundle).unwrap_err();
+        let via_pattern_str = resolve_pattern_str("{filter}", &bundle).unwrap_err();
+        assert!(matches!(via_parts, ResolveError::PathTraversal { .. }));
+        assert!(matches!(via_pattern_str, ResolveError::PathTraversal { .. }));
     }
 
     #[test]

--- a/crates/persistence/core/migrations/0003_plans_destination_root.sql
+++ b/crates/persistence/core/migrations/0003_plans_destination_root.sql
@@ -1,0 +1,7 @@
+-- Absolute destination root a plan's items must resolve under.
+--
+-- Source-view generation stores an absolute `plan_items.to_relative_path` with
+-- `to_root_id` NULL, so the executor had no root to contain the destination
+-- against and fell back to the item's SOURCE root. NULL keeps the destination
+-- gate inactive for plans that predate the column.
+ALTER TABLE "plans" ADD COLUMN destination_root TEXT;

--- a/crates/persistence/plans/src/repositories/plans.rs
+++ b/crates/persistence/plans/src/repositories/plans.rs
@@ -41,6 +41,11 @@ pub struct PlanRow {
     pub approved_at: Option<String>,
     pub discarded_at: Option<String>,
     pub created_at: String,
+    /// Absolute root every item destination in this plan must resolve under
+    /// (migration 0003). `None` leaves the executor's destination gate
+    /// inactive, which is the behaviour for every plan type that does not set
+    /// it.
+    pub destination_root: Option<String>,
 }
 
 /// Flat row returned from the `plan_items` table.
@@ -346,6 +351,30 @@ pub async fn confirm_plan_destructive_items(pool: &SqlitePool, plan_id: &str) ->
     .execute(pool)
     .await?;
     Ok(result.rows_affected())
+}
+
+/// Record the absolute destination root every item in `plan_id` must resolve
+/// under (migration 0003).
+///
+/// # Errors
+///
+/// Returns [`persistence_core::DbError::NotFound`] if no plan with `plan_id`
+/// exists, or [`persistence_core::DbError::Database`] on connection failure.
+pub async fn set_destination_root(
+    pool: &SqlitePool,
+    plan_id: &str,
+    destination_root: &str,
+) -> DbResult<()> {
+    let rows = sqlx::query("UPDATE plans SET destination_root = ? WHERE id = ?")
+        .bind(destination_root)
+        .bind(plan_id)
+        .execute(pool)
+        .await?
+        .rows_affected();
+    if rows == 0 {
+        return Err(persistence_core::DbError::NotFound(format!("plan {plan_id}")));
+    }
+    Ok(())
 }
 
 /// Update the plan state.


### PR DESCRIPTION
## Summary

- A project path of `/` was accepted at project creation, became the source-view
  destination root, and scaffolding plus generated links resolved directly under
  the filesystem root. Project creation now refuses any path that names no
  folder, which covers every filesystem and device root.
- A frame filter or exposure value containing `../` produced a plan-item
  destination outside the view root. Pattern resolution now applies the same
  traversal check on both of its entry points.
- Plan apply now validates the destination as well as the source before it
  mutates anything, so a destination outside the root the plan declared is
  refused with `root_escape` instead of applied.

## Detail

Three guards, each sufficient on its own.

| Layer | Location | Refusal |
| --- | --- | --- |
| Project path | `crates/app/projects/src/project_setup/create.rs:47` | A path with no `Normal` component fails with `path.invalid`. |
| Pattern resolution | `crates/patterns/src/resolver.rs` | `check_assembled_path` is the one implementation both `resolve` and `resolve_pattern_str` run; a `..` segment in the assembled path fails with `path.traversal`. |
| Plan apply | `crates/fs/executor/src/run/loop_.rs` | `gate_item_paths` validates the destination against the root `dispatch::execute_item` joins it onto. |

`safe-filename` leaves `/` inside a token value on purpose and defers separators
to the resolver (`crates/safe-filename/src/lib.rs:102`). Only `resolve` acted on
that; `resolve_pattern_str` did not, and it is the entry point the source-view
generator and the Inbox confirm pipeline use.

`plans.destination_root` (migration 0003) records the destination root the
source-view generator already computes. Source-view items store an absolute
destination with no `to_root_id`, so the executor used to fall back to the item's
source root; the recorded root outranks that fallback. A NULL column leaves the
destination gate inactive, so every other plan type applies as before.

`path_gate::resolve_and_validate` walks its symlink check below the root rather
than from the path's own root component, so an absolute destination no longer
trips on ancestor symlinks above the root.

A destination outside the declared root is not a plan the user could have
reviewed, so refusing it at apply time is the constitution II promise rather than
a new policy.

## Tests

| Test | Pins |
| --- | --- |
| `create_filesystem_root_path_rejected` | astro-plan-3v3r.9.12 |
| `pattern_str_token_value_traversal_rejected`, `assembled_traversal_rejected_alike_by_both_resolvers` | astro-plan-3v3r.9.10 |
| `destination_outside_destination_root_is_refused`, `destination_under_destination_root_is_allowed` | astro-plan-3v3r.9.29 |
| `resolve_and_validate_absolute_path_under_root_ok`, `resolve_and_validate_absolute_path_outside_root_refused` | the gate's absolute-path handling |

`cargo clippy --workspace --all-targets -- -D warnings`, `cargo nextest run
--workspace` (3112 passed, 31 skipped), and `cargo fmt --check` each exit 0. No
file under `apps/desktop` changed.

Tracks-Bead: astro-plan-d8cyr
Tracks-Bead: astro-plan-3v3r.9.29
Tracks-Bead: astro-plan-3v3r.9.12
Tracks-Bead: astro-plan-3v3r.9.10
Merge-Bead: astro-plan-wgrd4
