### PR TITLE
fix: refuse a path whose link status cannot be determined

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "domain_core",
  "fs_executor",
  "fs_inventory",
+ "fs_pathsafe",
  "hex",
  "patterns",
  "persistence_calibration",

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -180,50 +180,27 @@ fn tool_id_from_project_tool(project_tool: &str) -> String {
 /// Constitution: never follows symlinks/junctions (no per-root opt-in exists
 /// for project output folders in v1) — neither into a symlinked directory
 /// nor as a symlinked file.
-fn real_read_dir(dir: &Path) -> Result<workflow_artifacts::DirListing, String> {
-    let mut listing = workflow_artifacts::DirListing::default();
-    let entries =
-        std::fs::read_dir(dir).map_err(|e| format!("read_dir({}) failed: {e}", dir.display()))?;
-    real_read_dir_into(entries, &mut listing.files, &mut listing.unreadable);
-    Ok(listing)
-}
-
-/// Recursion helper for [`real_read_dir_reporting`]; `files` accumulates real
-/// file paths across the whole subtree and `skipped` the directories whose
-/// `read_dir` failed.
 ///
-/// An unreadable subdirectory is skipped, not propagated: one
-/// permission-denied directory must not abort reconciliation for every
-/// artifact elsewhere under the project root (matches
-/// `fs_pathsafe::real_files_under`). Callers must treat `skipped` as unknown
-/// state, never as absence.
-fn real_read_dir_into(
-    entries: std::fs::ReadDir,
-    files: &mut Vec<PathBuf>,
-    skipped: &mut Vec<PathBuf>,
-) {
-    for entry in entries.flatten() {
-        let Ok(file_type) = entry.file_type() else { continue };
-        if file_type.is_symlink() {
-            continue;
-        }
-        let path = entry.path();
-        if file_type.is_dir() {
-            match std::fs::read_dir(&path) {
-                Ok(child) => real_read_dir_into(child, files, skipped),
-                Err(_) => skipped.push(path),
-            }
-        } else if file_type.is_file() {
-            files.push(path);
-        }
-    }
+/// The walk itself is `fs_pathsafe::real_files_under_reporting`, which is
+/// reparse-aware (a Windows junction is a reparse point `is_symlink()` need
+/// not report) and iterative, so a deep tree cannot exhaust the stack. An
+/// unreadable subdirectory lands in `unreadable` rather than aborting the
+/// walk: one permission-denied directory must not stop reconciliation for
+/// every artifact elsewhere under the project root. Only an unreadable root
+/// is an error, because there the walk yields nothing at all.
+fn real_read_dir(dir: &Path) -> Result<workflow_artifacts::DirListing, String> {
+    fs_pathsafe::probe_root(dir, false)
+        .map_err(|reason| format!("read_dir({}) failed: {reason}", dir.display()))?;
+    let (files, unreadable) = fs_pathsafe::real_files_under_reporting(dir, false);
+    Ok(workflow_artifacts::DirListing { files, unreadable })
 }
 
-/// Real (size, mtime) probe. Uses `symlink_metadata` and rejects symlinks
-/// explicitly — belt-and-suspenders alongside `real_read_dir`'s filter.
+/// Real (size, mtime) probe. Uses `symlink_metadata` and rejects symlinks and
+/// junctions explicitly — belt-and-suspenders alongside `real_read_dir`'s
+/// filter.
 fn real_metadata(path: &Path) -> Option<(u64, std::time::SystemTime)> {
     let meta = std::fs::symlink_metadata(path).ok()?;
-    if meta.file_type().is_symlink() {
+    if fs_pathsafe::is_link_or_junction_metadata(&meta) {
         return None;
     }
     let modified = meta.modified().ok()?;

--- a/crates/app/projects/Cargo.toml
+++ b/crates/app/projects/Cargo.toml
@@ -21,6 +21,7 @@ fs_executor = { path = "../../fs/executor" }
 contracts_core = { path = "../../contracts/core" }
 domain_core = { path = "../../domain/core" }
 fs_inventory = { path = "../../fs/inventory" }
+fs_pathsafe = { path = "../../fs/pathsafe" }
 patterns = { path = "../../patterns" }
 persistence_calibration = { path = "../../persistence/calibration" }
 persistence_core = { path = "../../persistence/core" }

--- a/crates/app/projects/src/source_view_verify.rs
+++ b/crates/app/projects/src/source_view_verify.rs
@@ -116,7 +116,11 @@ fn classify_item(
         return Some(BrokenItemState::Missing);
     };
 
-    let is_symlink = lstat.file_type().is_symlink();
+    // The shared primitive, not `file_type().is_symlink()`: a Windows junction
+    // is a reparse point that `is_symlink()` need not report, and a
+    // misclassified one falls into the copy branch below, whose
+    // `partial_content_probe` opens the path and so reads through the link.
+    let is_symlink = fs_pathsafe::is_link_or_junction_metadata(&lstat);
     let recorded_symlink = item.materialization == "symlink";
 
     if is_symlink {

--- a/crates/fs/executor/src/update_view/install.rs
+++ b/crates/fs/executor/src/update_view/install.rs
@@ -156,9 +156,9 @@ fn resolve_no_follow(
 }
 
 fn open_no_follow(abs: &Utf8PathBuf) -> Result<std::fs::File, InstallError> {
-    let is_symlink =
-        std::fs::symlink_metadata(abs.as_std_path()).is_ok_and(|m| m.file_type().is_symlink());
-    if is_symlink {
+    // The shared primitive, not `file_type().is_symlink()`: a Windows junction
+    // is a reparse point that `is_symlink()` need not report.
+    if fs_pathsafe::is_link_or_junction(abs.as_std_path()) {
         return Err(InstallError {
             code: InstallErrorCode::SourcePathUnsafe,
             message: format!("source is a symlink: {abs}"),
@@ -260,7 +260,7 @@ mod tests {
         let link = src_dir.path().join("link.fits");
 
         // Create a symlink using the platform-appropriate API.
-        // The rejection check uses symlink_metadata().is_symlink() which is
+        // The rejection check is `fs_pathsafe::is_link_or_junction`, which is
         // cross-platform, so the assertion must hold on all three platforms.
         #[cfg(unix)]
         std::os::unix::fs::symlink(&real_file, &link).unwrap();

--- a/crates/fs/inventory/Cargo.toml
+++ b/crates/fs/inventory/Cargo.toml
@@ -19,6 +19,8 @@ tokio = { workspace = true }
 tracing.workspace = true
 
 [dev-dependencies]
+camino = { workspace = true }
+notify = ">=8,<9"
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/crates/fs/inventory/src/notify_bridge.rs
+++ b/crates/fs/inventory/src/notify_bridge.rs
@@ -94,6 +94,26 @@ pub fn register_watch_paths(
             continue;
         }
 
+        // `real_dirs_under` answers with an empty list for a root it refuses,
+        // which would leave the loop below with nothing to do and report
+        // success while watching nothing. Probe first so an unwatchable root is
+        // an error rather than an empty success.
+        //
+        // `GatedLink` is the exception: observing nothing under a symlinked
+        // root while `follow_symlinks` is off is the constitution's gate doing
+        // its job, not a failure, so it is recorded as skipped and the
+        // registration continues.
+        match fs_pathsafe::probe_root(path.as_std_path(), false) {
+            Ok(()) => {}
+            Err(fs_pathsafe::RootUnavailable::GatedLink) => {
+                let reason = fs_pathsafe::RootUnavailable::GatedLink.to_string();
+                tracing::info!(root = %path, "not watching a symlinked root: {reason}");
+                report.skipped.push((path.as_std_path().to_path_buf(), reason));
+                continue;
+            }
+            Err(reason) => return Err(format!("failed to watch {path}: {reason}")),
+        }
+
         let dirs = fs_pathsafe::real_dirs_under(path.as_std_path(), false);
         // Root path (dirs[0]) failure is always fatal — if we cannot watch the
         // root itself, there is nothing useful the watcher can do.

--- a/crates/fs/inventory/tests/watch_registration.rs
+++ b/crates/fs/inventory/tests/watch_registration.rs
@@ -1,0 +1,64 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Watch registration must not report success for a root it never watched
+//! (review round 1 on astro-plan-551nn, FIX 1).
+//!
+//! Kept out of the module's inline test module so both cases can be run against
+//! the pre-fix source with `src/notify_bridge.rs` stashed and the tests in
+//! place.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt as _;
+
+use camino::Utf8PathBuf;
+use fs_inventory::notify_bridge::register_watch_paths;
+
+fn watcher() -> notify::RecommendedWatcher {
+    notify::recommended_watcher(|_: Result<notify::Event, notify::Error>| {}).unwrap()
+}
+
+/// A root the walker refuses yields no directories, so without a probe the
+/// registration loop never runs, the fatal root branch is skipped, and the
+/// caller registers nothing while being told it succeeded.
+#[test]
+fn register_watch_paths_errors_on_an_unstatable_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let locked = dir.path().join("locked");
+    std::fs::create_dir_all(locked.join("root")).unwrap();
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+    let path = Utf8PathBuf::from_path_buf(locked.join("root")).unwrap();
+
+    // root bypasses mode bits, which would make the assertion vacuous.
+    let statable = std::fs::symlink_metadata(path.as_std_path()).is_ok();
+    let result = register_watch_paths(&mut watcher(), &[path], false, false);
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    if statable {
+        eprintln!("skipping: this environment can stat behind a mode-000 directory (root?)");
+        return;
+    }
+    let err = result.expect_err("an unwatchable root must not report success");
+    assert!(err.contains("could not be read"), "unexpected message: {err}");
+}
+
+/// Observing nothing under a symlinked root while `follow_symlinks` is off is
+/// the gate working, so registration succeeds. The root still has to appear in
+/// `skipped`, otherwise zero watched paths is indistinguishable from a root
+/// that was watched and is empty.
+#[test]
+fn register_watch_paths_reports_a_gated_symlinked_root_as_skipped() {
+    let dir = tempfile::tempdir().unwrap();
+    let real = dir.path().join("real");
+    std::fs::create_dir_all(&real).unwrap();
+    let link = dir.path().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    let path = Utf8PathBuf::from_path_buf(link.clone()).unwrap();
+
+    let report = register_watch_paths(&mut watcher(), &[path], false, false)
+        .expect("a gated symlinked root is not a registration failure");
+    assert!(report.watched.is_empty());
+    assert_eq!(report.skipped.len(), 1);
+    assert_eq!(report.skipped[0].0, link);
+}

--- a/crates/fs/pathsafe/src/lib.rs
+++ b/crates/fs/pathsafe/src/lib.rs
@@ -32,13 +32,20 @@ use camino::Utf8Path;
 ///
 /// Uses `symlink_metadata` (not `metadata`) so the check inspects the entry
 /// itself rather than following it — inspecting a link's target would defeat
-/// the purpose of the gate. A path that cannot be stat'd (missing,
-/// permission denied, race) is reported as "not a link" — callers that need
-/// to distinguish a stat failure from "not a link" should stat the path
-/// themselves and call [`is_link_or_junction_metadata`] instead.
+/// the purpose of the gate.
+///
+/// Fails closed. `NotFound` answers `false`, because a path that does not
+/// exist is determinately not a link. Every other stat failure (permission
+/// denied, stale mount, I/O error) answers `true`: the result feeds a refusal
+/// decision, so "cannot determine" must refuse rather than let the caller
+/// descend or traverse. Callers that must distinguish the cases should stat
+/// the path themselves and call [`is_link_or_junction_metadata`].
 #[must_use]
 pub fn is_link_or_junction(path: &Path) -> bool {
-    fs::symlink_metadata(path).is_ok_and(|m| is_link_or_junction_metadata(&m))
+    match fs::symlink_metadata(path) {
+        Ok(meta) => is_link_or_junction_metadata(&meta),
+        Err(e) => e.kind() != io::ErrorKind::NotFound,
+    }
 }
 
 /// Classify already-fetched [`Metadata`] (from `symlink_metadata`, never
@@ -185,15 +192,42 @@ pub fn real_dirs_under(root: &Path, follow_symlinks: bool) -> Vec<PathBuf> {
 /// enumerate on-disk frames without ever following a link (spec 048 R6).
 #[must_use]
 pub fn real_files_under(root: &Path, follow_symlinks: bool) -> Vec<PathBuf> {
+    real_files_under_reporting(root, follow_symlinks).0
+}
+
+/// [`real_files_under`], additionally returning the directories whose
+/// `read_dir` failed.
+///
+/// Both walkers skip an unreadable directory rather than aborting, which makes
+/// "no files here" ambiguous between empty and unreadable. Callers that must
+/// not read a permission-denied subtree as deletion need the second list;
+/// treat it as unknown state, never as absence.
+///
+/// When `follow_symlinks` is on, directories are deduplicated by their
+/// canonical path so a link pointing at an ancestor terminates instead of
+/// re-entering the subtree forever.
+#[must_use]
+pub fn real_files_under_reporting(
+    root: &Path,
+    follow_symlinks: bool,
+) -> (Vec<PathBuf>, Vec<PathBuf>) {
     let mut files = Vec::new();
+    let mut unreadable = Vec::new();
 
     if !follow_symlinks && is_link_or_junction(root) {
-        return files;
+        return (files, unreadable);
     }
 
+    let mut visited = std::collections::HashSet::new();
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
+        if follow_symlinks
+            && !visited.insert(fs::canonicalize(&dir).unwrap_or_else(|_| dir.clone()))
+        {
+            continue;
+        }
         let Ok(entries) = fs::read_dir(&dir) else {
+            unreadable.push(dir);
             continue;
         };
         for entry in entries.flatten() {
@@ -209,7 +243,7 @@ pub fn real_files_under(root: &Path, follow_symlinks: bool) -> Vec<PathBuf> {
         }
     }
 
-    files
+    (files, unreadable)
 }
 
 /// Create a symlink from `source` to `destination`, pointing at a **file**
@@ -321,6 +355,36 @@ mod tests {
         // A link whose target is gone is Missing, not GatedLink, when following.
         std::fs::remove_dir_all(&real).unwrap();
         assert_eq!(probe_root(&link, true), Err(RootUnavailable::Missing));
+    }
+
+    #[test]
+    fn a_missing_path_is_not_a_link() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_link_or_junction(&dir.path().join("absent")));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn real_files_under_reporting_names_the_unreadable_directory() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let locked = dir.path().join("locked");
+        std::fs::create_dir_all(&locked).unwrap();
+        std::fs::write(locked.join("hidden.fits"), b"data").unwrap();
+        std::fs::write(dir.path().join("top.fits"), b"data").unwrap();
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let readable = std::fs::read_dir(&locked).is_ok();
+        let (files, unreadable) = real_files_under_reporting(dir.path(), false);
+        std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        if readable {
+            eprintln!("skipping: this environment can read a mode-000 directory (root?)");
+            return;
+        }
+        assert_eq!(files, vec![dir.path().join("top.fits")]);
+        assert_eq!(unreadable, vec![locked]);
     }
 
     #[test]

--- a/crates/fs/pathsafe/tests/fail_closed.rs
+++ b/crates/fs/pathsafe/tests/fail_closed.rs
@@ -1,0 +1,67 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Containment regressions for the link-detection primitive
+//! (astro-plan-3v3r.1.26, astro-plan-3v3r.1.14).
+//!
+//! Kept out of the crate's inline test module so both cases can be run against
+//! the pre-fix source with the source files stashed and the tests in place.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::{symlink, PermissionsExt as _};
+
+/// An lstat that fails for a reason other than "absent" leaves link-ness
+/// undetermined, and the answer feeds a refusal, so it must refuse.
+#[test]
+fn an_undeterminable_path_is_treated_as_a_link() {
+    let dir = tempfile::tempdir().unwrap();
+    let locked = dir.path().join("locked");
+    std::fs::create_dir_all(&locked).unwrap();
+    let behind = locked.join("frame.fits");
+    std::fs::write(&behind, b"data").unwrap();
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    // root bypasses mode bits, which would make the assertion vacuous.
+    let statable = std::fs::symlink_metadata(&behind).is_ok();
+    let answer = fs_pathsafe::is_link_or_junction(&behind);
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    if statable {
+        eprintln!("skipping: this environment can stat behind a mode-000 directory (root?)");
+        return;
+    }
+    assert!(answer, "an lstat failure that is not NotFound must refuse");
+}
+
+#[test]
+fn a_missing_path_is_not_a_link() {
+    let dir = tempfile::tempdir().unwrap();
+    assert!(!fs_pathsafe::is_link_or_junction(&dir.path().join("absent")));
+}
+
+/// With following enabled the per-entry link skip is off and `is_dir()`
+/// resolves through the link, so an ancestor-pointing link re-enters the same
+/// subtree. Without a visited set the walk never returns, so the assertion is
+/// on a deadline: a non-terminating walk must fail the test rather than hang
+/// the suite. The walker thread is abandoned on timeout; the process reaps it.
+#[test]
+fn a_symlink_cycle_terminates_when_following_is_enabled() {
+    let dir = tempfile::tempdir().unwrap();
+    let deep = dir.path().join("a").join("b").join("c");
+    std::fs::create_dir_all(&deep).unwrap();
+    std::fs::write(deep.join("frame.fits"), b"data").unwrap();
+    symlink(dir.path(), deep.join("loop")).unwrap();
+    symlink(&deep, deep.join("self_loop")).unwrap();
+
+    let root = dir.path().to_path_buf();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(fs_pathsafe::real_files_under(&root, true));
+    });
+
+    let files = rx
+        .recv_timeout(std::time::Duration::from_secs(20))
+        .expect("the cycle-following walk must terminate");
+    assert_eq!(files, vec![deep.join("frame.fits")]);
+}


### PR DESCRIPTION
## What changes

`fs_pathsafe::is_link_or_junction` fails closed. A `symlink_metadata` failure
that is not `NotFound` (permission denied, stale network mount, I/O error)
answers "is a link", so the caller refuses instead of descending or
traversing. `NotFound` answers `false`, because an absent entry is
determinately not a link.

`real_files_under` terminates on a symlink cycle. With `follow_symlinks`
enabled the walk deduplicates directories by canonical path, so a link
pointing at an ancestor stops instead of re-entering the subtree.

Three sites that decided link-ness with `Metadata::file_type().is_symlink()`
call the shared primitive: `fs_executor::update_view::install`,
`app_core_projects::source_view_verify`, and the desktop artifact watcher.

`apps/desktop/src-tauri/src/watcher.rs` drops its own recursive directory
walker for `fs_pathsafe::real_files_under_reporting`, a new variant that also
returns the directories whose `read_dir` failed. `real_files_under` delegates
to it.

## What was undetectable before, and what is refused now

| Situation | Before | Now |
| --- | --- | --- |
| An entry whose `lstat` fails with permission denied | Reported as not a link, so scans descended it and the executor gate traversed it | Reported as a link, so it is skipped or refused |
| A Windows directory junction at an install source, a source-view destination, or a watched artifact path | `is_symlink()` reported `false`, so the install opened it, the verifier content-probed through it, and the watcher listed files behind it | Detected by the reparse-point attribute check and refused |
| A `follow_symlinks` root containing a link to an ancestor | The scan never returned and the result vector grew without bound | The walk terminates |

The cost of failing closed: an unreadable directory now reads as "refuse"
rather than "descend". `fs_pathsafe::probe_root` already reports that case as
`Unreadable`, and `fs_inventory::reconcile` probes before it walks, so no
caller loses a legitimate path.

## Findings already closed

`astro-plan-3v3r.1.13` (the path gate abandoning its per-component link walk)
and `astro-plan-3v3r.1.29` (the chain built on it) are closed by #1705, which
anchored the walk to `normalized.strip_prefix(root)`. The `..` collapse runs
before the walk, so no component can hide behind a missing one. Recorded as
already-fixed, not re-fixed.

## Tests

`crates/fs/pathsafe/tests/fail_closed.rs` covers the indeterminate stat and
the cycle. Run against `55229d8d9` with the source files stashed, the first
fails its assertion and the second times out at 20s. The junction cases stay
covered by the Windows-gated `junction_directory_is_detected_and_skipped` in
`fs_pathsafe`, which now guards all three call sites through delegation.

## Verification

| Gate | Exit |
| --- | --- |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo nextest run --workspace` | 0 (3148 passed, 31 skipped) |
| `cargo fmt --check` | 0 |
| `cd apps/desktop && pnpm lint` | 0 |

Merge-Bead: astro-plan-3fmqq
