### PR TITLE
test: pin the calibration soft-dimension tolerance guards against NaN and negative deltas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,6 +854,7 @@ dependencies = [
 name = "calibration_core"
 version = "0.1.0"
 dependencies = [
+ "proptest",
  "serde",
  "serde_json",
  "skymath 0.7.2",

--- a/crates/calibration/core/Cargo.toml
+++ b/crates/calibration/core/Cargo.toml
@@ -17,5 +17,8 @@ skymath = "0.7.2"
 # observing-night proximity (replaces the hand-rolled YMD parse + JDN math).
 time = { workspace = true }
 
+[dev-dependencies]
+proptest.workspace = true
+
 [lints]
 workspace = true

--- a/crates/calibration/core/tests/proptest_soft_penalty.rs
+++ b/crates/calibration/core/tests/proptest_soft_penalty.rs
@@ -1,0 +1,75 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Proptest invariant suite for `SoftDimConfig::penalty`.
+//!
+//! A `Some(_)` return is recorded by the rule evaluators as a MATCHED soft
+//! dimension and its value is subtracted from confidence, so both the domain of
+//! `Some` and the range of the penalty are correctness-bearing.
+
+use calibration_core::ranking::SoftDimConfig;
+use proptest::prelude::*;
+
+/// Deltas and configs spanning negatives, zero, subnormals, infinities, and
+/// NaN — `proptest::num::f64::ANY` excludes the non-finite cases that the
+/// guards exist for.
+fn any_f64() -> impl Strategy<Value = f64> {
+    prop_oneof![
+        9 => proptest::num::f64::NORMAL,
+        1 => prop_oneof![
+            Just(f64::NAN),
+            Just(f64::INFINITY),
+            Just(f64::NEG_INFINITY),
+            Just(0.0_f64),
+            Just(-0.0_f64),
+            Just(f64::MIN_POSITIVE),
+        ],
+    ]
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(1024))]
+
+    /// A penalty is a deduction. A negative return value would add confidence
+    /// to a master that deviates from the session more than an exact match
+    /// does, letting it outrank the exact match.
+    #[test]
+    fn negative_delta_never_yields_a_confidence_increase(
+        delta in any_f64().prop_filter("negative", |d| d.is_nan() || *d < 0.0),
+        tolerance in any_f64(),
+        max_penalty in any_f64(),
+    ) {
+        let config = SoftDimConfig::new(tolerance, max_penalty);
+        prop_assert_eq!(config.penalty(delta), None);
+    }
+
+    /// Every returned penalty is a real number in `0.0..=1.0`, whatever the
+    /// user-configured tolerance and `max_penalty` are.
+    #[test]
+    fn any_delta_respects_the_penalty_bound(
+        delta in any_f64(),
+        tolerance in any_f64(),
+        max_penalty in any_f64(),
+    ) {
+        let config = SoftDimConfig::new(tolerance, max_penalty);
+        if let Some(penalty) = config.penalty(delta) {
+            prop_assert!(penalty.is_finite(), "penalty {penalty} is not finite");
+            prop_assert!((0.0..=1.0).contains(&penalty), "penalty {penalty} out of bounds");
+        }
+    }
+
+    /// Every comparison against a NaN is false, so an unguarded `delta >
+    /// tolerance` check takes the inside-tolerance branch. A NaN on any of the
+    /// three inputs must yield `None`, never a MATCHED dimension.
+    #[test]
+    fn nan_delta_is_not_treated_as_inside_tolerance(
+        delta in any_f64(),
+        tolerance in any_f64(),
+        max_penalty in any_f64(),
+    ) {
+        if delta.is_nan() || tolerance.is_nan() || max_penalty.is_nan() {
+            let config = SoftDimConfig::new(tolerance, max_penalty);
+            prop_assert_eq!(config.penalty(delta), None);
+        }
+    }
+}

--- a/crates/calibration/core/tests/proptest_soft_penalty.rs
+++ b/crates/calibration/core/tests/proptest_soft_penalty.rs
@@ -6,26 +6,13 @@
 //! A `Some(_)` return is recorded by the rule evaluators as a MATCHED soft
 //! dimension and its value is subtracted from confidence, so both the domain of
 //! `Some` and the range of the penalty are correctness-bearing.
+//!
+//! `f64::ANY` spans POSITIVE|NEGATIVE over NORMAL, SUBNORMAL, ZERO, INFINITE,
+//! and `QUIET_NAN` — every class the guards discriminate.
 
 use calibration_core::ranking::SoftDimConfig;
+use proptest::num::f64::ANY;
 use proptest::prelude::*;
