### PR TITLE
feat(dev): start the MCP bridge only when PV_MCP_BRIDGE_ENABLE=1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,8 @@ tauri-build = { version = "2.6", features = [] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 # Tauri MCP bridge plugin (@hypothesi). Dev-only surface, an optional dependency
-# of desktop_shell behind its `dev-tools` feature; runs a WebSocket server on
+# of desktop_shell behind its `dev-tools` feature; started only when
+# PV_MCP_BRIDGE_ENABLE=1, then runs a WebSocket server on
 # 127.0.0.1:9223 (PV_MCP_BRIDGE_BIND overrides the address) for the
 # @hypothesi/tauri-mcp-server MCP server. Requires the dev-only tauri.dev.conf.json
 # overlay (withGlobalTauri).

--- a/apps/desktop/src-tauri/src/bootstrap/mod.rs
+++ b/apps/desktop/src-tauri/src/bootstrap/mod.rs
@@ -27,9 +27,34 @@ pub const fn single_instance_guard_enabled(e2e_instance_id_set: bool) -> bool {
     !(cfg!(feature = "e2e") && e2e_instance_id_set)
 }
 
+/// The address the MCP bridge binds, or `None` when it must not start.
+///
+/// Arguments are the raw values of `PV_MCP_BRIDGE_ENABLE` and
+/// `PV_MCP_BRIDGE_BIND`; `None` means unset. The gate is scoped two ways and
+/// both must hold: the binary is built with `dev-tools`, and the enable value is
+/// exactly `1`. Every other value -- `0`, `true`, empty, arbitrary text --
+/// leaves the port closed, so a typo fails closed rather than opening an
+/// unauthenticated control surface.
+///
+/// The default is loopback, not the plugin's own `0.0.0.0`. A blank
+/// `PV_MCP_BRIDGE_BIND` falls back to that default for the same reason.
+///
+/// Compiled only into the builds that can use it and into test builds, so a
+/// release binary carries neither this decision nor the plugin it feeds.
+#[cfg(any(feature = "dev-tools", test))]
+pub fn mcp_bridge_bind_address<'a>(enable: Option<&str>, bind: Option<&'a str>) -> Option<&'a str> {
+    if !cfg!(feature = "dev-tools") || enable != Some("1") {
+        return None;
+    }
+    Some(match bind {
+        Some(addr) if !addr.trim().is_empty() => addr,
+        _ => "127.0.0.1",
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::single_instance_guard_enabled;
+    use super::{mcp_bridge_bind_address, single_instance_guard_enabled};
 
     /// The release-leak regression: without the `e2e` feature compiled in, no
     /// value of `PV_E2E_INSTANCE_ID` may disable the guard.
@@ -47,5 +72,40 @@ mod tests {
     fn e2e_build_bypasses_only_when_marker_is_set() {
         assert!(!single_instance_guard_enabled(true));
         assert!(single_instance_guard_enabled(false));
+    }
+
+    /// The release-leak regression: without `dev-tools` compiled in, no
+    /// combination of the two variables may start the bridge.
+    #[test]
+    #[cfg(not(feature = "dev-tools"))]
+    fn env_vars_alone_cannot_start_the_bridge() {
+        assert_eq!(mcp_bridge_bind_address(Some("1"), None), None);
+        assert_eq!(mcp_bridge_bind_address(Some("1"), Some("0.0.0.0")), None);
+    }
+
+    /// Unset, and every value that is not exactly `1`, leaves the port closed.
+    #[test]
+    #[cfg(feature = "dev-tools")]
+    fn only_the_exact_value_one_starts_the_bridge() {
+        for enable in [None, Some(""), Some("0"), Some("true"), Some("yes"), Some("1 "), Some("01")]
+        {
+            assert_eq!(
+                mcp_bridge_bind_address(enable, None),
+                None,
+                "enable={enable:?} must not start the bridge"
+            );
+        }
+        assert_eq!(mcp_bridge_bind_address(Some("1"), None), Some("127.0.0.1"));
+    }
+
+    /// The bind default is loopback rather than the plugin's `0.0.0.0`, and an
+    /// explicit address (the WSL-client, Windows-host case) is honoured.
+    #[test]
+    #[cfg(feature = "dev-tools")]
+    fn bind_defaults_to_loopback_and_honours_an_explicit_address() {
+        assert_eq!(mcp_bridge_bind_address(Some("1"), None), Some("127.0.0.1"));
+        assert_eq!(mcp_bridge_bind_address(Some("1"), Some("   ")), Some("127.0.0.1"));
+        assert_eq!(mcp_bridge_bind_address(Some("1"), Some("0.0.0.0")), Some("0.0.0.0"));
+        assert_eq!(mcp_bridge_bind_address(Some("1"), Some("192.168.1.20")), Some("192.168.1.20"));
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -104,19 +104,26 @@ fn build_updater_plugin() -> tauri::plugin::TauriPlugin<tauri::Wry, tauri_plugin
 ///    than the plugin's own 0.0.0.0. An off-loopback address opts one run into
 ///    cross-host validation (an agent in WSL or on another machine driving a
 ///    Windows host).
+///
+/// Layers 2 and 3 are decided by [`crate::bootstrap::mcp_bridge_bind_address`],
+/// which is where they are tested; this function only reads the environment and
+/// logs.
 #[cfg(feature = "dev-tools")]
 #[expect(
     clippy::cognitive_complexity,
     reason = "three `tracing` macro expansions, not branching logic"
 )]
 fn build_mcp_bridge_plugin() -> Option<tauri::plugin::TauriPlugin<tauri::Wry>> {
-    if !std::env::var("PV_MCP_BRIDGE_ENABLE").is_ok_and(|v| v == "1") {
+    let enable = std::env::var("PV_MCP_BRIDGE_ENABLE").ok();
+    let bind_var = std::env::var("PV_MCP_BRIDGE_BIND").ok();
+    let Some(bind) =
+        crate::bootstrap::mcp_bridge_bind_address(enable.as_deref(), bind_var.as_deref())
+    else {
         tracing::info!(
             "MCP bridge not started: set PV_MCP_BRIDGE_ENABLE=1 to open the agent-driving port"
         );
         return None;
-    }
-    let bind = std::env::var("PV_MCP_BRIDGE_BIND").unwrap_or_else(|_| "127.0.0.1".to_string());
+    };
     if bind == "127.0.0.1" {
         tracing::info!(bind = %bind, "MCP bridge starting (PV_MCP_BRIDGE_ENABLE=1)");
     } else {
@@ -126,7 +133,7 @@ fn build_mcp_bridge_plugin() -> Option<tauri::plugin::TauriPlugin<tauri::Wry>> {
              reachable from that address"
         );
     }
-    Some(tauri_plugin_mcp_bridge::init_with_config(tauri_plugin_mcp_bridge::Config::new(&bind)))
+    Some(tauri_plugin_mcp_bridge::init_with_config(tauri_plugin_mcp_bridge::Config::new(bind)))
 }
 
 /// Build the Tauri `App` **without** starting the event loop.

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -83,6 +83,52 @@ fn build_updater_plugin() -> tauri::plugin::TauriPlugin<tauri::Wry, tauri_plugin
     b.build()
 }
 
+/// Build the Tauri MCP bridge plugin (@hypothesi tauri-plugin-mcp-bridge), or
+/// `None` when the runtime has not opted in.
+///
+/// The plugin runs a WebSocket server from port 9223 that the
+/// @hypothesi/tauri-mcp-server MCP server connects to, letting an agent drive the
+/// running app for automated UI testing. It also requires `withGlobalTauri`,
+/// enabled only via the dev-only `tauri.dev.conf.json` overlay (never in the
+/// shipped config). The server is unauthenticated and `execute_js` reaches every
+/// command handler, so whatever reaches its address controls the app. Three
+/// layers gate it:
+///
+/// 1. Compiled out of release builds. `dev-tools` gates the optional dependency,
+///    so a release binary does not link the plugin at all (`Cargo.toml`
+///    `dev-tools`, `capabilities/dev/mcp-bridge.json`).
+/// 2. Not started unless `PV_MCP_BRIDGE_ENABLE=1`. `1` is the only value that
+///    starts it; unset, empty, or anything else leaves the port closed even in a
+///    `dev-tools` build.
+/// 3. Bound wherever `PV_MCP_BRIDGE_BIND` says, defaulting to 127.0.0.1 rather
+///    than the plugin's own 0.0.0.0. An off-loopback address opts one run into
+///    cross-host validation (an agent in WSL or on another machine driving a
+///    Windows host).
+#[cfg(feature = "dev-tools")]
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "three `tracing` macro expansions, not branching logic"
+)]
+fn build_mcp_bridge_plugin() -> Option<tauri::plugin::TauriPlugin<tauri::Wry>> {
+    if !std::env::var("PV_MCP_BRIDGE_ENABLE").is_ok_and(|v| v == "1") {
+        tracing::info!(
+            "MCP bridge not started: set PV_MCP_BRIDGE_ENABLE=1 to open the agent-driving port"
+        );
+        return None;
+    }
+    let bind = std::env::var("PV_MCP_BRIDGE_BIND").unwrap_or_else(|_| "127.0.0.1".to_string());
+    if bind == "127.0.0.1" {
+        tracing::info!(bind = %bind, "MCP bridge starting (PV_MCP_BRIDGE_ENABLE=1)");
+    } else {
+        tracing::warn!(
+            bind = %bind,
+            "MCP bridge starting bound off-loopback: unauthenticated control of this app is \
+             reachable from that address"
+        );
+    }
+    Some(tauri_plugin_mcp_bridge::init_with_config(tauri_plugin_mcp_bridge::Config::new(&bind)))
+}
+
 /// Build the Tauri `App` **without** starting the event loop.
 ///
 /// The returned handle exposes the platform path resolver (needed to locate