-
-/// Deltas and configs spanning negatives, zero, subnormals, infinities, and
-/// NaN — `proptest::num::f64::ANY` excludes the non-finite cases that the
-/// guards exist for.
-fn any_f64() -> impl Strategy<Value = f64> {
-    prop_oneof![
-        9 => proptest::num::f64::NORMAL,
-        1 => prop_oneof![
-            Just(f64::NAN),
-            Just(f64::INFINITY),
-            Just(f64::NEG_INFINITY),
-            Just(0.0_f64),
-            Just(-0.0_f64),
-            Just(f64::MIN_POSITIVE),
-        ],
-    ]
-}
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(1024))]
@@ -33,11 +20,14 @@ proptest! {
     /// A penalty is a deduction. A negative return value would add confidence
     /// to a master that deviates from the session more than an exact match
     /// does, letting it outrank the exact match.
+    ///
+    /// `-0.0 < 0.0` is false, so a negative zero is not one of the deltas the
+    /// guard rejects and the filter must exclude it.
     #[test]
     fn negative_delta_never_yields_a_confidence_increase(
-        delta in any_f64().prop_filter("negative", |d| d.is_nan() || *d < 0.0),
-        tolerance in any_f64(),
-        max_penalty in any_f64(),
+        delta in ANY.prop_filter("negative or NaN", |d| d.is_nan() || *d < 0.0),
+        tolerance in ANY,
+        max_penalty in ANY,
     ) {
         let config = SoftDimConfig::new(tolerance, max_penalty);
         prop_assert_eq!(config.penalty(delta), None);
@@ -47,9 +37,9 @@ proptest! {
     /// user-configured tolerance and `max_penalty` are.
     #[test]
     fn any_delta_respects_the_penalty_bound(
-        delta in any_f64(),
-        tolerance in any_f64(),
-        max_penalty in any_f64(),
+        delta in ANY,
+        tolerance in ANY,
+        max_penalty in ANY,
     ) {
         let config = SoftDimConfig::new(tolerance, max_penalty);
         if let Some(penalty) = config.penalty(delta) {
@@ -63,9 +53,9 @@ proptest! {
     /// three inputs must yield `None`, never a MATCHED dimension.
     #[test]
     fn nan_delta_is_not_treated_as_inside_tolerance(
-        delta in any_f64(),
-        tolerance in any_f64(),
-        max_penalty in any_f64(),
+        delta in ANY,
+        tolerance in ANY,
+        max_penalty in ANY,
     ) {
         if delta.is_nan() || tolerance.is_nan() || max_penalty.is_nan() {
             let config = SoftDimConfig::new(tolerance, max_penalty);


### PR DESCRIPTION
Merge-Bead: astro-plan-wz2iq
Tracks-Bead: astro-plan-e3yx0
Tracks-Bead: astro-plan-3v3r.2.20
Tracks-Bead: astro-plan-3v3r.2.21

## Summary

Adds `crates/calibration/core/tests/proptest_soft_penalty.rs`: three proptest
properties over `SoftDimConfig::penalty`, and `proptest` as a dev-dependency of
`calibration_core`.

| Property | Invariant |
| --- | --- |
| `negative_delta_never_yields_a_confidence_increase` | a delta below zero, or a NaN, returns `None` |
| `any_delta_respects_the_penalty_bound` | every `Some(p)` has `p` finite and in `0.0..=1.0` |
| `nan_delta_is_not_treated_as_inside_tolerance` | a NaN on `delta`, `tolerance`, or `max_penalty` returns `None` |

No product code changes.

## Why

Findings `astro-plan-3v3r.2.20` and `astro-plan-3v3r.2.21` report that a NaN
delta bypasses the `delta > tolerance` guard and is recorded as a MATCHED soft
dimension, and that a negative delta yields a negative penalty that raises
confidence. Both were already fixed by #1680, which is an ancestor of this
branch's base sha `2aa4a537f`. Nothing pinned them: the fix is three plain `if`
statements guarding a comparison a later reader can fold back.

All three inputs are drawn from `proptest::num::f64::ANY`, which spans
POSITIVE|NEGATIVE over NORMAL, SUBNORMAL, ZERO, INFINITE, and QUIET_NAN.
`tolerance` and `max_penalty` are generated alongside `delta` because
`MatchingRuleConfig` is built from user settings keys with no construction-time
validation, so all three are untrusted inputs on this path.

## Verification

- `cargo test -p calibration_core --test proptest_soft_penalty` — 3 passed.
- `cargo test -p calibration_core` — 126 passed: 122 unit, 3 proptest, 1 doctest
  (`cargo nextest` reports 125, excluding the doctest).
- `cargo clippy -p calibration_core --all-targets -- -D warnings` — no issues.
- `cargo fmt -p calibration_core -- --check` — clean.
- Mutation check, all guards: with the #1680 guards removed from
  `SoftDimConfig::penalty`, all three properties fail. Counterexample
  `delta = NaN, tolerance = 0.00010919226269759501, max_penalty = 1.697e97`
  returns `Some(NaN)`.
- Mutation check, sign guard alone: with only `|| delta < 0.0` removed,
  `negative_delta_never_yields_a_confidence_increase` and
  `any_delta_respects_the_penalty_bound` fail. Counterexample `delta =
  -8.856817147392971e293, tolerance = 0.0, max_penalty = 0.0` returns
  `Some(0.0)` through the tolerance-zero branch.

## Beads

- Work node: `astro-plan-e3yx0`
- Merge bead: `astro-plan-wz2iq`
- Findings: `astro-plan-3v3r.2.20`, `astro-plan-3v3r.2.21`