@@ -225,31 +271,9 @@ pub fn build_app() -> tauri::App {
         // plugin's own (skipped) fern dispatch.
         .plugin(tauri_plugin_log::Builder::new().skip_logger().build());
 
-    // Tauri MCP bridge plugin (@hypothesi tauri-plugin-mcp-bridge) — `dev-tools`
-    // builds only. Runs a WebSocket server from port 9223 that the
-    // @hypothesi/tauri-mcp-server MCP server connects to, letting an agent drive
-    // the running app for automated UI testing. Requires `withGlobalTauri`, which
-    // is enabled only via the dev-only `tauri.dev.conf.json` overlay (never in the
-    // shipped config). The server is unauthenticated and `execute_js` reaches
-    // every command handler, so it binds 127.0.0.1 rather than the plugin's own
-    // 0.0.0.0 default. `PV_MCP_BRIDGE_BIND` opts one run into another address for
-    // cross-host validation (an agent in WSL or on another machine driving a
-    // Windows host); whatever reaches that address controls the app. The feature
-    // also gates the dependency, so release binaries do not link the plugin
-    // (`Cargo.toml` `dev-tools`, `capabilities/dev/mcp-bridge.json`).
     #[cfg(feature = "dev-tools")]
-    {
-        let bind = std::env::var("PV_MCP_BRIDGE_BIND").unwrap_or_else(|_| "127.0.0.1".to_string());
-        if bind != "127.0.0.1" {
-            tracing::warn!(
-                bind = %bind,
-                "MCP bridge bound off-loopback: unauthenticated control of this app is reachable \
-                 from that address"
-            );
-        }
-        tb = tb.plugin(tauri_plugin_mcp_bridge::init_with_config(
-            tauri_plugin_mcp_bridge::Config::new(&bind),
-        ));
+    if let Some(bridge) = build_mcp_bridge_plugin() {
+        tb = tb.plugin(bridge);
     }
 
     // E2E gate: embed the WebDriver server only when built with --features e2e.

--- a/docs/development/mcp-bridge.md
+++ b/docs/development/mcp-bridge.md
@@ -1,0 +1,63 @@
+# MCP bridge
+
+The MCP bridge is a WebSocket server inside the desktop app that lets an agent
+drive the running UI. `@hypothesi/tauri-mcp-server` connects to it and exposes
+tool calls such as `driver_session` and `webview_execute_js`, which is how
+automated journeys and manual validation sessions click through the real app
+against a real backend. It listens on port 9223.
+
+The bridge is compiled only into a build with `--features dev-tools`. Release
+binaries omit that feature, so `tauri-plugin-mcp-bridge` is not linked and the
+code is absent rather than switched off. `scripts/check-dev-surface-absent.sh`
+fails when a default-feature build resolves the plugin crate or a shipped
+capability file grants one of its permissions.
+
+## Turning it on
+
+| Variable | Default | Effect |
+|---|---|---|
+| `PV_MCP_BRIDGE_ENABLE` | unset | `1` starts the bridge. Every other value, including `0`, `true`, and empty, leaves the port closed. |
+| `PV_MCP_BRIDGE_BIND` | `127.0.0.1` | Address the bridge binds. Blank falls back to the default. |
+
+A `dev-tools` build started without `PV_MCP_BRIDGE_ENABLE=1` does not open the
+port, and logs `MCP bridge not started`.
+
+```sh
+cd apps/desktop
+PV_MCP_BRIDGE_ENABLE=1 pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-tools
+```
+
+The `tauri.dev.conf.json` overlay also enables `withGlobalTauri`, which
+`webview_execute_js` needs to reach command handlers.
+
+### Windows host, WSL client
+
+`scripts\win-native-dev.ps1 -McpBridge` launches the same overlay and sets the
+variable:
+
+```powershell
+cd C:\dev\astro-plan
+.\scripts\win-native-dev.ps1 -McpBridge
+```
+
+Under mirrored WSL networking, `localhost` inside WSL reaches Windows loopback,
+so the default bind is enough and the client connects to `localhost:9223`. Under
+NAT networking the client reaches the host through the gateway address, which a
+loopback-bound socket does not accept, so the bind has to widen:
+
+```powershell
+.\scripts\win-native-dev.ps1 -McpBridge -McpBridgeBind 0.0.0.0
+```
+
+## What binding off loopback exposes
+
+The bridge has no authentication, and `webview_execute_js` reaches every command
+handler through `window.__TAURI__.core.invoke`. Anything that can open a socket
+to the bind address therefore has full control of the app and of every library
+the app can write to. `0.0.0.0` accepts connections from every host that can
+route to the machine, so on a shared or untrusted network that is the whole
+network.
+
+Pick the narrowest address the client can actually reach, and prefer switching
+WSL to mirrored networking over widening the bind. The startup log records the
+address, and warns rather than informs when it is not loopback.

--- a/docs/development/windows-native-rust-dev.md
+++ b/docs/development/windows-native-rust-dev.md
@@ -223,8 +223,8 @@ refresh (Ctrl+R). Confirm the binary mtime is newer than the source.
 
 **Connect the MCP bridge.** The bridge needs `--features dev-tools` to be
 compiled in and `PV_MCP_BRIDGE_ENABLE=1` to start; without the variable a
-`dev-tools` build opens no port, and the startup log says `MCP bridge not
-started`. It serves a WebSocket on `127.0.0.1:9223`. `scripts/win-native-dev.ps1
+`dev-tools` build does not open the port, and the startup log says `MCP bridge
+not started`. It serves a WebSocket on `127.0.0.1:9223`. `scripts/win-native-dev.ps1
 -McpBridge` sets the variable. This host runs WSL in mirrored networking, so
 `localhost` reaches Windows loopback directly — connect with `driver_session
 host=localhost port=9223`. The old NAT gateway-IP lookup (`ip route show
@@ -234,6 +234,8 @@ bridge. Anything that reaches that address controls the app without
 authentication. Invoke a command directly with `webview_execute_js` →
 `window.__TAURI__.core.invoke('<snake_command>', {args})` (`ipc_execute_command`
 rejects many real commands but is fine for scripted backend probes).
+[`mcp-bridge.md`](mcp-bridge.md) covers the two variables and what a non-loopback
+bind exposes.
 
 **Native pickers can't be driven.** Relaunch with `VITE_E2E=1` to expose
 `data-testid="e2e-path-input-<kind>"` / `e2e-add-path-btn-<kind>` stand-ins

--- a/docs/development/windows-native-rust-dev.md
+++ b/docs/development/windows-native-rust-dev.md
@@ -221,8 +221,11 @@ Get-ChildItem <changed>.rs | ForEach-Object { $_.LastWriteTime = Get-Date }
 Then relaunch (`tauri dev` recompiles). A frontend-only change needs only a hard
 refresh (Ctrl+R). Confirm the binary mtime is newer than the source.
 
-**Connect the MCP bridge.** The bridge needs `--features dev-tools` and serves a
-WebSocket on `127.0.0.1:9223`. This host runs WSL in mirrored networking, so
+**Connect the MCP bridge.** The bridge needs `--features dev-tools` to be
+compiled in and `PV_MCP_BRIDGE_ENABLE=1` to start; without the variable a
+`dev-tools` build opens no port, and the startup log says `MCP bridge not
+started`. It serves a WebSocket on `127.0.0.1:9223`. `scripts/win-native-dev.ps1
+-McpBridge` sets the variable. This host runs WSL in mirrored networking, so
 `localhost` reaches Windows loopback directly — connect with `driver_session
 host=localhost port=9223`. The old NAT gateway-IP lookup (`ip route show
 default`) is **obsolete** here; under NAT networking, set

--- a/docs/journeys/README.md
+++ b/docs/journeys/README.md
@@ -40,7 +40,8 @@ PlateVault ships as a Tauri v2 desktop app; the only real-app validation path
 today is the Windows build driven through the Tauri MCP bridge from WSL
 (`driver_session host=localhost port=9223`, mirrored WSL networking reaches
 Windows services via `localhost`). The bridge exists only in a build launched
-with `--features dev-tools`, and it binds `127.0.0.1` unless the launch sets
+with `--features dev-tools`, starts only when the launch sets
+`PV_MCP_BRIDGE_ENABLE=1`, and binds `127.0.0.1` unless the launch also sets
 `PV_MCP_BRIDGE_BIND`. `exclusive: true` because only one
 validator can hold the Windows checkout/app process at a time. The
 Vite/mockIPC runtime fakes backend responses and MUST NOT be used to

--- a/e2e-agentic-test/003-first-run-source-setup/restart-first-run/scenario.md
+++ b/e2e-agentic-test/003-first-run-source-setup/restart-first-run/scenario.md
@@ -253,7 +253,8 @@ FAIL if:
   Preconditions step 2).
 - **Tauri MCP bridge** (needed only for Test 5): launch with the dev overlay
   enabled (`cargo tauri dev --config src-tauri\tauri.dev.conf.json
-  --features dev-tools`, WS on `127.0.0.1:9223`, so a gateway connection needs
+  --features dev-tools` plus `PV_MCP_BRIDGE_ENABLE=1`, without which the bridge
+  does not start; WS on `127.0.0.1:9223`, so a gateway connection also needs
   `PV_MCP_BRIDGE_BIND=0.0.0.0` at launch), connect from WSL via
   `driver_session host=<gateway> port=9223` where
   `gateway = ip route show default | awk '{print $3}'`; then use

--- a/e2e-agentic-test/019-bottom-log-viewer/event-source-class/scenario.md
+++ b/e2e-agentic-test/019-bottom-log-viewer/event-source-class/scenario.md
@@ -180,9 +180,10 @@ FAIL if:
 - **DOM inspection without a bridge**: if right-click → Inspect is
   unavailable in the packaged dev window, you likely need the Tauri MCP
   bridge. Launch with `cargo tauri dev --config src-tauri\tauri.dev.conf.json
-  --features dev-tools` and `PV_MCP_BRIDGE_BIND=0.0.0.0` (the feature compiles the
-  bridge in; the variable widens its `127.0.0.1:9223` bind so the gateway address
-  reaches it), connect from WSL via
+  --features dev-tools`, `PV_MCP_BRIDGE_ENABLE=1`, and
+  `PV_MCP_BRIDGE_BIND=0.0.0.0` (the feature compiles the bridge in, the first
+  variable starts it, the second widens its `127.0.0.1:9223` bind so the gateway
+  address reaches it), connect from WSL via
   `driver_session host=<gateway> port=9223` (gateway =
   `ip route show default | awk '{print $3}'`), then use
   `webview_dom_snapshot` or `webview_find_element` targeting

--- a/e2e-agentic-test/035-targets-catalog/list-search-aliases-sort/scenario.md
+++ b/e2e-agentic-test/035-targets-catalog/list-search-aliases-sort/scenario.md
@@ -53,8 +53,8 @@
    files are needed for this scenario.
 4. Connect the Tauri MCP bridge (`driver_session host=<WSL gateway> port=9223`).
    The gateway address reaches the bridge only when `run-dev.bat` sets
-   `PV_MCP_BRIDGE_BIND=0.0.0.0` and passes `--features dev-tools`
-   (see AGENT-RUNNER.md).
+   `PV_MCP_BRIDGE_ENABLE=1` and `PV_MCP_BRIDGE_BIND=0.0.0.0` and passes
+   `--features dev-tools` (see AGENT-RUNNER.md).
 
 ## Stage 1 — Agent validation via Tauri MCP
 

--- a/e2e-agentic-test/041-inbox-plan-surface/mixed-folder-single-type-subitems/scenario.md
+++ b/e2e-agentic-test/041-inbox-plan-surface/mixed-folder-single-type-subitems/scenario.md
@@ -34,7 +34,8 @@ already (spec 041 iteration 2, PR #315 lineage).
    with 2×light/Ha/300s + 2×light/Ha/120s + 2×dark/300s. Also create the
    empty **RECIPE-DEST** folder (`test-data\library-lights`).
 4. Launch the dev app with the bridge and E2E hooks
-   (`VITE_E2E=1`, dev overlay config, `--features dev-tools`, WS bridge on
+   (`VITE_E2E=1`, dev overlay config, `--features dev-tools`,
+   `PV_MCP_BRIDGE_ENABLE=1` to start the bridge, WS on
    `127.0.0.1:9223` unless `PV_MCP_BRIDGE_BIND` widens it), connect
    `driver_session` from WSL, and set the window to **1100×720** via
    `manage_window`.

--- a/e2e-agentic-test/043-ui-redesign-platevault/shell-left-nav/scenario.md
+++ b/e2e-agentic-test/043-ui-redesign-platevault/shell-left-nav/scenario.md
@@ -47,8 +47,9 @@ Calibration / Targets / Projects can show count badges
    Frontend-only surface — no forced Rust recompile needed.
 2. App launched per AGENT-RUNNER.md with the dev overlay config so the bridge
    is up: `cargo tauri dev --config src-tauri\tauri.dev.conf.json`
-   (`--features dev-tools`; bridge WS on `127.0.0.1:9223`, so a NAT-gateway
-   connection from WSL needs `PV_MCP_BRIDGE_BIND=0.0.0.0` at launch).
+   (`--features dev-tools` plus `PV_MCP_BRIDGE_ENABLE=1`, without which the
+   bridge does not start; bridge WS on `127.0.0.1:9223`, so a NAT-gateway
+   connection from WSL also needs `PV_MCP_BRIDGE_BIND=0.0.0.0` at launch).
 3. First-run setup completed with at least ONE registered source root (any
    empty folder as Light frames), so the app lands on the shell, not `/setup`.
 4. `.env` has `VITE_USE_MOCKS=false`. Verify: `mcp__tauri__ipc_get_backend_state`

--- a/e2e-agentic-test/AGENT-RUNNER.md
+++ b/e2e-agentic-test/AGENT-RUNNER.md
@@ -36,6 +36,7 @@ Windows repo root holds, each on its own line (no `&&`):
 ```
 cd /d C:\dev\astro-plan
 set PV_DB_URL=sqlite://C:\dev\astro-plan\wizard-test.db?mode=rwc
+set PV_MCP_BRIDGE_ENABLE=1
 set PV_MCP_BRIDGE_BIND=0.0.0.0
 cargo tauri dev --config src-tauri\tauri.dev.conf.json --features dev-tools
 ```
@@ -49,12 +50,14 @@ powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentL
 - The `--config src-tauri\tauri.dev.conf.json` overlay enables `withGlobalTauri`,
   and `--features dev-tools` compiles the MCP bridge WebSocket server in. Without
   the feature the plugin is not linked and nothing listens on 9223.
+- `PV_MCP_BRIDGE_ENABLE=1` starts the bridge. `1` is the only value that starts
+  it; without the variable a `dev-tools` build opens no port.
 - The bridge binds `127.0.0.1:9223`. `PV_MCP_BRIDGE_BIND=0.0.0.0` binds all
   interfaces, which is what a WSL agent connecting through the NAT gateway needs.
   Anything that reaches that address drives the app without authentication, so set
   it only for a validation run on a trusted network.
 - Scenarios in this tree REQUIRE the bridge, so always launch with the overlay,
-  the feature, and the bind variable.
+  the feature, and both bridge variables.
 - App process = `desktop_shell.exe`; Vite dev server on `localhost:5173`.
 - `.env` in the Windows checkout must have `VITE_USE_MOCKS=false` (real
   backend). **Verify this before running any scenario** — a scenario executed
@@ -139,10 +142,13 @@ gateway=$(ip route show default | awk '{print $3}')   # e.g. 172.23.112.1
 
 Connect: `mcp__tauri__driver_session` with `host=<gateway>` `port=9223`.
 The Windows firewall already allows 9223. A gateway connection reaches the bridge
-only when the app was launched with `PV_MCP_BRIDGE_BIND=0.0.0.0`; the default
-`127.0.0.1` bind accepts connections from the Windows host alone. If the session
-fails, confirm the app was launched with the `tauri.dev.conf.json` overlay,
-`--features dev-tools`, and that bind variable.
+only when the app was launched with `PV_MCP_BRIDGE_ENABLE=1` and
+`PV_MCP_BRIDGE_BIND=0.0.0.0`; the default `127.0.0.1` bind accepts connections
+from the Windows host alone, and without the enable variable no port is open at
+all. If the session fails, confirm the app was launched with the
+`tauri.dev.conf.json` overlay, `--features dev-tools`, and both variables. The
+startup log records which case applies: `MCP bridge starting` or `MCP bridge not
+started`.
 
 ## Driving and asserting
 

--- a/justfile
+++ b/justfile
@@ -190,9 +190,16 @@ dev:
 
 # Start the Tauri desktop app in development mode (Rust + frontend).
 # The dev overlay enables `withGlobalTauri`, and the `dev-tools` feature compiles
-# in the MCP bridge plugin that requires it. Release builds carry neither.
+# in the MCP bridge plugin that requires it. Release builds carry neither. The
+# bridge stays closed here: it needs PV_MCP_BRIDGE_ENABLE=1 (see tauri-dev-mcp).
 tauri-dev:
     cd apps/desktop && pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-tools
+
+# Start the desktop app with the MCP bridge open so an agent can drive it.
+# The bridge is unauthenticated and reaches every command handler; BIND defaults
+# to loopback and takes an address (0.0.0.0) only for cross-host validation.
+tauri-dev-mcp bind="127.0.0.1":
+    cd apps/desktop && PV_MCP_BRIDGE_ENABLE=1 PV_MCP_BRIDGE_BIND={{bind}} pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-tools
 
 # Clean build artifacts
 clean:

--- a/scripts/win-native-dev.ps1
+++ b/scripts/win-native-dev.ps1
@@ -19,14 +19,26 @@
   the WSL side (via \\wsl$ or /mnt/c) reliably trigger HMR; turn it off if you
   only ever edit from Windows-native tools and want lower idle CPU.
 
+.PARAMETER McpBridge
+  Start the MCP bridge (PV_MCP_BRIDGE_ENABLE=1) so an agent can drive this app.
+  Off by default: the bridge is unauthenticated and reaches every command
+  handler. Set -McpBridgeBind to widen its 127.0.0.1 bind for a WSL-side agent.
+
+.PARAMETER McpBridgeBind
+  Address the MCP bridge binds (PV_MCP_BRIDGE_BIND), e.g. 0.0.0.0 so the WSL NAT
+  gateway address reaches it. Requires -McpBridge.
+
 .EXAMPLE
   pwsh -File scripts\win-native-dev.ps1            # real backend, polling on
   pwsh -File scripts\win-native-dev.ps1 -Mocks     # fixtures, no backend
+  pwsh -File scripts\win-native-dev.ps1 -McpBridge -McpBridgeBind 0.0.0.0
 #>
 [CmdletBinding()]
 param(
   [switch]$Mocks,
-  [switch]$NoPolling
+  [switch]$NoPolling,
+  [switch]$McpBridge,
+  [string]$McpBridgeBind
 )
 
 $ErrorActionPreference = 'Stop'
@@ -49,9 +61,20 @@ $env:VITE_USE_MOCKS = if ($Mocks) { 'true' } else { 'false' }
 if ($NoPolling) { Remove-Item Env:CHOKIDAR_USEPOLLING -ErrorAction SilentlyContinue }
 else { $env:CHOKIDAR_USEPOLLING = 'true' }
 
+if ($McpBridgeBind -and -not $McpBridge) {
+  throw "-McpBridgeBind requires -McpBridge (the bridge does not start without it)."
+}
+if ($McpBridge) {
+  $env:PV_MCP_BRIDGE_ENABLE = '1'
+  if ($McpBridgeBind) { $env:PV_MCP_BRIDGE_BIND = $McpBridgeBind }
+} else {
+  Remove-Item Env:PV_MCP_BRIDGE_ENABLE -ErrorAction SilentlyContinue
+}
+
 Write-Host "Repo:        $repoRoot"
 Write-Host "Backend:     $(if ($Mocks) { 'MOCKS (fixtures, no Rust backend)' } else { 'REAL (Rust backend wired)' })"
 Write-Host "Watch:       $(if ($NoPolling) { 'native notifications' } else { 'polling (WSL-edit safe)' })"
+Write-Host "MCP bridge:  $(if ($McpBridge) { "ON (bind $(if ($McpBridgeBind) { $McpBridgeBind } else { '127.0.0.1' }))" } else { 'OFF (-McpBridge to enable)' })"
 Write-Host "Starting tauri dev... (first build compiles the Rust workspace; later builds are incremental)"
 
 Set-Location $desktop
@@ -60,6 +83,7 @@ Set-Location $desktop
 # MUST stay out of the base tauri.conf.json (production security surface); it is
 # applied here in dev only — mirrors the `just tauri-dev` invocation.
 # `--features dev-tools` compiles the MCP bridge in; without it the plugin is
-# not linked and nothing listens on 9223. The bridge binds 127.0.0.1 unless
-# PV_MCP_BRIDGE_BIND overrides it (see docs/development/windows-native-rust-dev.md).
+# not linked. Compiled in is not started: `-McpBridge` sets PV_MCP_BRIDGE_ENABLE=1,
+# and nothing listens on 9223 without it (see
+# docs/development/windows-native-rust-dev.md).
 pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-tools


### PR DESCRIPTION
## What changed

The Tauri MCP bridge starts only when `PV_MCP_BRIDGE_ENABLE=1`. In a `dev-tools`
build without that variable the plugin is registered nowhere and no port opens.

The bridge is gated in three places:

| Layer | Mechanism | Effect when absent |
| --- | --- | --- |
| Build | `dev-tools` feature gates the optional dependency | release binaries do not link the plugin |
| Start | `PV_MCP_BRIDGE_ENABLE=1` | no listener in a `dev-tools` build |
| Address | `PV_MCP_BRIDGE_BIND`, default `127.0.0.1` | loopback only |

`1` is the only value that starts the bridge. Startup logs one `tracing` line
either way: `MCP bridge starting` with the bind address, or `MCP bridge not
started`. An off-loopback bind logs at `warn`.

`PV_MCP_BRIDGE_BIND` keeps the loopback default. A blank value now falls back to
that default rather than to the plugin's own `0.0.0.0`
(`apps/desktop/src-tauri/src/bootstrap/mod.rs:39-40`).

## Why

The bridge is unauthenticated, and `execute_js` plus `withGlobalTauri` reaches
all 202 command handlers with the full capability grant, so before this change
every `dev-tools` build opened full control of the app on launch
(astro-plan-3v3r.8.23).

## Consumers updated

- `e2e-agentic-test/AGENT-RUNNER.md`: `run-dev.bat` block and the connect section
- five scenario docs that name the bind variable in their launch prose
- `scripts/win-native-dev.ps1`: new `-McpBridge` / `-McpBridgeBind` switches
- `justfile`: new `tauri-dev-mcp` recipe; `tauri-dev` leaves the bridge closed
- `docs/development/windows-native-rust-dev.md`, `docs/journeys/README.md`, `Cargo.toml`
- `docs/development/mcp-bridge.md` (new), linked from the Windows runbook

Checked and unaffected: no CI workflow launches a `dev-tools` app (only clippy
and bindings builds); `crates/e2e-tests` drives WebDriver, not the bridge;
`scripts/check-dev-surface-absent.sh` asserts the build layer and still passes.

## Tests

`bootstrap::mcp_bridge_bind_address` takes the two variable values as arguments
and returns the bind address or `None`, so the start decision is asserted
without launching an app or binding a port. Cases:

| Input | Result |
| --- | --- |
| enable unset, `0`, `true`, `yes`, `1 `, `01`, empty | closed |
| enable `1`, bind unset or blank | `127.0.0.1` |
| enable `1`, bind `0.0.0.0` or `192.168.1.20` | that address |
| any input, build without `dev-tools` | closed |

The function is compiled only into `dev-tools` and test builds.

## Docs

`docs/development/mcp-bridge.md` states the two variables and their defaults,
the launch command for a WSL client against a Windows host under both mirrored
and NAT networking, and what a non-loopback bind exposes.

## Verification

- `cargo clippy -p desktop_shell --all-targets -- -D warnings` (0)
- `cargo clippy -p desktop_shell --all-targets --features dev-tools -- -D warnings` (0)
- `cargo test -p desktop_shell --lib bootstrap::` (0; 23 passed)
- `cargo test -p desktop_shell --features dev-tools --lib bootstrap::` (0; 24 passed)
- `cargo fmt --all --check` (0)
- `bash scripts/check-dev-surface-absent.sh` (0; 1 capability file, 5360 feature-graph lines)
- `just check-generated` (0; generated artifacts up to date)
- PowerShell parse check of `scripts/win-native-dev.ps1`

`scripts/check-dev-surface-absent.sh` did not change: its gated-crate list
already names `tauri-plugin-mcp-bridge` and its permission list `mcp-bridge:`,
so a default-feature graph that links the plugin, or a shipped capability that
grants it, already fails.

Work bead: astro-plan-pjsxi. Merge bead: astro-plan-ce12b.



