### PR TITLE
fix: a move or copy whose destination is outside the chosen folder is refused instead of applied

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,6 +2032,7 @@ name = "fs_pathsafe"
 version = "0.1.0"
 dependencies = [
  "camino",
+ "path-clean",
  "proptest",
  "safe-filename",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4793,6 +4793,7 @@ name = "project_structure"
 version = "0.1.0"
 dependencies = [
  "domain_core",
+ "fs_pathsafe",
  "serde",
  "serde_json",
  "tempfile",
@@ -8609,6 +8610,7 @@ dependencies = [
 name = "workflow_profiles"
 version = "0.1.0"
 dependencies = [
+ "fs_pathsafe",
  "itertools",
  "project_structure",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "contracts_core",
  "dashmap",
  "domain_core",
+ "dunce",
  "filetime",
  "fs_executor",
  "fs_inventory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,9 @@ schemars = { version = "1", features = ["uuid1"] }
 jsonschema = { version = "0.48", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Canonicalizes without the Windows `\\?\` verbatim prefix, so a canonicalized
+# path and a `canonicalize`-failed fallback compare with the same spelling.
+dunce = "1"
 thiserror = "2"
 time = { version = "0.3", features = ["formatting", "parsing", "serde", "serde-well-known"] }
 trash = "5.2"

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -25,6 +25,7 @@ domain_core = { path = "../../domain/core" }
 fs_executor = { path = "../../fs/executor" }
 fs_inventory = { path = "../../fs/inventory" }
 fs_pathsafe = { path = "../../fs/pathsafe" }
+dunce = { workspace = true }
 patterns = { path = "../../patterns" }
 persistence_calibration = { path = "../../persistence/calibration" }
 persistence_core = { path = "../../persistence/core" }
@@ -58,6 +59,9 @@ tracing = { workspace = true }
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
 
 [dev-dependencies]
+# Containment fixtures build platform-absolute roots via `test_support`, which the
+# `[dependencies]` edge above leaves off so it is absent from release builds.
+fs_pathsafe = { path = "../../fs/pathsafe", features = ["test-fixture"] }
 app_core_cache = { path = "../cache" }
 # plan_resume_integration.rs paces the executor's forward pass so its retry lands
 # while the resumed run is still draining. The feature is off on the

--- a/crates/app/core/src/plan_apply/paths.rs
+++ b/crates/app/core/src/plan_apply/paths.rs
@@ -12,15 +12,19 @@ use super::{
 /// held across an `.await`.
 pub(super) static OVERLAP_GATE: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Resolve one claimed relative path the same way the executor resolves item
-/// paths (`resolve_item_path`): join against the root when known, then
-/// lexically normalize. Unrooted paths normalize as-is — they never falsely
-/// prefix-match rooted absolute paths.
+/// Resolve one claimed relative path for the FR-017 overlap set: join against
+/// the root when known, then lexically normalize. Unrooted paths normalize
+/// as-is — they never falsely prefix-match rooted absolute paths.
+///
+/// This set is compared for overlap and never mutated, so an uncontained path
+/// is deliberately kept rather than refused: over-claiming a path only makes
+/// the concurrency check stricter. Anything that mutates goes through
+/// `fs_pathsafe::contain` instead.
 pub(super) fn resolve_claimed_path(relative: &str, root: Option<&Utf8PathBuf>) -> Utf8PathBuf {
-    use fs_executor::ops::path_gate::lexical_normalize;
+    use fs_pathsafe::contain::normalize_utf8;
     match root {
-        Some(r) => lexical_normalize(&r.join(relative)),
-        None => lexical_normalize(Utf8Path::new(relative)),
+        Some(r) => normalize_utf8(&r.join(relative)),
+        None => normalize_utf8(Utf8Path::new(relative)),
     }
 }
 
@@ -35,7 +39,7 @@ pub(super) fn compute_plan_path_set(
     item_rows: &[plans_repo::PlanItemRow],
     root_map: &HashMap<String, Utf8PathBuf>,
 ) -> PlanPathSet {
-    use fs_executor::ops::path_gate::lexical_normalize;
+    use fs_pathsafe::contain::normalize_utf8;
 
     let mut set = PlanPathSet::new();
     for row in item_rows {
@@ -51,7 +55,7 @@ pub(super) fn compute_plan_path_set(
         if let Some(archive) = row.archive_path.as_deref().filter(|a| !a.is_empty()) {
             let p = Utf8Path::new(archive);
             if p.is_absolute() {
-                set.insert(lexical_normalize(p));
+                set.insert(normalize_utf8(p));
             } else {
                 set.insert(resolve_claimed_path(archive, to_root));
             }

--- a/crates/app/core/src/plan_apply/reconcile.rs
+++ b/crates/app/core/src/plan_apply/reconcile.rs
@@ -28,8 +28,8 @@ use domain_core::ids::{new_id, Timestamp};
 use sqlx::SqlitePool;
 
 use super::{apply_repo, resolve_root_path};
-use fs_executor::ops::lexical_normalize;
 use fs_executor::{classify, MutationShape, ReconcileVerdict};
+use fs_pathsafe::contain::normalize_utf8;
 
 /// Outcome of the boot reconciliation pass, consumed by the unclean-shutdown
 /// recovery prompt (kyo7.48).
@@ -167,7 +167,7 @@ fn resolve(
         return None;
     }
     let root = root_id.and_then(|rid| root_map.get(rid))?;
-    Some(lexical_normalize(&root.join(relative)))
+    Some(normalize_utf8(&root.join(relative)))
 }
 
 /// Resolve an archive item's destination from `archive_path`. When
@@ -182,8 +182,8 @@ fn resolve_archive(
         return None;
     }
     match item.from_root_id.as_deref().and_then(|rid| root_map.get(rid)) {
-        Some(root) => Some(lexical_normalize(&root.join(archive))),
-        None => Some(lexical_normalize(Utf8PathBuf::from(archive).as_path())),
+        Some(root) => Some(normalize_utf8(&root.join(archive))),
+        None => Some(normalize_utf8(Utf8PathBuf::from(archive).as_path())),
     }
 }
 

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -1601,7 +1601,7 @@ fn relative_destination_still_takes_library_root_fallback() {
 fn t023a_root_escape_gate_fires_when_library_root_is_set() {
     use fs_executor::ops::path_gate;
 
-    let root = Utf8PathBuf::from("/mnt/library");
+    let root = Utf8PathBuf::from(fs_pathsafe::test_support::abs("/mnt/library"));
     // A path that escapes the root via ".." — must be refused.
     let escaping_relative = Utf8PathBuf::from("../../etc/passwd");
 

--- a/crates/app/core/src/plans/archive.rs
+++ b/crates/app/core/src/plans/archive.rs
@@ -61,8 +61,10 @@ fn resolve_archive_abs_path(
 
 /// Resolve one archived item, recording an uncontained path as a failure.
 ///
-/// An uncontained path is a failed item, not a skipped one: skipping would let
-/// `items_moved` report success for an archive entry nobody could account for.
+/// The recorded failure surfaces to the caller only when no item moved at all,
+/// which is the same handling the trash and delete primitives already get. In a
+/// mixed batch the refusal is a `warn` and the response still reports the items
+/// that did move.
 fn resolve_or_record_failure(
     archive_path: &str,
     from_root_id: Option<&str>,

--- a/crates/app/core/src/plans/archive.rs
+++ b/crates/app/core/src/plans/archive.rs
@@ -59,6 +59,27 @@ fn resolve_archive_abs_path(
     }
 }
 
+/// Resolve one archived item, recording an uncontained path as a failure.
+///
+/// An uncontained path is a failed item, not a skipped one: skipping would let
+/// `items_moved` report success for an archive entry nobody could account for.
+fn resolve_or_record_failure(
+    archive_path: &str,
+    from_root_id: Option<&str>,
+    root_map: &HashMap<String, Utf8PathBuf>,
+    item_id: &str,
+    last_failure: &mut Option<(FailureCode, String)>,
+) -> Option<Utf8PathBuf> {
+    match resolve_archive_abs_path(archive_path, from_root_id, root_map) {
+        Ok(path) => Some(path),
+        Err(e) => {
+            tracing::warn!(item_id = %item_id, error = %e, "archive item path not contained");
+            *last_failure = Some((FailureCode::PathInvalid, e.to_string()));
+            None
+        }
+    }
+}
+
 /// Map a trash-primitive failure to the closed `archive.send_to_trash` error set.
 fn trash_failure_error_code(code: FailureCode) -> ErrorCode {
     match code {
@@ -125,19 +146,14 @@ pub async fn send_archive_to_trash(
     for item in &archive_items {
         // Filtered by `archive_path.is_some()` above.
         let archive_rel = item.archive_path.as_deref().unwrap_or_default();
-        // An uncontained path is a failed item, not a skipped one: skipping
-        // would report success for an archive entry nobody could account for.
-        let abs_path = match resolve_archive_abs_path(
+        let Some(abs_path) = resolve_or_record_failure(
             archive_rel,
             item.from_root_id.as_deref(),
             &root_map,
-        ) {
-            Ok(path) => path,
-            Err(e) => {
-                tracing::warn!(item_id = %item.id, error = %e, "archive item path not contained");
-                last_failure = Some((FailureCode::PathInvalid, e.to_string()));
-                continue;
-            }
+            &item.id,
+            &mut last_failure,
+        ) else {
+            continue;
         };
 
         if !abs_path.exists() {
@@ -243,19 +259,14 @@ pub async fn permanently_delete_archive(
     let mut last_failure: Option<(FailureCode, String)> = None;
     for item in &archive_items {
         let archive_rel = item.archive_path.as_deref().unwrap_or_default();
-        // An uncontained path is a failed item, not a skipped one: skipping
-        // would report success for an archive entry nobody could account for.
-        let abs_path = match resolve_archive_abs_path(
+        let Some(abs_path) = resolve_or_record_failure(
             archive_rel,
             item.from_root_id.as_deref(),
             &root_map,
-        ) {
-            Ok(path) => path,
-            Err(e) => {
-                tracing::warn!(item_id = %item.id, error = %e, "archive item path not contained");
-                last_failure = Some((FailureCode::PathInvalid, e.to_string()));
-                continue;
-            }
+            &item.id,
+            &mut last_failure,
+        ) else {
+            continue;
         };
 
         if !abs_path.exists() {

--- a/crates/app/core/src/plans/archive.rs
+++ b/crates/app/core/src/plans/archive.rs
@@ -321,7 +321,19 @@ mod tests {
     use super::*;
 
     fn root_map() -> HashMap<String, Utf8PathBuf> {
-        HashMap::from([("root-1".to_owned(), Utf8PathBuf::from("/mnt/library"))])
+        HashMap::from([(
+            "root-1".to_owned(),
+            Utf8PathBuf::from(fs_pathsafe::test_support::abs("/mnt/library")),
+        )])
+    }
+
+    /// Compare by path components: the resolved form carries the platform
+    /// separator, which differs from the Unix-style literal on Windows.
+    fn assert_same_path(actual: &camino::Utf8Path, expected_unix: &str) {
+        assert_eq!(
+            actual.as_std_path(),
+            std::path::Path::new(&fs_pathsafe::test_support::abs(expected_unix)),
+        );
     }
 
     #[test]
@@ -332,7 +344,7 @@ mod tests {
             &root_map(),
         )
         .unwrap();
-        assert_eq!(path, "/mnt/library/.astro-plan-archive/plan-1/x.fits");
+        assert_same_path(&path, "/mnt/library/.astro-plan-archive/plan-1/x.fits");
     }
 
     /// astro-plan-3v3r.5.20: an unresolvable root id took the no-root branch and
@@ -354,9 +366,9 @@ mod tests {
     /// Legacy archive/cleanup generators store an absolute path with no root id.
     #[test]
     fn a_rootless_absolute_path_still_resolves() {
-        let path =
-            resolve_archive_abs_path("/mnt/library/archive/x.fits", None, &root_map()).unwrap();
-        assert_eq!(path, "/mnt/library/archive/x.fits");
+        let supplied = fs_pathsafe::test_support::abs("/mnt/library/archive/x.fits");
+        let path = resolve_archive_abs_path(&supplied, None, &root_map()).unwrap();
+        assert_same_path(&path, "/mnt/library/archive/x.fits");
     }
 
     #[test]

--- a/crates/app/core/src/plans/archive.rs
+++ b/crates/app/core/src/plans/archive.rs
@@ -8,7 +8,7 @@ use audit::event_bus::{
     ArchivePermanentlyDeleted, ArchiveSentToTrash, Source, TOPIC_ARCHIVE_PERMANENTLY_DELETED,
     TOPIC_ARCHIVE_SENT_TO_TRASH,
 };
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use contracts_core::plans::{ArchivePermanentlyDeleteResponse, ArchiveSendToTrashResponse};
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use domain_core::ids::{new_id, Timestamp};
@@ -26,19 +26,36 @@ use super::{build_root_map, db_err, PERMANENT_DELETE_CONFIRM_TEXT};
 
 /// Resolve an archived item's on-disk absolute path.
 ///
-/// `archive_path` is stored root-relative when the item has a `from_root_id`
-/// (mirrors the spec-025 executor's `resolve_item_path`, `crates/fs/executor/src/run.rs`);
+/// `archive_path` is stored root-relative when the item has a `from_root_id`;
 /// archive-plan generators that predate a resolved root (`archive_generator`,
 /// `cleanup_generator`) store an already-absolute path with `from_root_id: None`,
-/// so the "no root" branch uses `archive_path` as-is rather than erroring.
+/// so that shape is accepted through `resolve_unrooted`.
+///
+/// A `from_root_id` that does not resolve is an error rather than the no-root
+/// shape. Sharing one branch meant an unresolvable root id produced a
+/// cwd-relative path, which then reached `trash_file` or `delete_file`
+/// (astro-plan-3v3r.5.20).
+///
+/// # Errors
+///
+/// [`fs_pathsafe::contain::ContainmentError`] when the path does not resolve
+/// inside its root, or when a rootless path is not absolute and normal.
 fn resolve_archive_abs_path(
     archive_path: &str,
     from_root_id: Option<&str>,
     root_map: &HashMap<String, Utf8PathBuf>,
-) -> Utf8PathBuf {
-    match from_root_id.and_then(|rid| root_map.get(rid)) {
-        Some(root) => root.join(archive_path),
-        None => Utf8PathBuf::from(archive_path),
+) -> Result<Utf8PathBuf, fs_pathsafe::contain::ContainmentError> {
+    let path = Utf8Path::new(archive_path);
+    match from_root_id {
+        Some(rid) => {
+            let root = root_map.get(rid).ok_or_else(|| {
+                fs_pathsafe::contain::ContainmentError::RootMissing {
+                    path: path.as_std_path().to_path_buf(),
+                }
+            })?;
+            fs_pathsafe::contain::resolve_in_root_utf8(root, path)
+        }
+        None => fs_pathsafe::contain::resolve_unrooted_utf8(path),
     }
 }
 
@@ -108,8 +125,20 @@ pub async fn send_archive_to_trash(
     for item in &archive_items {
         // Filtered by `archive_path.is_some()` above.
         let archive_rel = item.archive_path.as_deref().unwrap_or_default();
-        let abs_path =
-            resolve_archive_abs_path(archive_rel, item.from_root_id.as_deref(), &root_map);
+        // An uncontained path is a failed item, not a skipped one: skipping
+        // would report success for an archive entry nobody could account for.
+        let abs_path = match resolve_archive_abs_path(
+            archive_rel,
+            item.from_root_id.as_deref(),
+            &root_map,
+        ) {
+            Ok(path) => path,
+            Err(e) => {
+                tracing::warn!(item_id = %item.id, error = %e, "archive item path not contained");
+                last_failure = Some((FailureCode::PathInvalid, e.to_string()));
+                continue;
+            }
+        };
 
         if !abs_path.exists() {
             // Already gone (e.g. a repeated call) — not a failure, no-op.
@@ -214,8 +243,20 @@ pub async fn permanently_delete_archive(
     let mut last_failure: Option<(FailureCode, String)> = None;
     for item in &archive_items {
         let archive_rel = item.archive_path.as_deref().unwrap_or_default();
-        let abs_path =
-            resolve_archive_abs_path(archive_rel, item.from_root_id.as_deref(), &root_map);
+        // An uncontained path is a failed item, not a skipped one: skipping
+        // would report success for an archive entry nobody could account for.
+        let abs_path = match resolve_archive_abs_path(
+            archive_rel,
+            item.from_root_id.as_deref(),
+            &root_map,
+        ) {
+            Ok(path) => path,
+            Err(e) => {
+                tracing::warn!(item_id = %item.id, error = %e, "archive item path not contained");
+                last_failure = Some((FailureCode::PathInvalid, e.to_string()));
+                continue;
+            }
+        };
 
         if !abs_path.exists() {
             // Already gone (e.g. a repeated call) — not a failure, no-op.
@@ -258,4 +299,56 @@ pub async fn permanently_delete_archive(
     .map_err(bus_err)?;
 
     Ok(ArchivePermanentlyDeleteResponse { plan_id: plan_id.to_owned(), items_deleted, audit_id })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root_map() -> HashMap<String, Utf8PathBuf> {
+        HashMap::from([("root-1".to_owned(), Utf8PathBuf::from("/mnt/library"))])
+    }
+
+    #[test]
+    fn a_root_relative_archive_path_resolves_under_its_root() {
+        let path = resolve_archive_abs_path(
+            ".astro-plan-archive/plan-1/x.fits",
+            Some("root-1"),
+            &root_map(),
+        )
+        .unwrap();
+        assert_eq!(path, "/mnt/library/.astro-plan-archive/plan-1/x.fits");
+    }
+
+    /// astro-plan-3v3r.5.20: an unresolvable root id took the no-root branch and
+    /// produced a cwd-relative path, which then reached trash_file/delete_file.
+    #[test]
+    fn an_unresolvable_root_id_is_refused_rather_than_treated_as_rootless() {
+        let err = resolve_archive_abs_path("plan-1/x.fits", Some("missing-root"), &root_map())
+            .unwrap_err();
+        assert!(matches!(err, fs_pathsafe::contain::ContainmentError::RootMissing { .. }), "{err}");
+    }
+
+    #[test]
+    fn a_root_relative_path_that_escapes_its_root_is_refused() {
+        let err =
+            resolve_archive_abs_path("../../etc/passwd", Some("root-1"), &root_map()).unwrap_err();
+        assert!(matches!(err, fs_pathsafe::contain::ContainmentError::Escapes { .. }), "{err}");
+    }
+
+    /// Legacy archive/cleanup generators store an absolute path with no root id.
+    #[test]
+    fn a_rootless_absolute_path_still_resolves() {
+        let path =
+            resolve_archive_abs_path("/mnt/library/archive/x.fits", None, &root_map()).unwrap();
+        assert_eq!(path, "/mnt/library/archive/x.fits");
+    }
+
+    #[test]
+    fn a_rootless_relative_path_is_refused() {
+        let err = resolve_archive_abs_path("archive/x.fits", None, &root_map()).unwrap_err();
+        assert!(matches!(err, fs_pathsafe::contain::ContainmentError::NotAbsolute { .. }), "{err}");
+    }
 }

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -276,7 +276,8 @@ async fn resolve_and_check_working_dir(
 ) -> Result<String, ToolLaunchResponse> {
     let project_root = std::path::PathBuf::from(project_path);
     let active_source_view = resolve_active_source_view_folder(pool, project_id).await;
-    let working_dir_path = resolve_working_folder(&project_root, active_source_view.as_deref());
+    let working_dir_path = resolve_working_folder(&project_root, active_source_view.as_deref())
+        .map_err(|e| error_response("cwd.outside_library_root", e.to_string()))?;
 
     let canonical_cwd =
         working_dir_path.canonicalize().unwrap_or_else(|_| working_dir_path.clone());

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -279,8 +279,11 @@ async fn resolve_and_check_working_dir(
     let working_dir_path = resolve_working_folder(&project_root, active_source_view.as_deref())
         .map_err(|e| error_response("cwd.outside_library_root", e.to_string()))?;
 
+    // `dunce` on both sides, not `std::fs::canonicalize`: a working folder that
+    // does not exist yet falls back to its raw non-verbatim spelling, so a root
+    // canonicalized to a Windows `\\?\` verbatim path would never prefix-match it.
     let canonical_cwd =
-        working_dir_path.canonicalize().unwrap_or_else(|_| working_dir_path.clone());
+        dunce::canonicalize(&working_dir_path).unwrap_or_else(|_| working_dir_path.clone());
     let all_roots = inv_repo::list_all_roots(pool)
         .await
         .map_err(|e| error_response("db.error", format!("{e}")))?;
@@ -293,7 +296,7 @@ async fn resolve_and_check_working_dir(
         .chain(registered.iter().map(|s| s.path.as_str()))
         .map(|raw| {
             let p = std::path::PathBuf::from(raw);
-            p.canonicalize().unwrap_or(p)
+            dunce::canonicalize(&p).unwrap_or(p)
         })
         .collect();
     let root_refs: Vec<&std::path::Path> =
@@ -917,9 +920,10 @@ mod tests {
         sqlx::query(
             "INSERT INTO registered_sources \
              (id, kind, path, scan_depth, created_at, created_via, organization_state) \
-             VALUES ('rs-proj', 'project', '/mnt/library', 'recursive', \
+             VALUES ('rs-proj', 'project', ?, 'recursive', \
                      '2026-01-01T00:00:00Z', 'first_run', 'organized')",
         )
+        .bind(abs("/mnt/library"))
         .execute(db.pool())
         .await
         .unwrap();

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -689,13 +689,22 @@ mod tests {
         // Insert a minimal project row
         sqlx::query(
             "INSERT INTO projects (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
-             VALUES (?, 'Test Project', 'PixInsight', 'setup_incomplete', '/mnt/library/test_project', NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')"
+             VALUES (?, 'Test Project', 'PixInsight', 'setup_incomplete', ?, NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')"
         )
         .bind(&project_id)
+        .bind(abs(PROJECT_DIR))
         .execute(pool)
         .await
         .unwrap();
         project_id
+    }
+
+    /// Unix-style project folder of [`make_project`]; absolute on the current
+    /// platform through [`abs`].
+    const PROJECT_DIR: &str = "/mnt/library/test_project";
+
+    fn abs(path: &str) -> String {
+        fs_pathsafe::test_support::abs(path)
     }
 
     async fn insert_root(db: &Database, path: &str) {
@@ -794,7 +803,7 @@ mod tests {
         let bus = make_bus(db.pool().clone());
         let spawner = FakeSpawner::ok();
         // Register a root that does NOT contain the project path (/mnt/library/test_project).
-        insert_root(&db, "/different/root").await;
+        insert_root(&db, &abs("/different/root")).await;
         set_tool_path(&db, "pixinsight", "/usr/bin/pixinsight").await;
         let req = ToolLaunchRequest { project_id, tool_id: "pixinsight".to_owned(), force: false };
         let resp = launch(db.pool(), &bus, &spawner, req).await.unwrap();
@@ -811,7 +820,7 @@ mod tests {
         let bus = make_bus(db.pool().clone());
         let spawner = FakeSpawner::ok();
         // Register library root that contains the project
-        insert_root(&db, "/mnt/library").await;
+        insert_root(&db, &abs("/mnt/library")).await;
         set_tool_path(&db, "pixinsight", "/usr/bin/pixinsight").await;
         let req = ToolLaunchRequest {
             project_id: project_id.clone(),
@@ -835,7 +844,7 @@ mod tests {
         let project_id = make_project(&db).await;
         let bus = make_bus(db.pool().clone());
         let spawner = FakeSpawner::ok();
-        insert_root(&db, "/mnt/library").await;
+        insert_root(&db, &abs("/mnt/library")).await;
         set_tool_path(&db, "siril", "/usr/bin/siril").await;
 
         psv_repo::insert_view(
@@ -848,7 +857,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let view_dir = "/mnt/library/test_project/source-views/plan-1/2026-01-01/L";
+        let view_dir = abs("/mnt/library/test_project/source-views/plan-1/2026-01-01/L");
         for (idx, name) in ["light1.fits", "light2.fits"].iter().enumerate() {
             psv_repo::insert_view_item(
                 db.pool(),
@@ -867,7 +876,10 @@ mod tests {
         let req = ToolLaunchRequest { project_id, tool_id: "siril".to_owned(), force: false };
         let resp = launch(db.pool(), &bus, &spawner, req).await.unwrap();
         assert_eq!(resp.status, ToolLaunchStatus::Success);
-        assert_eq!(resp.working_dir.as_deref(), Some(view_dir));
+        assert_eq!(
+            resp.working_dir.as_deref().map(std::path::Path::new),
+            Some(std::path::Path::new(&view_dir))
+        );
     }
 
     /// No generated view exists — must fall back to the project root exactly
@@ -878,13 +890,16 @@ mod tests {
         let project_id = make_project(&db).await;
         let bus = make_bus(db.pool().clone());
         let spawner = FakeSpawner::ok();
-        insert_root(&db, "/mnt/library").await;
+        insert_root(&db, &abs("/mnt/library")).await;
         set_tool_path(&db, "siril", "/usr/bin/siril").await;
 
         let req = ToolLaunchRequest { project_id, tool_id: "siril".to_owned(), force: false };
         let resp = launch(db.pool(), &bus, &spawner, req).await.unwrap();
         assert_eq!(resp.status, ToolLaunchStatus::Success);
-        assert_eq!(resp.working_dir.as_deref(), Some("/mnt/library/test_project"));
+        assert_eq!(
+            resp.working_dir.as_deref().map(std::path::Path::new),
+            Some(std::path::Path::new(&abs(PROJECT_DIR)))
+        );
     }
 
     /// Wizard-registered roots live in `registered_sources` only (they are
@@ -921,7 +936,7 @@ mod tests {
         let project_id = make_project(&db).await;
         let bus = make_bus(db.pool().clone());
         let spawner = FakeSpawner::ok();
-        insert_root(&db, "/mnt/library").await;
+        insert_root(&db, &abs("/mnt/library")).await;
         set_tool_path(&db, "pixinsight", "/usr/bin/pixinsight").await;
         let req = ToolLaunchRequest {
             project_id: project_id.clone(),
@@ -944,7 +959,7 @@ mod tests {
         let db = setup_db().await;
         let project_id = make_project(&db).await;
         let bus = make_bus(db.pool().clone());
-        insert_root(&db, "/mnt/library").await;
+        insert_root(&db, &abs("/mnt/library")).await;
         set_tool_path(&db, "pixinsight", "/usr/bin/pixinsight").await;
 
         // Insert a "spawned" row with a pid that the test process can never have as its own child.

--- a/crates/app/projects/Cargo.toml
+++ b/crates/app/projects/Cargo.toml
@@ -47,6 +47,9 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+# Containment fixtures build platform-absolute roots via `test_support`, which the
+# `[dependencies]` edge above leaves off so it is absent from release builds.
+fs_pathsafe = { path = "../../fs/pathsafe", features = ["test-fixture"] }
 contracts_core = { path = "../../contracts/core" }
 persistence_core = { path = "../../persistence/core", features = ["test-fixture"] }
 persistence_sessions = { path = "../../persistence/sessions", features = ["test-fixture"] }

--- a/crates/app/projects/src/test_support.rs
+++ b/crates/app/projects/src/test_support.rs
@@ -22,11 +22,7 @@ pub const TEST_PROJECT_ROOT: &str = "/library/projects-root";
 
 /// Make a Unix-style test path absolute on the current platform.
 pub fn abs(path: &str) -> String {
-    if cfg!(windows) {
-        format!("C:{path}")
-    } else {
-        path.to_owned()
-    }
+    fs_pathsafe::test_support::abs(path)
 }
 
 /// Register a project-kind source so relative request paths have an anchor

--- a/crates/fs/executor/src/ops/mod.rs
+++ b/crates/fs/executor/src/ops/mod.rs
@@ -29,7 +29,7 @@ pub use delete_op::delete_file;
 pub use link_op::create_link;
 pub use mkdir_op::make_dir;
 pub use move_op::move_file;
-pub use path_gate::{lexical_normalize, resolve_and_validate};
+pub use path_gate::resolve_and_validate;
 pub use trash_op::trash_file;
 pub use volume_check::{available_space_bytes, recheck_disk_space, recheck_volume_available};
 pub use write_manifest_op::write_marker;

--- a/crates/fs/executor/src/ops/path_gate.rs
+++ b/crates/fs/executor/src/ops/path_gate.rs
@@ -61,8 +61,8 @@ pub fn resolve_and_validate(
     // `fs_pathsafe::contain` so this gate and every other root-relative
     // resolver in the workspace cannot drift apart
     // (`specs/tiny/root-relative-path-containment.md`).
-    let normalized =
-        fs_pathsafe::contain::resolve_in_root_utf8(root, relative).map_err(containment_failure)?;
+    let normalized = fs_pathsafe::contain::resolve_in_root_utf8(root, relative)
+        .map_err(|e| containment_failure(&e))?;
     // The containment verdict is against the *normalized* root, so the walk
     // below must strip that same prefix rather than the caller's spelling.
     let root = &fs_pathsafe::contain::normalize_utf8(root);
@@ -121,9 +121,10 @@ pub fn resolve_and_validate(
 /// Only [`ContainmentError::Escapes`] is `root_escape`; a malformed root or an
 /// unrooted path that cannot be resolved is a bad plan item, not a traversal
 /// attempt, and the two must stay distinguishable in the audit record.
-pub fn containment_failure(error: fs_pathsafe::contain::ContainmentError) -> PlanItemFailure {
+#[must_use]
+pub fn containment_failure(error: &fs_pathsafe::contain::ContainmentError) -> PlanItemFailure {
     use fs_pathsafe::contain::ContainmentError as E;
-    let code = match error {
+    let code = match *error {
         E::Escapes { .. } => FailureCode::RootEscape,
         E::RootMissing { .. }
         | E::RootNotAbsolute { .. }

--- a/crates/fs/executor/src/ops/path_gate.rs
+++ b/crates/fs/executor/src/ops/path_gate.rs
@@ -57,20 +57,15 @@ pub fn resolve_and_validate(
     root: &Utf8Path,
     relative: &Utf8Path,
 ) -> Result<ResolvedPath, PlanItemFailure> {
-    // Step 1: join + lexical normalize.
-    let joined = root.join(relative);
-    let normalized = lexical_normalize(&joined);
-
-    // Step 2: root-escape check.
-    if !normalized.starts_with(root) {
-        return Err(PlanItemFailure::with_code(
-            FailureCode::RootEscape,
-            format!(
-                "path '{relative}' escapes library root '{root}' after normalization; \
-                 resolved to '{normalized}'"
-            ),
-        ));
-    }
+    // Steps 1-2: join, normalize, and prove containment. The rule lives in
+    // `fs_pathsafe::contain` so this gate and every other root-relative
+    // resolver in the workspace cannot drift apart
+    // (`specs/tiny/root-relative-path-containment.md`).
+    let normalized =
+        fs_pathsafe::contain::resolve_in_root_utf8(root, relative).map_err(containment_failure)?;
+    // The containment verdict is against the *normalized* root, so the walk
+    // below must strip that same prefix rather than the caller's spelling.
+    let root = &fs_pathsafe::contain::normalize_utf8(root);
 
     // Step 3: per-component lstat for symlinks/junctions.
     // Walk the normalized path's portion below the root only (the root itself
@@ -119,6 +114,23 @@ pub fn resolve_and_validate(
     }
 
     Ok(ResolvedPath(normalized))
+}
+
+/// Map a containment refusal onto the executor's failure taxonomy.
+///
+/// Only [`ContainmentError::Escapes`] is `root_escape`; a malformed root or an
+/// unrooted path that cannot be resolved is a bad plan item, not a traversal
+/// attempt, and the two must stay distinguishable in the audit record.
+pub fn containment_failure(error: fs_pathsafe::contain::ContainmentError) -> PlanItemFailure {
+    use fs_pathsafe::contain::ContainmentError as E;
+    let code = match error {
+        E::Escapes { .. } => FailureCode::RootEscape,
+        E::RootMissing { .. }
+        | E::RootNotAbsolute { .. }
+        | E::NotAbsolute { .. }
+        | E::NotNormalized { .. } => FailureCode::PathInvalid,
+    };
+    PlanItemFailure::with_code(code, error.to_string())
 }
 
 /// Lexically normalize a path by collapsing `.` and `..` components **without**

--- a/crates/fs/executor/src/ops/path_gate.rs
+++ b/crates/fs/executor/src/ops/path_gate.rs
@@ -134,36 +134,6 @@ pub fn containment_failure(error: &fs_pathsafe::contain::ContainmentError) -> Pl
     PlanItemFailure::with_code(code, error.to_string())
 }
 
-/// Lexically normalize a path by collapsing `.` and `..` components **without**
-/// making any filesystem calls (no `canonicalize`).
-///
-/// - `.` components are dropped.
-/// - `..` components pop the last pushed component (or are ignored at root).
-/// - Absolute path prefixes (root component) are preserved.
-///
-/// This is intentionally conservative: it does not strip Windows UNC
-/// prefixes or long-path `\\?\` prefixes.
-///
-/// spec 042 (T206): the lexical collapse is delegated to `path-clean`, whose
-/// `PathClean::clean` implements the same purely-lexical algorithm (drop `.`,
-/// pop the element preceding an inner `..`, drop a leading `..` on a rooted
-/// path, preserve the root/prefix). This is *only* the lexical step — the
-/// symlink/junction safety walk in [`resolve_and_validate`] is unchanged and
-/// still runs `symlink_metadata` per component of the original relative path,
-/// so the no-link-following guard (Product Constraints §II) is preserved. The
-/// `lexical_normalize_*` unit tests are the equivalence guard for the collapse.
-#[must_use]
-pub fn lexical_normalize(path: &Utf8Path) -> Utf8PathBuf {
-    use path_clean::PathClean as _;
-    // `path-clean` operates on `std::path`; bridge through it. The input is
-    // already guaranteed UTF-8 and `clean` only drops/pops/reorders existing
-    // components (it never synthesizes new bytes), so the cleaned result is
-    // UTF-8 by construction — the back-conversion cannot lose data.
-    let cleaned = path.as_std_path().clean();
-    Utf8PathBuf::from_path_buf(cleaned)
-        .unwrap_or_else(|p| Utf8PathBuf::from(p.to_string_lossy().into_owned()))
-}
-
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -173,28 +143,6 @@ mod tests {
     /// Convert a tempdir path to a guaranteed-UTF-8 path for the tests.
     fn utf8_root(p: &std::path::Path) -> Utf8PathBuf {
         Utf8PathBuf::from_path_buf(p.to_path_buf()).expect("temp dir path is UTF-8")
-    }
-
-    #[test]
-    fn lexical_normalize_simple_path() {
-        let p = Utf8PathBuf::from("/lib/root/./sub/../file.fits");
-        let n = lexical_normalize(&p);
-        assert_eq!(n, Utf8PathBuf::from("/lib/root/file.fits"));
-    }
-
-    #[test]
-    fn lexical_normalize_no_escape_at_root() {
-        // `..` at the root should not escape.
-        let p = Utf8PathBuf::from("/../../file.fits");
-        let n = lexical_normalize(&p);
-        assert_eq!(n, Utf8PathBuf::from("/file.fits"));
-    }
-
-    #[test]
-    fn lexical_normalize_deep_traversal() {
-        let p = Utf8PathBuf::from("/a/b/c/../../d");
-        let n = lexical_normalize(&p);
-        assert_eq!(n, Utf8PathBuf::from("/a/d"));
     }
 
     #[test]

--- a/crates/fs/executor/src/run/dispatch.rs
+++ b/crates/fs/executor/src/run/dispatch.rs
@@ -1,8 +1,8 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! Pure action → filesystem-op dispatch (no async, no callbacks): resolves
-//! item paths against their roots and calls the matching `ops::*` primitive.
+//! Pure action → filesystem-op dispatch (no async, no callbacks): calls the
+//! matching `ops::*` primitive on paths already resolved by the run loop.
 
 use camino::{Utf8Path, Utf8PathBuf};
 
@@ -13,7 +13,6 @@ use crate::ops::delete_op;
 use crate::ops::link_op;
 use crate::ops::mkdir_op;
 use crate::ops::move_op;
-use crate::ops::path_gate;
 use crate::ops::trash_op;
 use crate::ops::write_manifest_op;
 
@@ -21,47 +20,48 @@ use super::{ExecutorItem, ExecutorItemAction};
 
 pub(super) type OpError = (PlanItemFailure, bool, RollbackOutcome, Option<String>);
 
-pub(super) fn execute_item(item: &ExecutorItem) -> Result<(), OpError> {
-    // Resolve the source and destination paths against the library root (if set).
-    // The path gate has already validated them earlier in the loop; this is the
-    // absolute-path computation for the actual filesystem operation.
-    let resolved_src: Option<Utf8PathBuf> =
-        resolve_item_path(item.source_path.as_deref(), item.library_root.as_deref());
-    // #765: destination_root (picked destination root) takes precedence over
-    // library_root (source root) for the destination join. Falls back to
-    // library_root when destination_root is unset, preserving same-root
-    // behavior for archive/trash/catalogue/legacy items.
-    let resolved_dst: Option<Utf8PathBuf> = resolve_item_path(
-        item.destination_path.as_deref(),
-        item.destination_root.as_deref().or(item.library_root.as_deref()),
-    );
+/// Both sides of an item, resolved and proven contained by
+/// `run::loop_::resolve_item_paths`.
+///
+/// Dispatch takes these rather than the roots so there is one resolution per
+/// item: a second join here disagreed with the gate about which root governs a
+/// destination (astro-plan-3v3r.1.12).
+#[derive(Debug, Clone, Default)]
+pub(super) struct ResolvedItemPaths {
+    pub(super) source: Option<Utf8PathBuf>,
+    pub(super) destination: Option<Utf8PathBuf>,
+}
+
+pub(super) fn execute_item(item: &ExecutorItem, paths: &ResolvedItemPaths) -> Result<(), OpError> {
+    let resolved_src = paths.source.as_deref();
+    let resolved_dst = paths.destination.as_deref();
 
     match &item.action {
         ExecutorItemAction::NoOp => Ok(()),
 
         ExecutorItemAction::Move => {
-            let src = require_resolved_path(resolved_src.as_deref(), "source")?;
-            let dst = require_resolved_path(resolved_dst.as_deref(), "destination")?;
+            let src = require_resolved_path(resolved_src, "source")?;
+            let dst = require_resolved_path(resolved_dst, "destination")?;
             move_op::move_file(src, dst)
                 .map_err(|(f, r)| (f, r.rollback_attempted, r.rollback_outcome, r.rollback_message))
         }
 
         ExecutorItemAction::Archive { archive_destination } => {
-            let src = require_resolved_path(resolved_src.as_deref(), "source")?;
+            let src = require_resolved_path(resolved_src, "source")?;
             // archive_destination is already absolute (pre-computed at plan generation).
             archive_op::archive_file(src, archive_destination)
                 .map_err(|(f, r)| (f, r.rollback_attempted, r.rollback_outcome, r.rollback_message))
         }
 
         ExecutorItemAction::Trash { fallback_archive_destination } => {
-            let src = require_resolved_path(resolved_src.as_deref(), "source")?;
+            let src = require_resolved_path(resolved_src, "source")?;
             trash_op::trash_file(src, fallback_archive_destination.as_deref())
                 .map(|_| ()) // discard TrashResult (audit_reason recorded by caller)
                 .map_err(|(f, r)| (f, r.rollback_attempted, r.rollback_outcome, r.rollback_message))
         }
 
         ExecutorItemAction::Delete => {
-            let src = require_resolved_path(resolved_src.as_deref(), "source")?;
+            let src = require_resolved_path(resolved_src, "source")?;
             // T020: use `destructive_confirmed`, not `is_protected`.
             delete_op::delete_file(src, item.destructive_confirmed)
                 .map_err(|(f, r)| (f, r.rollback_attempted, r.rollback_outcome, None))
@@ -74,38 +74,22 @@ pub(super) fn execute_item(item: &ExecutorItem) -> Result<(), OpError> {
         }
 
         ExecutorItemAction::Mkdir => {
-            let dst = require_resolved_path(resolved_dst.as_deref(), "destination")?;
+            let dst = require_resolved_path(resolved_dst, "destination")?;
             mkdir_op::make_dir(dst).map_err(|f| (f, false, RollbackOutcome::NotApplicable, None))
         }
 
         ExecutorItemAction::Link { kind } => {
-            let src = require_resolved_path(resolved_src.as_deref(), "source")?;
-            let dst = require_resolved_path(resolved_dst.as_deref(), "destination")?;
+            let src = require_resolved_path(resolved_src, "source")?;
+            let dst = require_resolved_path(resolved_dst, "destination")?;
             link_op::create_link(src, dst, *kind)
                 .map_err(|f| (f, false, RollbackOutcome::NotApplicable, None))
         }
 
         ExecutorItemAction::WriteManifest { project_id } => {
-            let dst = require_resolved_path(resolved_dst.as_deref(), "destination")?;
+            let dst = require_resolved_path(resolved_dst, "destination")?;
             write_manifest_op::write_marker(dst, project_id)
                 .map_err(|f| (f, false, RollbackOutcome::NotApplicable, None))
         }
-    }
-}
-
-/// Resolve a relative path against an optional library root.
-/// Returns `None` if either argument is `None`.
-fn resolve_item_path(relative: Option<&Utf8Path>, root: Option<&Utf8Path>) -> Option<Utf8PathBuf> {
-    match (relative, root) {
-        (Some(rel), Some(r)) => {
-            // Use the validated lexical normalization (path_gate already checked safety).
-            Some(path_gate::lexical_normalize(&r.join(rel)))
-        }
-        (Some(rel), None) => {
-            // Legacy: no root — use path as-is.
-            Some(rel.to_path_buf())
-        }
-        _ => None,
     }
 }
 

--- a/crates/fs/executor/src/run/loop_.rs
+++ b/crates/fs/executor/src/run/loop_.rs
@@ -179,7 +179,7 @@ fn resolve_side(
         (Some(path), Some(root)) => path_gate::resolve_and_validate(root, path).map(|r| Some(r.0)),
         (Some(path), None) => fs_pathsafe::contain::resolve_unrooted_utf8(path)
             .map(Some)
-            .map_err(path_gate::containment_failure),
+            .map_err(|e| path_gate::containment_failure(&e)),
     }
 }
 

--- a/crates/fs/executor/src/run/loop_.rs
+++ b/crates/fs/executor/src/run/loop_.rs
@@ -12,7 +12,7 @@ use crate::failure::{FailureCode, PlanItemFailure, RollbackOutcome};
 use crate::ops::cas_check::check_cas;
 use crate::ops::path_gate;
 
-use super::dispatch::execute_item;
+use super::dispatch::{execute_item, ResolvedItemPaths};
 use super::{
     ApplyOutcome, CancellationToken, ExecutorCallbacks, ExecutorItem, ExecutorItemAction,
     ItemProgressEvent, RetryQueue, SkipSet, TerminalCounts,
@@ -148,24 +148,39 @@ async fn drive_plan<C: ExecutorCallbacks>(
 }
 
 /// Path-resolution gate (FR-001/002, D8, T018): resolve and validate both sides
-/// of an item against the roots `dispatch::execute_item` joins them onto, before
-/// any filesystem CAS or mutation.
+/// of an item once, before any filesystem CAS or mutation.
 ///
-/// The destination side (astro-plan-d8cyr) is checked against
-/// `destination_root` alone. Gating the source alone left a traversing or
-/// absolute destination to reach `mkdir`/`link`/`move` unchecked. Falling back
-/// to `library_root` here would put a second fallback behind the one in
-/// `app_core::plan_apply::paths`, and the two would disagree about which root
-/// governs an absolute destination. A side with no root stays ungated, which is
-/// the legacy mode for items carrying pre-resolved absolute paths.
-fn gate_item_paths(item: &ExecutorItem) -> Result<(), PlanItemFailure> {
-    if let (Some(src_rel), Some(root)) = (&item.source_path, &item.library_root) {
-        path_gate::resolve_and_validate(root, src_rel)?;
+/// The resolved paths are what `dispatch::execute_item` operates on. This is the
+/// only place in the executor that chooses a root or performs a join: a second
+/// resolution downstream is how a destination gated against `destination_root`
+/// reached `mkdir`/`link`/`move` joined onto `library_root` instead
+/// (astro-plan-3v3r.1.12). `destination_root` still takes precedence over
+/// `library_root` (#765), and the fallback now exists exactly once.
+///
+/// A side with no root is refused unless it carries an absolute, already-normal
+/// path, which is the legacy mode for items storing a pre-resolved destination
+/// (`fs_pathsafe::contain::resolve_unrooted`).
+fn resolve_item_paths(item: &ExecutorItem) -> Result<ResolvedItemPaths, PlanItemFailure> {
+    Ok(ResolvedItemPaths {
+        source: resolve_side(item.source_path.as_deref(), item.library_root.as_deref())?,
+        destination: resolve_side(
+            item.destination_path.as_deref(),
+            item.destination_root.as_deref().or(item.library_root.as_deref()),
+        )?,
+    })
+}
+
+fn resolve_side(
+    path: Option<&camino::Utf8Path>,
+    root: Option<&camino::Utf8Path>,
+) -> Result<Option<Utf8PathBuf>, PlanItemFailure> {
+    match (path, root) {
+        (None, _) => Ok(None),
+        (Some(path), Some(root)) => path_gate::resolve_and_validate(root, path).map(|r| Some(r.0)),
+        (Some(path), None) => fs_pathsafe::contain::resolve_unrooted_utf8(path)
+            .map(Some)
+            .map_err(path_gate::containment_failure),
     }
-    if let (Some(dst_rel), Some(root)) = (&item.destination_path, &item.destination_root) {
-        path_gate::resolve_and_validate(root, dst_rel)?;
-    }
-    Ok(())
 }
 
 /// Outcome of one retry-queue drain pass.
@@ -407,36 +422,31 @@ async fn process_single_item<C: ExecutorCallbacks>(
         callbacks.on_item_start(&item.id).await;
     }
 
-    if let Err(gate_failure) = gate_item_paths(item) {
-        let audit_reason = gate_failure.code.as_str().to_owned();
-        let triggers_pause = gate_failure.code.triggers_pause();
-        callbacks
-            .on_item_progress(ItemProgressEvent::terminal(
-                item.id.clone(),
-                "applying",
-                "refused",
-                Some(gate_failure),
-                Some(audit_reason),
-            ))
-            .await;
-        counts.failed += 1;
-        if triggers_pause {
-            return ItemOutcome::Pause("path.invalid".to_owned());
+    let resolved_paths = match resolve_item_paths(item) {
+        Ok(paths) => paths,
+        Err(gate_failure) => {
+            let audit_reason = gate_failure.code.as_str().to_owned();
+            let triggers_pause = gate_failure.code.triggers_pause();
+            callbacks
+                .on_item_progress(ItemProgressEvent::terminal(
+                    item.id.clone(),
+                    "applying",
+                    "refused",
+                    Some(gate_failure),
+                    Some(audit_reason),
+                ))
+                .await;
+            counts.failed += 1;
+            if triggers_pause {
+                return ItemOutcome::Pause("path.invalid".to_owned());
+            }
+            return ItemOutcome::Continue;
         }
-        return ItemOutcome::Continue;
-    }
+    };
 
-    // Per-item FS CAS revalidation (R-FS-1).
-    // Use the library-root-resolved path if available; otherwise use the raw path (legacy).
-    let resolved_source_for_cas: Option<Utf8PathBuf> =
-        if let (Some(ref src_rel), Some(ref root)) = (&item.source_path, &item.library_root) {
-            // Already validated above; re-resolve (cheap lexical op).
-            path_gate::resolve_and_validate(root, src_rel).ok().map(|r| r.0)
-        } else {
-            item.source_path.clone()
-        };
-
-    if let Some(ref src) = resolved_source_for_cas {
+    // Per-item FS CAS revalidation (R-FS-1) against the same resolved path the
+    // mutation will use, so the snapshot cannot be checked on a different file.
+    if let Some(ref src) = resolved_paths.source {
         if let Err(stale_failure) = check_cas(src, &item.cas_snapshot) {
             let triggers_pause = stale_failure.code.triggers_pause();
             let failure_clone = stale_failure.clone();
@@ -490,21 +500,22 @@ async fn process_single_item<C: ExecutorCallbacks>(
     // dedicated blocking thread pool and yields the worker thread back to the
     // runtime until the fs op completes.
     let item_for_blocking = item.clone();
-    let op_result = tokio::task::spawn_blocking(move || execute_item(&item_for_blocking))
-        .await
-        .unwrap_or_else(|join_err| {
-            // The blocking task panicked. Surface it as an internal failure
-            // rather than propagating the panic through the executor loop.
-            Err((
-                PlanItemFailure::with_code(
-                    FailureCode::Unknown,
-                    format!("filesystem worker task failed: {join_err}"),
-                ),
-                false,
-                RollbackOutcome::NotApplicable,
-                None,
-            ))
-        });
+    let op_result =
+        tokio::task::spawn_blocking(move || execute_item(&item_for_blocking, &resolved_paths))
+            .await
+            .unwrap_or_else(|join_err| {
+                // The blocking task panicked. Surface it as an internal failure
+                // rather than propagating the panic through the executor loop.
+                Err((
+                    PlanItemFailure::with_code(
+                        FailureCode::Unknown,
+                        format!("filesystem worker task failed: {join_err}"),
+                    ),
+                    false,
+                    RollbackOutcome::NotApplicable,
+                    None,
+                ))
+            });
 
     match op_result {
         Ok(()) => {

--- a/crates/fs/executor/tests/destination_containment.rs
+++ b/crates/fs/executor/tests/destination_containment.rs
@@ -1,0 +1,251 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Destination containment (astro-plan-3v3r.1.12).
+//!
+//! The run loop gated a destination against `destination_root` while dispatch
+//! joined it onto `destination_root.or(library_root)`. An item carrying only a
+//! `library_root` therefore reached `move`, `mkdir`, and `write_manifest` with a
+//! destination nobody had checked: a `../` or absolute value mutated outside
+//! every library root and the item was recorded `succeeded`.
+//!
+//! Each test asserts on the filesystem outside the root, not only on the event,
+//! because the defect's signature was a mutation that happened and was reported
+//! as a contained, reviewed action.
+
+use camino::Utf8PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use fs_executor::ops::cas_check::CasSnapshot;
+use fs_executor::run::{
+    execute_plan, CancellationToken, ExecutorCallbacks, ExecutorItem, ExecutorItemAction,
+    ItemProgressEvent, RetryQueue, SkipSet,
+};
+
+fn utf8(p: &std::path::Path) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(p.to_path_buf()).expect("temp dir path is UTF-8")
+}
+
+#[derive(Default, Clone)]
+struct RecordingCallbacks {
+    events: Arc<Mutex<Vec<ItemProgressEvent>>>,
+}
+
+impl ExecutorCallbacks for RecordingCallbacks {
+    fn on_item_start(
+        &self,
+        _item_id: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn on_item_progress(
+        &self,
+        event: ItemProgressEvent,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        let events = self.events.clone();
+        Box::pin(async move {
+            events.lock().await.push(event);
+        })
+    }
+}
+
+/// An item with a `library_root` and no `destination_root`, which is the shape
+/// the run loop left ungated.
+fn item_with_library_root_only(
+    id: &str,
+    action: ExecutorItemAction,
+    source_path: Option<Utf8PathBuf>,
+    destination_path: Option<Utf8PathBuf>,
+    library_root: Utf8PathBuf,
+) -> ExecutorItem {
+    ExecutorItem {
+        id: id.to_owned(),
+        plan_id: "plan-containment".to_owned(),
+        action,
+        source_path,
+        destination_path,
+        library_root: Some(library_root),
+        destination_root: None,
+        cas_snapshot: CasSnapshot { approved_mtime: None, approved_size_bytes: None },
+        is_protected: false,
+        requires_destructive_confirm: false,
+        destructive_confirmed: false,
+        current_state: "pending".to_owned(),
+    }
+}
+
+async fn apply(item: ExecutorItem) -> Vec<ItemProgressEvent> {
+    let cb = RecordingCallbacks::default();
+    execute_plan(vec![item], &cb, &CancellationToken::new(), &SkipSet::new(), &RetryQueue::new())
+        .await;
+    let events = cb.events.lock().await.clone();
+    events
+}
+
+fn assert_refused(events: &[ItemProgressEvent]) {
+    let last = events.last().expect("at least one event");
+    assert_eq!(
+        last.new_state, "refused",
+        "uncontained destination must be refused, got state '{}'",
+        last.new_state
+    );
+}
+
+#[tokio::test]
+async fn a_traversing_move_destination_never_escapes_its_root() {
+    let root_dir = tempfile::tempdir().unwrap();
+    let outside_dir = tempfile::tempdir().unwrap();
+    let root = utf8(root_dir.path());
+    std::fs::write(root_dir.path().join("frame.fits"), b"data").unwrap();
+
+    // `../<outside-dir-name>/stolen.fits` relative to the root, so the escape
+    // target is a real directory this test owns rather than a path under `/`.
+    let escape = Utf8PathBuf::from(format!(
+        "../{}/stolen.fits",
+        outside_dir.path().file_name().unwrap().to_str().unwrap()
+    ));
+
+    let events = apply(item_with_library_root_only(
+        "move-escape",
+        ExecutorItemAction::Move,
+        Some(Utf8PathBuf::from("frame.fits")),
+        Some(escape),
+        root,
+    ))
+    .await;
+
+    assert_refused(&events);
+    assert!(
+        !outside_dir.path().join("stolen.fits").exists(),
+        "move wrote outside every library root"
+    );
+    assert!(root_dir.path().join("frame.fits").exists(), "source must be left in place");
+}
+
+#[tokio::test]
+async fn an_absolute_move_destination_never_replaces_its_root() {
+    let root_dir = tempfile::tempdir().unwrap();
+    let outside_dir = tempfile::tempdir().unwrap();
+    let root = utf8(root_dir.path());
+    std::fs::write(root_dir.path().join("frame.fits"), b"data").unwrap();
+
+    let absolute_outside = utf8(&outside_dir.path().join("stolen.fits"));
+
+    let events = apply(item_with_library_root_only(
+        "move-absolute",
+        ExecutorItemAction::Move,
+        Some(Utf8PathBuf::from("frame.fits")),
+        Some(absolute_outside),
+        root,
+    ))
+    .await;
+
+    assert_refused(&events);
+    assert!(
+        !outside_dir.path().join("stolen.fits").exists(),
+        "an absolute destination replaced the root"
+    );
+}
+
+#[tokio::test]
+async fn a_traversing_mkdir_destination_never_escapes_its_root() {
+    let root_dir = tempfile::tempdir().unwrap();
+    let outside_dir = tempfile::tempdir().unwrap();
+    let root = utf8(root_dir.path());
+
+    let escape = Utf8PathBuf::from(format!(
+        "../{}/created",
+        outside_dir.path().file_name().unwrap().to_str().unwrap()
+    ));
+
+    let events = apply(item_with_library_root_only(
+        "mkdir-escape",
+        ExecutorItemAction::Mkdir,
+        None,
+        Some(escape),
+        root,
+    ))
+    .await;
+
+    assert_refused(&events);
+    assert!(!outside_dir.path().join("created").exists(), "mkdir created a directory outside");
+}
+
+#[tokio::test]
+async fn a_traversing_manifest_destination_never_escapes_its_root() {
+    let root_dir = tempfile::tempdir().unwrap();
+    let outside_dir = tempfile::tempdir().unwrap();
+    let root = utf8(root_dir.path());
+
+    let escape = Utf8PathBuf::from(format!(
+        "../{}/marker.json",
+        outside_dir.path().file_name().unwrap().to_str().unwrap()
+    ));
+
+    let events = apply(item_with_library_root_only(
+        "manifest-escape",
+        ExecutorItemAction::WriteManifest { project_id: "proj-1".to_owned() },
+        None,
+        Some(escape),
+        root,
+    ))
+    .await;
+
+    assert_refused(&events);
+    assert!(!outside_dir.path().join("marker.json").exists(), "manifest written outside");
+}
+
+/// A rootless relative destination resolved against the process working
+/// directory, which is the repository checkout under test.
+#[tokio::test]
+async fn a_rootless_relative_destination_is_refused_rather_than_cwd_relative() {
+    let root_dir = tempfile::tempdir().unwrap();
+    std::fs::write(root_dir.path().join("frame.fits"), b"data").unwrap();
+
+    let item = ExecutorItem {
+        id: "rootless".to_owned(),
+        plan_id: "plan-containment".to_owned(),
+        action: ExecutorItemAction::Mkdir,
+        source_path: None,
+        destination_path: Some(Utf8PathBuf::from("cwd-relative-dir")),
+        library_root: None,
+        destination_root: None,
+        cas_snapshot: CasSnapshot { approved_mtime: None, approved_size_bytes: None },
+        is_protected: false,
+        requires_destructive_confirm: false,
+        destructive_confirmed: false,
+        current_state: "pending".to_owned(),
+    };
+
+    let events = apply(item).await;
+
+    assert_refused(&events);
+    assert!(
+        !std::path::Path::new("cwd-relative-dir").exists(),
+        "a rootless relative destination resolved against the process cwd"
+    );
+}
+
+/// A destination whose parent does not exist yet is the normal case for a write:
+/// containment is lexical, so it must resolve rather than be refused for absence.
+#[tokio::test]
+async fn a_destination_whose_leaf_does_not_exist_yet_is_contained() {
+    let root_dir = tempfile::tempdir().unwrap();
+    let root = utf8(root_dir.path());
+
+    let events = apply(item_with_library_root_only(
+        "new-leaf",
+        ExecutorItemAction::Mkdir,
+        None,
+        Some(Utf8PathBuf::from("brand/new/leaf")),
+        root,
+    ))
+    .await;
+
+    let last = events.last().expect("at least one event");
+    assert_eq!(last.new_state, "succeeded", "a non-existent leaf must not be refused");
+    assert!(root_dir.path().join("brand/new/leaf").is_dir());
+}

--- a/crates/fs/pathsafe/Cargo.toml
+++ b/crates/fs/pathsafe/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 camino = { workspace = true }
+path-clean = { workspace = true }
 safe-filename = { path = "../../safe-filename" }
 
 [dev-dependencies]

--- a/crates/fs/pathsafe/Cargo.toml
+++ b/crates/fs/pathsafe/Cargo.toml
@@ -12,6 +12,11 @@ camino = { workspace = true }
 path-clean = { workspace = true }
 safe-filename = { path = "../../safe-filename" }
 
+[features]
+# Enables `test_support` for crates that build containment fixtures in their own
+# tests. Off by default, so the helpers stay out of release builds.
+test-fixture = []
+
 [dev-dependencies]
 proptest.workspace = true
 tempfile.workspace = true

--- a/crates/fs/pathsafe/src/contain.rs
+++ b/crates/fs/pathsafe/src/contain.rs
@@ -184,10 +184,32 @@ pub fn resolve_in_root_utf8(
     path: &camino::Utf8Path,
 ) -> Result<camino::Utf8PathBuf, ContainmentError> {
     let contained = resolve_in_root(root.as_std_path(), path.as_std_path())?;
-    // `clean` only drops, pops, and reorders existing components, so a UTF-8
-    // input cannot produce a non-UTF-8 result.
-    Ok(camino::Utf8PathBuf::from_path_buf(contained.into_path_buf())
-        .unwrap_or_else(|p| camino::Utf8PathBuf::from(p.to_string_lossy().into_owned())))
+    Ok(to_utf8(contained.into_path_buf()))
+}
+
+/// Camino-typed [`resolve_unrooted`].
+///
+/// # Errors
+///
+/// As [`resolve_unrooted`].
+pub fn resolve_unrooted_utf8(
+    path: &camino::Utf8Path,
+) -> Result<camino::Utf8PathBuf, ContainmentError> {
+    let contained = resolve_unrooted(path.as_std_path())?;
+    Ok(to_utf8(contained.into_path_buf()))
+}
+
+/// Camino-typed [`normalize`].
+#[must_use]
+pub fn normalize_utf8(path: &camino::Utf8Path) -> camino::Utf8PathBuf {
+    to_utf8(normalize(path.as_std_path()))
+}
+
+/// `clean` only drops, pops, and reorders existing components, so a UTF-8 input
+/// cannot produce a non-UTF-8 result; the fallback is unreachable in practice.
+fn to_utf8(path: PathBuf) -> camino::Utf8PathBuf {
+    camino::Utf8PathBuf::from_path_buf(path)
+        .unwrap_or_else(|p| camino::Utf8PathBuf::from(p.to_string_lossy().into_owned()))
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/fs/pathsafe/src/contain.rs
+++ b/crates/fs/pathsafe/src/contain.rs
@@ -198,7 +198,11 @@ fn to_utf8(path: PathBuf) -> camino::Utf8PathBuf {
 mod tests {
     use super::*;
 
-    const ROOT: &str = "/mnt/library";
+    use crate::test_support::abs_path as p;
+
+    fn root() -> PathBuf {
+        p("/mnt/library")
+    }
 
     /// The collapse is delegated to `path-clean`; these are the equivalence
     /// guard for it, moved here when `path_gate::lexical_normalize` folded into
@@ -223,28 +227,27 @@ mod tests {
 
     #[test]
     fn relative_path_inside_the_root_resolves() {
-        let contained = resolve_in_root(Path::new(ROOT), Path::new("targets/m31/light.fits"))
-            .expect("inside the root");
-        assert_eq!(contained.as_path(), Path::new("/mnt/library/targets/m31/light.fits"));
+        let contained =
+            resolve_in_root(&root(), Path::new("targets/m31/light.fits")).expect("inside the root");
+        assert_eq!(contained.as_path(), p("/mnt/library/targets/m31/light.fits"));
     }
 
     #[test]
     fn relative_path_that_escapes_after_normalization_is_refused() {
-        let err = resolve_in_root(Path::new(ROOT), Path::new("targets/../../outside/x.fits"))
-            .unwrap_err();
+        let err = resolve_in_root(&root(), Path::new("targets/../../outside/x.fits")).unwrap_err();
         assert!(matches!(err, ContainmentError::Escapes { .. }), "{err}");
     }
 
     #[test]
     fn absolute_path_inside_the_root_resolves() {
-        let contained = resolve_in_root(Path::new(ROOT), Path::new("/mnt/library/views/a.fits"))
-            .expect("inside the root");
-        assert_eq!(contained.as_path(), Path::new("/mnt/library/views/a.fits"));
+        let contained =
+            resolve_in_root(&root(), &p("/mnt/library/views/a.fits")).expect("inside the root");
+        assert_eq!(contained.as_path(), p("/mnt/library/views/a.fits"));
     }
 
     #[test]
     fn absolute_path_outside_the_root_does_not_replace_it() {
-        let err = resolve_in_root(Path::new(ROOT), Path::new("/etc/passwd")).unwrap_err();
+        let err = resolve_in_root(&root(), &p("/etc/passwd")).unwrap_err();
         assert!(matches!(err, ContainmentError::Escapes { .. }), "{err}");
     }
 
@@ -252,16 +255,15 @@ mod tests {
     fn a_leaf_that_does_not_exist_is_contained() {
         // No filesystem entry is created anywhere in this crate's tests; the
         // verdict is lexical, which is what makes a write destination resolvable.
-        let contained =
-            resolve_in_root(Path::new(ROOT), Path::new("brand/new/dir/file.fits")).unwrap();
-        assert_eq!(contained.as_path(), Path::new("/mnt/library/brand/new/dir/file.fits"));
+        let contained = resolve_in_root(&root(), Path::new("brand/new/dir/file.fits")).unwrap();
+        assert_eq!(contained.as_path(), p("/mnt/library/brand/new/dir/file.fits"));
     }
 
     #[test]
     fn a_path_that_traverses_out_of_an_absolute_root_is_refused() {
         // The defect this rule replaces: `starts_with` on unnormalized text
         // accepted this pair, because the text prefix matched.
-        let err = resolve_in_root(Path::new(ROOT), Path::new("/mnt/library/../../a")).unwrap_err();
+        let err = resolve_in_root(&root(), &p("/mnt/library/../../a")).unwrap_err();
         assert!(matches!(err, ContainmentError::Escapes { .. }), "{err}");
     }
 
@@ -273,8 +275,8 @@ mod tests {
 
     #[test]
     fn unrooted_accepts_an_absolute_normal_path() {
-        let contained = resolve_unrooted(Path::new("/mnt/archive/plan/x.fits")).unwrap();
-        assert_eq!(contained.as_path(), Path::new("/mnt/archive/plan/x.fits"));
+        let contained = resolve_unrooted(&p("/mnt/archive/plan/x.fits")).unwrap();
+        assert_eq!(contained.as_path(), p("/mnt/archive/plan/x.fits"));
     }
 
     #[test]
@@ -285,26 +287,25 @@ mod tests {
 
     #[test]
     fn unrooted_refuses_a_traversing_absolute_path() {
-        let err = resolve_unrooted(Path::new("/mnt/archive/../../etc/passwd")).unwrap_err();
+        let err = resolve_unrooted(&p("/mnt/archive/../../etc/passwd")).unwrap_err();
         assert!(matches!(err, ContainmentError::NotNormalized { .. }), "{err}");
     }
 
     #[test]
     fn contained_in_any_finds_the_matching_root() {
-        let a = Path::new("/mnt/a");
-        let b = Path::new("/mnt/b");
-        assert!(contained_in_any(Path::new("/mnt/b/project"), &[a, b]));
-        assert!(!contained_in_any(Path::new("/tmp/scratch"), &[a, b]));
+        let (a, b) = (p("/mnt/a"), p("/mnt/b"));
+        let roots = [a.as_path(), b.as_path()];
+        assert!(contained_in_any(&p("/mnt/b/project"), &roots));
+        assert!(!contained_in_any(&p("/tmp/scratch"), &roots));
     }
 
     #[test]
     fn contained_in_any_refuses_when_no_root_is_registered() {
-        assert!(!contained_in_any(Path::new("/anywhere"), &[]));
+        assert!(!contained_in_any(&p("/anywhere"), &[]));
     }
 
     #[test]
     fn contained_in_any_normalizes_before_comparing() {
-        let root = Path::new("/mnt/library");
-        assert!(!contained_in_any(Path::new("/mnt/library/../../a"), &[root]));
+        assert!(!contained_in_any(&p("/mnt/library/../../a"), &[root().as_path()]));
     }
 }

--- a/crates/fs/pathsafe/src/contain.rs
+++ b/crates/fs/pathsafe/src/contain.rs
@@ -145,26 +145,6 @@ pub fn resolve_unrooted(path: &Path) -> Result<ContainedPath, ContainmentError> 
     }
 }
 
-/// Resolve `path` against a root that may be absent.
-///
-/// A present root delegates to [`resolve_in_root`]. An absent root is refused:
-/// the rootless shape is [`resolve_unrooted`], and a caller that legitimately
-/// holds a pre-resolved absolute path calls it by name.
-///
-/// # Errors
-///
-/// [`ContainmentError::RootMissing`] when `root` is `None`, plus every error of
-/// [`resolve_in_root`].
-pub fn resolve_in_optional_root(
-    root: Option<&Path>,
-    path: &Path,
-) -> Result<ContainedPath, ContainmentError> {
-    match root {
-        Some(root) => resolve_in_root(root, path),
-        None => Err(ContainmentError::RootMissing { path: path.to_path_buf() }),
-    }
-}
-
 /// Report whether `path` resolves inside at least one of `roots`.
 ///
 /// An empty `roots` is not contained: no registered root means nothing to be
@@ -220,6 +200,27 @@ mod tests {
 
     const ROOT: &str = "/mnt/library";
 
+    /// The collapse is delegated to `path-clean`; these are the equivalence
+    /// guard for it, moved here when `path_gate::lexical_normalize` folded into
+    /// this one implementation.
+    #[test]
+    fn normalize_collapses_dot_and_dotdot() {
+        assert_eq!(
+            normalize(Path::new("/lib/root/./sub/../file.fits")),
+            Path::new("/lib/root/file.fits")
+        );
+    }
+
+    #[test]
+    fn normalize_does_not_escape_at_the_root() {
+        assert_eq!(normalize(Path::new("/../../file.fits")), Path::new("/file.fits"));
+    }
+
+    #[test]
+    fn normalize_collapses_deep_traversal() {
+        assert_eq!(normalize(Path::new("/a/b/c/../../d")), Path::new("/a/d"));
+    }
+
     #[test]
     fn relative_path_inside_the_root_resolves() {
         let contained = resolve_in_root(Path::new(ROOT), Path::new("targets/m31/light.fits"))
@@ -268,18 +269,6 @@ mod tests {
     fn a_relative_root_is_refused() {
         let err = resolve_in_root(Path::new("library"), Path::new("x.fits")).unwrap_err();
         assert!(matches!(err, ContainmentError::RootNotAbsolute { .. }), "{err}");
-    }
-
-    #[test]
-    fn an_absent_root_refuses_a_relative_path() {
-        let err = resolve_in_optional_root(None, Path::new("sub/x.fits")).unwrap_err();
-        assert!(matches!(err, ContainmentError::RootMissing { .. }), "{err}");
-    }
-
-    #[test]
-    fn an_absent_root_refuses_an_absolute_path_too() {
-        let err = resolve_in_optional_root(None, Path::new("/mnt/library/x.fits")).unwrap_err();
-        assert!(matches!(err, ContainmentError::RootMissing { .. }), "{err}");
     }
 
     #[test]

--- a/crates/fs/pathsafe/src/contain.rs
+++ b/crates/fs/pathsafe/src/contain.rs
@@ -1,0 +1,299 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Root containment: the one rule for resolving a caller-supplied path against
+//! a library, project, or archive root.
+//!
+//! See `specs/tiny/root-relative-path-containment.md`.
+//!
+//! The verdict is purely lexical. `canonicalize` follows symlinks, which the
+//! Product Constraints forbid, and it fails on a path that does not exist yet,
+//! which is the normal case for a write destination. Both the path and the root
+//! are normalized before the prefix comparison: `starts_with` against an
+//! unnormalized root accepts `/mnt/library/../../a` as contained.
+//!
+//! Link refusal is a separate concern and stays in
+//! `fs_executor::ops::path_gate`, which walks each component with `lstat`.
+
+use std::path::{Path, PathBuf};
+
+use path_clean::PathClean as _;
+
+/// A path proven to resolve inside its root.
+///
+/// The inner path is lexically normalized and absolute whenever the root was.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContainedPath(PathBuf);
+
+impl ContainedPath {
+    #[must_use]
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn into_path_buf(self) -> PathBuf {
+        self.0
+    }
+}
+
+/// Why a path could not be resolved inside a root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContainmentError {
+    /// A root-relative path was supplied with no root to resolve it against.
+    RootMissing { path: PathBuf },
+    /// The root itself is relative, so everything resolved against it would
+    /// depend on the process working directory.
+    RootNotAbsolute { root: PathBuf },
+    /// The path resolves outside its root.
+    Escapes { root: PathBuf, resolved: PathBuf },
+    /// An unrooted path is relative, so it would resolve against the process
+    /// working directory.
+    NotAbsolute { path: PathBuf },
+    /// An unrooted absolute path carries `.` or `..` components, so its target
+    /// depends on where the caller reads it.
+    NotNormalized { path: PathBuf, normalized: PathBuf },
+}
+
+impl std::fmt::Display for ContainmentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RootMissing { path } => {
+                write!(f, "path '{}' is root-relative but no root was resolved", path.display())
+            }
+            Self::RootNotAbsolute { root } => write!(
+                f,
+                "root '{}' is not absolute; it would resolve against the process working \
+                 directory",
+                root.display()
+            ),
+            Self::Escapes { root, resolved } => write!(
+                f,
+                "path escapes root '{}' after normalization; resolved to '{}'",
+                root.display(),
+                resolved.display()
+            ),
+            Self::NotAbsolute { path } => write!(
+                f,
+                "path '{}' has no root and is not absolute; it would resolve against the \
+                 process working directory",
+                path.display()
+            ),
+            Self::NotNormalized { path, normalized } => write!(
+                f,
+                "unrooted path '{}' carries '.' or '..' components; normalizes to '{}'",
+                path.display(),
+                normalized.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ContainmentError {}
+
+/// Lexically normalize a path: collapse `.` and inner `..`, preserve the root or
+/// prefix component, make no filesystem call.
+#[must_use]
+pub fn normalize(path: &Path) -> PathBuf {
+    path.clean()
+}
+
+/// Resolve `path` against `root` and prove the result stays inside it.
+///
+/// An absolute `path` is used as supplied rather than joined, so containment is
+/// decided by the same prefix check either way. A leaf that does not exist is
+/// contained on its lexical form alone.
+///
+/// # Errors
+///
+/// [`ContainmentError::RootNotAbsolute`] for a relative root;
+/// [`ContainmentError::Escapes`] when the normalized result does not start with
+/// the normalized root.
+pub fn resolve_in_root(root: &Path, path: &Path) -> Result<ContainedPath, ContainmentError> {
+    if !root.is_absolute() {
+        return Err(ContainmentError::RootNotAbsolute { root: root.to_path_buf() });
+    }
+    let root = normalize(root);
+    let resolved = normalize(&root.join(path));
+    if resolved.starts_with(&root) {
+        Ok(ContainedPath(resolved))
+    } else {
+        Err(ContainmentError::Escapes { root, resolved })
+    }
+}
+
+/// Accept a path that carries no root, which requires it to be already absolute
+/// and already normal.
+///
+/// Callers name this entry point to opt into an unrooted path (plan items that
+/// store a pre-resolved absolute destination). No arm of [`resolve_in_root`]
+/// reaches it, so a missing root can never silently produce one.
+///
+/// # Errors
+///
+/// [`ContainmentError::NotAbsolute`] for a relative path;
+/// [`ContainmentError::NotNormalized`] when normalization changes the path.
+pub fn resolve_unrooted(path: &Path) -> Result<ContainedPath, ContainmentError> {
+    if !path.is_absolute() {
+        return Err(ContainmentError::NotAbsolute { path: path.to_path_buf() });
+    }
+    let normalized = normalize(path);
+    if normalized == path {
+        Ok(ContainedPath(normalized))
+    } else {
+        Err(ContainmentError::NotNormalized { path: path.to_path_buf(), normalized })
+    }
+}
+
+/// Resolve `path` against a root that may be absent.
+///
+/// A present root delegates to [`resolve_in_root`]. An absent root is refused:
+/// the rootless shape is [`resolve_unrooted`], and a caller that legitimately
+/// holds a pre-resolved absolute path calls it by name.
+///
+/// # Errors
+///
+/// [`ContainmentError::RootMissing`] when `root` is `None`, plus every error of
+/// [`resolve_in_root`].
+pub fn resolve_in_optional_root(
+    root: Option<&Path>,
+    path: &Path,
+) -> Result<ContainedPath, ContainmentError> {
+    match root {
+        Some(root) => resolve_in_root(root, path),
+        None => Err(ContainmentError::RootMissing { path: path.to_path_buf() }),
+    }
+}
+
+/// Report whether `path` resolves inside at least one of `roots`.
+///
+/// An empty `roots` is not contained: no registered root means nothing to be
+/// inside of.
+#[must_use]
+pub fn contained_in_any(path: &Path, roots: &[&Path]) -> bool {
+    roots.iter().any(|root| resolve_in_root(root, path).is_ok())
+}
+
+/// Camino-typed [`resolve_in_root`] for callers that hold `Utf8Path`.
+///
+/// # Errors
+///
+/// As [`resolve_in_root`].
+pub fn resolve_in_root_utf8(
+    root: &camino::Utf8Path,
+    path: &camino::Utf8Path,
+) -> Result<camino::Utf8PathBuf, ContainmentError> {
+    let contained = resolve_in_root(root.as_std_path(), path.as_std_path())?;
+    // `clean` only drops, pops, and reorders existing components, so a UTF-8
+    // input cannot produce a non-UTF-8 result.
+    Ok(camino::Utf8PathBuf::from_path_buf(contained.into_path_buf())
+        .unwrap_or_else(|p| camino::Utf8PathBuf::from(p.to_string_lossy().into_owned())))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ROOT: &str = "/mnt/library";
+
+    #[test]
+    fn relative_path_inside_the_root_resolves() {
+        let contained = resolve_in_root(Path::new(ROOT), Path::new("targets/m31/light.fits"))
+            .expect("inside the root");
+        assert_eq!(contained.as_path(), Path::new("/mnt/library/targets/m31/light.fits"));
+    }
+
+    #[test]
+    fn relative_path_that_escapes_after_normalization_is_refused() {
+        let err = resolve_in_root(Path::new(ROOT), Path::new("targets/../../outside/x.fits"))
+            .unwrap_err();
+        assert!(matches!(err, ContainmentError::Escapes { .. }), "{err}");
+    }
+
+    #[test]
+    fn absolute_path_inside_the_root_resolves() {
+        let contained = resolve_in_root(Path::new(ROOT), Path::new("/mnt/library/views/a.fits"))
+            .expect("inside the root");
+        assert_eq!(contained.as_path(), Path::new("/mnt/library/views/a.fits"));
+    }
+
+    #[test]
+    fn absolute_path_outside_the_root_does_not_replace_it() {
+        let err = resolve_in_root(Path::new(ROOT), Path::new("/etc/passwd")).unwrap_err();
+        assert!(matches!(err, ContainmentError::Escapes { .. }), "{err}");
+    }
+
+    #[test]
+    fn a_leaf_that_does_not_exist_is_contained() {
+        // No filesystem entry is created anywhere in this crate's tests; the
+        // verdict is lexical, which is what makes a write destination resolvable.
+        let contained =
+            resolve_in_root(Path::new(ROOT), Path::new("brand/new/dir/file.fits")).unwrap();
+        assert_eq!(contained.as_path(), Path::new("/mnt/library/brand/new/dir/file.fits"));
+    }
+
+    #[test]
+    fn a_path_that_traverses_out_of_an_absolute_root_is_refused() {
+        // The defect this rule replaces: `starts_with` on unnormalized text
+        // accepted this pair, because the text prefix matched.
+        let err = resolve_in_root(Path::new(ROOT), Path::new("/mnt/library/../../a")).unwrap_err();
+        assert!(matches!(err, ContainmentError::Escapes { .. }), "{err}");
+    }
+
+    #[test]
+    fn a_relative_root_is_refused() {
+        let err = resolve_in_root(Path::new("library"), Path::new("x.fits")).unwrap_err();
+        assert!(matches!(err, ContainmentError::RootNotAbsolute { .. }), "{err}");
+    }
+
+    #[test]
+    fn an_absent_root_refuses_a_relative_path() {
+        let err = resolve_in_optional_root(None, Path::new("sub/x.fits")).unwrap_err();
+        assert!(matches!(err, ContainmentError::RootMissing { .. }), "{err}");
+    }
+
+    #[test]
+    fn an_absent_root_refuses_an_absolute_path_too() {
+        let err = resolve_in_optional_root(None, Path::new("/mnt/library/x.fits")).unwrap_err();
+        assert!(matches!(err, ContainmentError::RootMissing { .. }), "{err}");
+    }
+
+    #[test]
+    fn unrooted_accepts_an_absolute_normal_path() {
+        let contained = resolve_unrooted(Path::new("/mnt/archive/plan/x.fits")).unwrap();
+        assert_eq!(contained.as_path(), Path::new("/mnt/archive/plan/x.fits"));
+    }
+
+    #[test]
+    fn unrooted_refuses_a_relative_path() {
+        let err = resolve_unrooted(Path::new("plan/x.fits")).unwrap_err();
+        assert!(matches!(err, ContainmentError::NotAbsolute { .. }), "{err}");
+    }
+
+    #[test]
+    fn unrooted_refuses_a_traversing_absolute_path() {
+        let err = resolve_unrooted(Path::new("/mnt/archive/../../etc/passwd")).unwrap_err();
+        assert!(matches!(err, ContainmentError::NotNormalized { .. }), "{err}");
+    }
+
+    #[test]
+    fn contained_in_any_finds_the_matching_root() {
+        let a = Path::new("/mnt/a");
+        let b = Path::new("/mnt/b");
+        assert!(contained_in_any(Path::new("/mnt/b/project"), &[a, b]));
+        assert!(!contained_in_any(Path::new("/tmp/scratch"), &[a, b]));
+    }
+
+    #[test]
+    fn contained_in_any_refuses_when_no_root_is_registered() {
+        assert!(!contained_in_any(Path::new("/anywhere"), &[]));
+    }
+
+    #[test]
+    fn contained_in_any_normalizes_before_comparing() {
+        let root = Path::new("/mnt/library");
+        assert!(!contained_in_any(Path::new("/mnt/library/../../a"), &[root]));
+    }
+}

--- a/crates/fs/pathsafe/src/lib.rs
+++ b/crates/fs/pathsafe/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod contain;
 pub mod export_dest;
+pub mod test_support;
 
 use std::fs::{self, Metadata};
 use std::io;

--- a/crates/fs/pathsafe/src/lib.rs
+++ b/crates/fs/pathsafe/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod contain;
 pub mod export_dest;
+#[cfg(any(test, feature = "test-fixture"))]
 pub mod test_support;
 
 use std::fs::{self, Metadata};

--- a/crates/fs/pathsafe/src/lib.rs
+++ b/crates/fs/pathsafe/src/lib.rs
@@ -19,6 +19,7 @@
 //! in depth for reparse-point kinds `is_symlink()` might not classify as a
 //! symlink — callers should treat any doubt as "skip".
 
+pub mod contain;
 pub mod export_dest;
 
 use std::fs::{self, Metadata};

--- a/crates/fs/pathsafe/src/test_support.rs
+++ b/crates/fs/pathsafe/src/test_support.rs
@@ -1,0 +1,27 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Platform-absolute fixture paths for containment tests.
+//!
+//! `Path::is_absolute` requires a drive or UNC prefix on Windows, so a
+//! leading-slash literal like `/mnt/library` is relative there and every
+//! containment entry point refuses it as
+//! [`contain::ContainmentError::RootNotAbsolute`](crate::contain::ContainmentError::RootNotAbsolute).
+//! Tests that assert containment verdicts on made-up paths therefore build
+//! their roots through [`abs`] instead of writing the literal.
+
+/// Make a Unix-style test path absolute on the current platform.
+#[must_use]
+pub fn abs(path: &str) -> String {
+    if cfg!(windows) {
+        format!("C:{path}")
+    } else {
+        path.to_owned()
+    }
+}
+
+/// [`abs`] as a `PathBuf`.
+#[must_use]
+pub fn abs_path(path: &str) -> std::path::PathBuf {
+    std::path::PathBuf::from(abs(path))
+}

--- a/crates/project/structure/Cargo.toml
+++ b/crates/project/structure/Cargo.toml
@@ -15,6 +15,9 @@ serde_json = { workspace = true }
 time = { workspace = true }
 
 [dev-dependencies]
+# Containment fixtures build platform-absolute roots via `test_support`, which the
+# `[dependencies]` edge above leaves off so it is absent from release builds.
+fs_pathsafe = { path = "../../fs/pathsafe", features = ["test-fixture"] }
 tempfile = { workspace = true }
 # spec 042 (T251): tokio is dev-only now — used solely by `#[tokio::test]` to
 # drive the async `NotesFileAdapter`/`write_manifest_file` seams in unit tests.

--- a/crates/project/structure/Cargo.toml
+++ b/crates/project/structure/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 domain_core = { path = "../../domain/core" }
+fs_pathsafe = { path = "../../fs/pathsafe" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 time = { workspace = true }

--- a/crates/project/structure/src/lib.rs
+++ b/crates/project/structure/src/lib.rs
@@ -220,21 +220,25 @@ impl std::fmt::Display for ParseMarkerError {
 ///    from the project's `source_view_folder` DB column.
 /// 2. Otherwise fall back to the project root.
 ///
-/// Returns the resolved path as an `std::path::PathBuf`.
-#[must_use]
+/// The source-view folder is configuration, so it is resolved inside the project
+/// envelope rather than trusted: a relative `..` escaped the project root and an
+/// absolute value replaced it outright, taking every later project artifact
+/// (prepared view, manifest, notes) outside the project with it
+/// (astro-plan-3v3r.1.16).
+///
+/// # Errors
+///
+/// [`fs_pathsafe::contain::ContainmentError`] when the source-view folder does
+/// not resolve inside `project_root`.
 pub fn resolve_working_folder(
     project_root: &std::path::Path,
     source_view_folder: Option<&str>,
-) -> std::path::PathBuf {
-    if let Some(sv) = source_view_folder.filter(|s| !s.trim().is_empty()) {
-        let sv_path = std::path::Path::new(sv);
-        if sv_path.is_absolute() {
-            return sv_path.to_path_buf();
-        }
-        // Relative source-view path — join with the project root.
-        return project_root.join(sv_path);
+) -> Result<std::path::PathBuf, fs_pathsafe::contain::ContainmentError> {
+    match source_view_folder.filter(|s| !s.trim().is_empty()) {
+        Some(sv) => fs_pathsafe::contain::resolve_in_root(project_root, std::path::Path::new(sv))
+            .map(fs_pathsafe::contain::ContainedPath::into_path_buf),
+        None => Ok(project_root.to_path_buf()),
     }
-    project_root.to_path_buf()
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -307,7 +311,7 @@ mod tests {
     #[test]
     fn resolve_working_folder_uses_project_root_when_no_source_view() {
         let root = std::path::Path::new("/mnt/library/my_project");
-        let result = resolve_working_folder(root, None);
+        let result = resolve_working_folder(root, None).unwrap();
         assert_eq!(result, root);
     }
 
@@ -315,21 +319,48 @@ mod tests {
     fn resolve_working_folder_uses_source_view_when_absolute() {
         let root = std::path::Path::new("/mnt/library/my_project");
         let sv = "/mnt/library/my_project/_source_view";
-        let result = resolve_working_folder(root, Some(sv));
+        let result = resolve_working_folder(root, Some(sv)).unwrap();
         assert_eq!(result, std::path::Path::new(sv));
     }
 
     #[test]
     fn resolve_working_folder_joins_relative_source_view() {
         let root = std::path::Path::new("/mnt/library/my_project");
-        let result = resolve_working_folder(root, Some("_source_view"));
+        let result = resolve_working_folder(root, Some("_source_view")).unwrap();
         assert_eq!(result, root.join("_source_view"));
     }
 
     #[test]
     fn resolve_working_folder_treats_blank_as_missing() {
         let root = std::path::Path::new("/mnt/library/my_project");
-        let result = resolve_working_folder(root, Some("  "));
+        let result = resolve_working_folder(root, Some("  ")).unwrap();
         assert_eq!(result, root);
+    }
+
+    /// astro-plan-3v3r.1.16: a relative source-view folder that traverses out of
+    /// the project takes every later project artifact with it.
+    #[test]
+    fn a_relative_source_view_folder_never_escapes_the_project_root() {
+        let root = std::path::Path::new("/mnt/library/my_project");
+        let err = resolve_working_folder(root, Some("../../elsewhere")).unwrap_err();
+        assert!(matches!(err, fs_pathsafe::contain::ContainmentError::Escapes { .. }), "{err}");
+    }
+
+    /// astro-plan-3v3r.1.16: an absolute source-view folder replaced the project
+    /// root entirely, because `Path::join` discards the base.
+    #[test]
+    fn an_absolute_source_view_folder_must_not_replace_the_project_root() {
+        let root = std::path::Path::new("/mnt/library/my_project");
+        let err = resolve_working_folder(root, Some("/etc")).unwrap_err();
+        assert!(matches!(err, fs_pathsafe::contain::ContainmentError::Escapes { .. }), "{err}");
+    }
+
+    /// A source-view folder is resolved before it exists, so absence is not a
+    /// refusal: the verdict is lexical.
+    #[test]
+    fn a_source_view_folder_that_does_not_exist_yet_resolves() {
+        let root = std::path::Path::new("/mnt/library/my_project");
+        let result = resolve_working_folder(root, Some("_source_view/not/created")).unwrap();
+        assert_eq!(result, root.join("_source_view/not/created"));
     }
 }

--- a/crates/project/structure/src/lib.rs
+++ b/crates/project/structure/src/lib.rs
@@ -308,32 +308,36 @@ mod tests {
         assert!(ProcessingTool::parse("Photoshop").is_err());
     }
 
+    fn project_root() -> std::path::PathBuf {
+        fs_pathsafe::test_support::abs_path("/mnt/library/my_project")
+    }
+
     #[test]
     fn resolve_working_folder_uses_project_root_when_no_source_view() {
-        let root = std::path::Path::new("/mnt/library/my_project");
-        let result = resolve_working_folder(root, None).unwrap();
+        let root = project_root();
+        let result = resolve_working_folder(&root, None).unwrap();
         assert_eq!(result, root);
     }
 
     #[test]
     fn resolve_working_folder_uses_source_view_when_absolute() {
-        let root = std::path::Path::new("/mnt/library/my_project");
-        let sv = "/mnt/library/my_project/_source_view";
-        let result = resolve_working_folder(root, Some(sv)).unwrap();
-        assert_eq!(result, std::path::Path::new(sv));
+        let root = project_root();
+        let sv = fs_pathsafe::test_support::abs("/mnt/library/my_project/_source_view");
+        let result = resolve_working_folder(&root, Some(&sv)).unwrap();
+        assert_eq!(result, std::path::Path::new(&sv));
     }
 
     #[test]
     fn resolve_working_folder_joins_relative_source_view() {
-        let root = std::path::Path::new("/mnt/library/my_project");
-        let result = resolve_working_folder(root, Some("_source_view")).unwrap();
+        let root = project_root();
+        let result = resolve_working_folder(&root, Some("_source_view")).unwrap();
         assert_eq!(result, root.join("_source_view"));
     }
 
     #[test]
     fn resolve_working_folder_treats_blank_as_missing() {
-        let root = std::path::Path::new("/mnt/library/my_project");
-        let result = resolve_working_folder(root, Some("  ")).unwrap();
+        let root = project_root();
+        let result = resolve_working_folder(&root, Some("  ")).unwrap();
         assert_eq!(result, root);
     }
 
@@ -341,8 +345,8 @@ mod tests {
     /// the project takes every later project artifact with it.
     #[test]
     fn a_relative_source_view_folder_never_escapes_the_project_root() {
-        let root = std::path::Path::new("/mnt/library/my_project");
-        let err = resolve_working_folder(root, Some("../../elsewhere")).unwrap_err();
+        let root = project_root();
+        let err = resolve_working_folder(&root, Some("../../elsewhere")).unwrap_err();
         assert!(matches!(err, fs_pathsafe::contain::ContainmentError::Escapes { .. }), "{err}");
     }
 
@@ -350,8 +354,9 @@ mod tests {
     /// root entirely, because `Path::join` discards the base.
     #[test]
     fn an_absolute_source_view_folder_must_not_replace_the_project_root() {
-        let root = std::path::Path::new("/mnt/library/my_project");
-        let err = resolve_working_folder(root, Some("/etc")).unwrap_err();
+        let root = project_root();
+        let outside = fs_pathsafe::test_support::abs("/etc");
+        let err = resolve_working_folder(&root, Some(&outside)).unwrap_err();
         assert!(matches!(err, fs_pathsafe::contain::ContainmentError::Escapes { .. }), "{err}");
     }
 
@@ -359,8 +364,8 @@ mod tests {
     /// refusal: the verdict is lexical.
     #[test]
     fn a_source_view_folder_that_does_not_exist_yet_resolves() {
-        let root = std::path::Path::new("/mnt/library/my_project");
-        let result = resolve_working_folder(root, Some("_source_view/not/created")).unwrap();
+        let root = project_root();
+        let result = resolve_working_folder(&root, Some("_source_view/not/created")).unwrap();
         assert_eq!(result, root.join("_source_view/not/created"));
     }
 }

--- a/crates/workflow/profiles/Cargo.toml
+++ b/crates/workflow/profiles/Cargo.toml
@@ -16,6 +16,7 @@ name = "spawn-stub"
 path = "src/bin/spawn-stub.rs"
 
 [dependencies]
+fs_pathsafe = { path = "../../fs/pathsafe" }
 # spec 042 (T203): first-wins dedup of discovery results by tool id
 # (replaces the hand-rolled `HashSet`-insert filter).
 itertools = { workspace = true }

--- a/crates/workflow/profiles/Cargo.toml
+++ b/crates/workflow/profiles/Cargo.toml
@@ -22,6 +22,9 @@ fs_pathsafe = { path = "../../fs/pathsafe" }
 itertools = { workspace = true }
 
 [dev-dependencies]
+# Containment fixtures build platform-absolute roots via `test_support`, which the
+# `[dependencies]` edge above leaves off so it is absent from release builds.
+fs_pathsafe = { path = "../../fs/pathsafe", features = ["test-fixture"] }
 # Real-spawn integration test (spec 011 T022): disposable project roots, plus
 # the same working-folder resolution production launch uses.
 project_structure = { path = "../../project/structure" }

--- a/crates/workflow/profiles/src/launch.rs
+++ b/crates/workflow/profiles/src/launch.rs
@@ -227,10 +227,17 @@ fn pid_is_alive_impl(_pid: u32) -> bool {
 
 // ── Verify working-dir containment ────────────────────────────────────────────
 
-/// Verify that `working_dir` is a prefix-descendant of at least one registered
-/// library root (R-CwdContain, FR-010).
+/// Verify that `working_dir` resolves inside at least one registered library
+/// root (R-CwdContain, FR-010).
 ///
-/// Returns `Ok(())` when at least one root contains `working_dir`.
+/// The comparison normalizes both sides. A bare `Path::starts_with` compares
+/// unnormalized text, which accepted `/mnt/library/../../a` as inside
+/// `/mnt/library` whenever the caller's `canonicalize` had failed, as it does
+/// for a directory that does not exist yet (astro-plan-3v3r.13.26).
+///
+/// An empty `library_roots` is refused: with nothing registered there is no root
+/// for the working directory to be inside of, and reporting containment made the
+/// check depend on configuration.
 ///
 /// # Errors
 ///
@@ -239,17 +246,11 @@ pub fn verify_cwd_containment(
     working_dir: &Path,
     library_roots: &[&Path],
 ) -> Result<(), &'static str> {
-    if library_roots.is_empty() {
-        // No roots registered — treat as contained to avoid blocking users with
-        // zero-root setups; the UI will guide them to register roots separately.
-        return Ok(());
+    if fs_pathsafe::contain::contained_in_any(working_dir, library_roots) {
+        Ok(())
+    } else {
+        Err("cwd.outside_library_root")
     }
-    for root in library_roots {
-        if working_dir.starts_with(root) {
-            return Ok(());
-        }
-    }
-    Err("cwd.outside_library_root")
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -320,9 +321,29 @@ mod tests {
     }
 
     #[test]
-    fn cwd_containment_passes_with_no_roots() {
+    fn cwd_containment_fails_with_no_roots() {
         let cwd = PathBuf::from("/anywhere");
-        assert!(verify_cwd_containment(&cwd, &[]).is_ok());
+        assert_eq!(verify_cwd_containment(&cwd, &[]), Err("cwd.outside_library_root"));
+    }
+
+    /// astro-plan-3v3r.13.26: the text prefix matches, the resolved path does not.
+    #[test]
+    fn cwd_containment_fails_for_a_path_that_traverses_out_of_a_root() {
+        let root = PathBuf::from("/mnt/library");
+        let cwd = PathBuf::from("/mnt/library/../../a");
+        assert_eq!(
+            verify_cwd_containment(&cwd, &[root.as_path()]),
+            Err("cwd.outside_library_root")
+        );
+    }
+
+    /// A working directory the app is about to create is not yet on disk, which
+    /// is when the caller's `canonicalize` fails and the raw path arrives here.
+    #[test]
+    fn cwd_containment_passes_for_a_directory_that_does_not_exist_yet() {
+        let root = PathBuf::from("/mnt/library");
+        let cwd = PathBuf::from("/mnt/library/project/_source_view");
+        assert!(verify_cwd_containment(&cwd, &[root.as_path()]).is_ok());
     }
 
     #[test]

--- a/crates/workflow/profiles/src/launch.rs
+++ b/crates/workflow/profiles/src/launch.rs
@@ -258,7 +258,6 @@ pub fn verify_cwd_containment(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     fn sample_req() -> SpawnRequest {
         SpawnRequest {
@@ -305,15 +304,15 @@ mod tests {
 
     #[test]
     fn cwd_containment_passes_when_inside_root() {
-        let root = PathBuf::from("/mnt/library");
-        let cwd = PathBuf::from("/mnt/library/project");
+        let root = fs_pathsafe::test_support::abs_path("/mnt/library");
+        let cwd = fs_pathsafe::test_support::abs_path("/mnt/library/project");
         assert!(verify_cwd_containment(&cwd, &[root.as_path()]).is_ok());
     }
 
     #[test]
     fn cwd_containment_fails_when_outside_roots() {
-        let root = PathBuf::from("/mnt/library");
-        let cwd = PathBuf::from("/tmp/scratch");
+        let root = fs_pathsafe::test_support::abs_path("/mnt/library");
+        let cwd = fs_pathsafe::test_support::abs_path("/tmp/scratch");
         assert_eq!(
             verify_cwd_containment(&cwd, &[root.as_path()]),
             Err("cwd.outside_library_root")
@@ -322,15 +321,15 @@ mod tests {
 
     #[test]
     fn cwd_containment_fails_with_no_roots() {
-        let cwd = PathBuf::from("/anywhere");
+        let cwd = fs_pathsafe::test_support::abs_path("/anywhere");
         assert_eq!(verify_cwd_containment(&cwd, &[]), Err("cwd.outside_library_root"));
     }
 
     /// astro-plan-3v3r.13.26: the text prefix matches, the resolved path does not.
     #[test]
     fn cwd_containment_fails_for_a_path_that_traverses_out_of_a_root() {
-        let root = PathBuf::from("/mnt/library");
-        let cwd = PathBuf::from("/mnt/library/../../a");
+        let root = fs_pathsafe::test_support::abs_path("/mnt/library");
+        let cwd = fs_pathsafe::test_support::abs_path("/mnt/library/../../a");
         assert_eq!(
             verify_cwd_containment(&cwd, &[root.as_path()]),
             Err("cwd.outside_library_root")
@@ -341,8 +340,8 @@ mod tests {
     /// is when the caller's `canonicalize` fails and the raw path arrives here.
     #[test]
     fn cwd_containment_passes_for_a_directory_that_does_not_exist_yet() {
-        let root = PathBuf::from("/mnt/library");
-        let cwd = PathBuf::from("/mnt/library/project/_source_view");
+        let root = fs_pathsafe::test_support::abs_path("/mnt/library");
+        let cwd = fs_pathsafe::test_support::abs_path("/mnt/library/project/_source_view");
         assert!(verify_cwd_containment(&cwd, &[root.as_path()]).is_ok());
     }
 

--- a/crates/workflow/profiles/tests/real_spawn_stub.rs
+++ b/crates/workflow/profiles/tests/real_spawn_stub.rs
@@ -90,7 +90,7 @@ fn real_spawn_anchors_cwd_to_project_root_when_no_source_view() {
     // the project folder reaches the tool only as its cwd (R-CwdContain).
     let profile = seed::find("pixinsight").unwrap();
     assert!(!profile.supports_open_folder);
-    let working_dir = resolve_working_folder(&project_root, None);
+    let working_dir = resolve_working_folder(&project_root, None).unwrap();
     let rendered = render(&profile.args_template, &RenderContext::default());
 
     let observed = spawn_and_observe(&working_dir, &rendered, &tmp.path().join("pi.record"));
@@ -110,7 +110,7 @@ fn real_spawn_anchors_cwd_and_argv_to_source_view_folder() {
     // appears both as the cwd and as the rendered `{folder}` argument.
     let profile = seed::find("siril").unwrap();
     assert_eq!(profile.args_template, vec![ArgsToken::Folder]);
-    let working_dir = resolve_working_folder(&project_root, Some("_source_view"));
+    let working_dir = resolve_working_folder(&project_root, Some("_source_view")).unwrap();
     let folder = working_dir.to_string_lossy().into_owned();
     let rendered =
         render(&profile.args_template, &RenderContext { folder: Some(&folder), file: None });

--- a/specs/tiny/root-relative-path-containment.md
+++ b/specs/tiny/root-relative-path-containment.md
@@ -75,17 +75,17 @@ two byte-different spellings as one location, the comparison sees two different
 components and reduces the match, so each divergence below refuses a path the
 filesystem would have accepted. None admits a path outside the root.
 
-| Divergence | Comparison behaviour | Verdict |
-|------------|----------------------|---------|
-| NTFS case: root `C:\Library`, path `C:\library\a` | components differ byte-wise | over-refuses (`Escapes`) |
-| Separators `\` and `/` on Windows | `std` treats both as component separators, so neither side is favoured | handled |
-| Verbatim `\\?\C:\Library` against `C:\Library` | the prefix component differs, so no component matches | over-refuses (`Escapes`) |
-| UNC `\\server\share` against a `Disk` prefix | prefix kinds differ | over-refuses (`Escapes`) |
-| Drive-relative `C:foo` | `is_absolute` is false | over-refuses (`RootNotAbsolute`) |
-| 8.3 short name `PROGRA~1` against the long name | components differ byte-wise | over-refuses (`Escapes`) |
-| Unicode NFC against NFD spelling of one filename | components differ byte-wise | over-refuses (`Escapes`) |
+| Divergence | Comparison behaviour | Verdict | Evidence |
+|------------|----------------------|---------|----------|
+| NTFS case: root `C:\Library`, path `C:\library\a` | components differ byte-wise | over-refuses (`Escapes`) | read from `resolve_in_root`; no test presents a case-divergent pair |
+| Separators `\` and `/` on Windows | `std` treats both as component separators, so neither side is favoured | handled | Windows lane: `contain.rs:229-233` asserts a `Path::join` result equals a forward-slash literal |
+| Verbatim `\\?\C:\Library` against `C:\Library` | the prefix component differs, so no component matches | over-refuses (`Escapes`) | read from `resolve_in_root`; no test executes this input |
+| UNC `\\server\share` against a `Disk` prefix | prefix kinds differ | over-refuses (`Escapes`) | read from `resolve_in_root`; no test executes this input |
+| Drive-relative `C:foo` | `is_absolute` is false | over-refuses (`RootNotAbsolute`) | Windows lane: `contain.rs:271-273` takes the same `is_absolute` branch through a bare relative root; `C:foo` itself is not executed |
+| 8.3 short name `PROGRA~1` against the long name | components differ byte-wise | over-refuses (`Escapes`) | read from `resolve_in_root`; no test executes this input |
+| Unicode NFC against NFD spelling of one filename | components differ byte-wise | over-refuses (`Escapes`) | read from `resolve_in_root`; no test executes this input |
 
-The six over-refusals in the table are intended behaviour, and none offers the
+Every over-refusal in the table is intended behaviour, and none offers the
 user a recovery path. The operation is refused, and re-spelling the input does
 not make it pass, because the stored root is the other side of the comparison.
 
@@ -157,7 +157,7 @@ assembly, not root-relative resolution, and stays where it is.
 |------|------|
 | `crates/fs/pathsafe/src/contain.rs` | Add: `ContainedPath`, `ContainmentError`, `resolve_in_root`, `resolve_unrooted`, `contained_in_any`, `normalize` |
 | `crates/fs/executor/src/ops/path_gate.rs` | Modify: `resolve_and_validate` delegates the join-and-contain step, symlink walk unchanged; `lexical_normalize` deleted so one normalizer remains |
-| `crates/app/core/src/plan_apply/{paths,reconcile}.rs` | Modify: use `contain::normalize_utf8`; the FR-017 overlap set is compared, never mutated, so an uncontained path is kept rather than refused |
+| `crates/app/core/src/plan_apply/{paths,reconcile}.rs` | Modify: use `contain::normalize_utf8`; the FR-017 overlap set is only compared, so an uncontained path is kept rather than refused |
 | `crates/fs/executor/src/run/loop_.rs` | Modify: resolve each side once and hand the resolved paths to `execute_item`, so no second root choice exists |
 | `crates/fs/executor/src/run/dispatch.rs` | Modify: `execute_item` consumes resolved paths, `resolve_item_path` deleted |
 | `crates/project/structure/src/lib.rs` | Modify: `resolve_working_folder` returns `Result` |
@@ -179,7 +179,7 @@ assembly, not root-relative resolution, and stays where it is.
 6. A launch whose working directory is outside every registered root, or which
    has no registered root at all, is refused with `cwd.outside_library_root`.
 7. `verify_cwd_containment`'s caller canonicalizes the roots and the working
-   folder through the same function, so the two sides carry the same Windows
+   folder through the same function, so the two sides have the same Windows
    prefix spelling.
 8. Fixture helpers that build platform-absolute roots are absent from a release
    build.

--- a/specs/tiny/root-relative-path-containment.md
+++ b/specs/tiny/root-relative-path-containment.md
@@ -38,6 +38,7 @@ rather than reaching it through a fallback arm:
 | root present, relative path that escapes after normalization | `Err(Escapes)` |
 | root present, absolute path inside the root | `Ok`, the path itself |
 | root present, absolute path outside the root | `Err(Escapes)` |
+| root present but relative | `Err(RootNotAbsolute)` |
 | root absent, relative path | `Err(RootMissing)` |
 | root absent, absolute path with `.` or `..` components | `Err(NotNormalized)` |
 | root absent, absolute normal path | `Ok`, via `resolve_unrooted` only |
@@ -105,18 +106,19 @@ assembly, not root-relative resolution, and stays where it is.
 
 ## Tasks
 
-- [ ] Add `fs_pathsafe::contain` with a unit test for each of the seven rule rows
-- [ ] Route `path_gate::resolve_and_validate` through it, keeping the symlink walk
-- [ ] Resolve once in `run/loop_.rs`, delete `dispatch::resolve_item_path`
-- [ ] `resolve_working_folder` returns `Result`; update callers and tests
-- [ ] `resolve_archive_abs_path` returns `Result`; an unresolvable root id errors
-- [ ] `verify_cwd_containment` uses `contained_in_any`; empty roots refuse
-- [ ] One regression test per LIVE finding, run red before the fix
-- [ ] `cargo clippy` and `cargo nextest` for the six touched crates
+- [x] Add `fs_pathsafe::contain` with a unit test for each of the seven rule rows
+- [x] Route `path_gate::resolve_and_validate` through it, keeping the symlink walk
+- [x] Resolve once in `run/loop_.rs`, delete `dispatch::resolve_item_path`
+- [x] `resolve_working_folder` returns `Result`; update callers and tests
+- [x] `resolve_archive_abs_path` returns `Result`; an unresolvable root id errors
+- [x] `verify_cwd_containment` uses `contained_in_any`; empty roots refuse
+- [x] One regression test per LIVE finding, run red before the fix
+- [x] `cargo clippy` and `cargo nextest` for the six touched crates
 
 ## Done When
 
-- [ ] Every LIVE finding has a test that fails at base 4948b3ece and passes here
-- [ ] All four rule cases (absent root, escape after normalization, absolute
+- [x] Every LIVE finding has a test that fails at base 4948b3ece and passes here
+      (.1.12 5/6, .1.16 2/2, .5.20 2/2, .13.26 2/2 red at base)
+- [x] All four rule cases (absent root, escape after normalization, absolute
       where a root is expected, non-existent leaf) have a unit test
-- [ ] Touched-crate lint and test gates are green
+- [x] Touched-crate lint and test gates are green

--- a/specs/tiny/root-relative-path-containment.md
+++ b/specs/tiny/root-relative-path-containment.md
@@ -39,9 +39,9 @@ rather than reaching it through a fallback arm:
 | root present, absolute path inside the root | `Ok`, the path itself |
 | root present, absolute path outside the root | `Err(Escapes)` |
 | root present but relative | `Err(RootNotAbsolute)` |
-| root absent, relative path | `Err(RootMissing)` |
-| root absent, absolute path with `.` or `..` components | `Err(NotNormalized)` |
-| root absent, absolute normal path | `Ok`, via `resolve_unrooted` only |
+| no root, absolute path with `.` or `..` components | `Err(NotNormalized)` |
+| no root, absolute normal path | `Ok`, via `resolve_unrooted` only |
+| no root, relative path | `Err(NotAbsolute)` from `resolve_unrooted`, or `RootMissing` where the caller knows a root id failed to resolve |
 
 ### The verdict is lexical, so a non-existent leaf is contained
 
@@ -81,8 +81,9 @@ assembly, not root-relative resolution, and stays where it is.
 
 | File | Role |
 |------|------|
-| `crates/fs/pathsafe/src/contain.rs` | Add: `ContainedPath`, `ContainmentError`, `resolve_in_root`, `resolve_unrooted`, `resolve_in_optional_root`, `contained_in_any` |
-| `crates/fs/executor/src/ops/path_gate.rs` | Modify: `resolve_and_validate` delegates the join-and-contain step, symlink walk unchanged |
+| `crates/fs/pathsafe/src/contain.rs` | Add: `ContainedPath`, `ContainmentError`, `resolve_in_root`, `resolve_unrooted`, `contained_in_any`, `normalize` |
+| `crates/fs/executor/src/ops/path_gate.rs` | Modify: `resolve_and_validate` delegates the join-and-contain step, symlink walk unchanged; `lexical_normalize` deleted so one normalizer remains |
+| `crates/app/core/src/plan_apply/{paths,reconcile}.rs` | Modify: use `contain::normalize_utf8`; the FR-017 overlap set is compared, never mutated, so an uncontained path is kept rather than refused |
 | `crates/fs/executor/src/run/loop_.rs` | Modify: resolve each side once and hand the resolved paths to `execute_item`, so no second root choice exists |
 | `crates/fs/executor/src/run/dispatch.rs` | Modify: `execute_item` consumes resolved paths, `resolve_item_path` deleted |
 | `crates/project/structure/src/lib.rs` | Modify: `resolve_working_folder` returns `Result` |

--- a/specs/tiny/root-relative-path-containment.md
+++ b/specs/tiny/root-relative-path-containment.md
@@ -63,12 +63,73 @@ be a link.
 Unix-shaped literal `/mnt/library` is a relative root there and every entry
 point answers `RootNotAbsolute`. Tests that assert a containment verdict on a
 made-up path build their roots through `fs_pathsafe::test_support::abs`, which
-prefixes `C:` on Windows and returns the path unchanged elsewhere.
+prefixes `C:` on Windows and returns the path unchanged elsewhere. The module is
+gated behind `cfg(test)` plus the default-off `test-fixture` feature, so the
+helpers are absent from a release build.
 
-The prefix comparison is case-sensitive on every platform, while NTFS treats
-`C:\Library` and `C:\library` as one directory. A case difference therefore
-turns a contained path into `Escapes`: the divergence produces a refusal, never
-an admission.
+#### Verdict per platform divergence
+
+`resolve_in_root` normalizes both sides with `path-clean` and then compares with
+`Path::starts_with`, which matches whole components. Where the filesystem treats
+two byte-different spellings as one location, the comparison sees two different
+components and reduces the match, so each divergence below refuses a path the
+filesystem would have accepted. None admits a path outside the root.
+
+| Divergence | Comparison behaviour | Verdict |
+|------------|----------------------|---------|
+| NTFS case: root `C:\Library`, path `C:\library\a` | components differ byte-wise | over-refuses (`Escapes`) |
+| Separators `\` and `/` on Windows | `std` treats both as component separators, so neither side is favoured | handled |
+| Verbatim `\\?\C:\Library` against `C:\Library` | the prefix component differs, so no component matches | over-refuses (`Escapes`) |
+| UNC `\\server\share` against a `Disk` prefix | prefix kinds differ | over-refuses (`Escapes`) |
+| Drive-relative `C:foo` | `is_absolute` is false | over-refuses (`RootNotAbsolute`) |
+| 8.3 short name `PROGRA~1` against the long name | components differ byte-wise | over-refuses (`Escapes`) |
+| Unicode NFC against NFD spelling of one filename | components differ byte-wise | over-refuses (`Escapes`) |
+
+The six over-refusals in the table are intended behaviour, and none offers the
+user a recovery path. The operation is refused, and re-spelling the input does
+not make it pass, because the stored root is the other side of the comparison.
+
+Principle IV requires that tradeoff recorded. A byte-wise comparison cannot
+admit a path outside the root. Case-folding or Unicode-folding the comparison
+makes two distinct on-disk names compare equal, which admits one of them.
+Sibling PR #1712 folds a destination *key* for deduplication, a different
+question from a containment verdict.
+
+`verify_cwd_containment` at `crates/app/core/src/tool_launch.rs:282-300` is the
+one caller that canonicalizes before comparing, because a working folder is an
+existing directory. It canonicalizes both the roots and the working folder with
+`dunce`, which strips the Windows verbatim prefix. `std::fs::canonicalize`
+returns a verbatim path for an existing root and fails on a working folder that
+does not exist yet, and that fallback keeps the raw non-verbatim spelling, so
+canonicalizing only one side refuses a legitimate working folder on Windows.
+
+#### The lexical verdict and the `lstat` walk answer different questions
+
+The containment verdict is lexical, so `..` collapses before the comparison. A
+lexically contained path can still leave the root at run time when one of its
+components is a symlink or an NTFS junction. Refusing that is the job of the
+per-component `lstat` walk in `path_gate::resolve_and_validate`, not of
+`contain`. Both checks are therefore required, and a side that reaches the
+filesystem without passing `path_gate` is not protected by the lexical rule
+alone.
+
+### Archive and trash destinations reach the filesystem ungated
+
+`ExecutorItemAction::Archive { archive_destination }` and
+`ExecutorItemAction::Trash { fallback_archive_destination }` reach
+`archive_op::archive_file` and `trash_op::trash_file` directly from
+`crates/fs/executor/src/run/dispatch.rs:49-61`. `run/loop_.rs:179-182` applies
+`resolve_side` and `path_gate` to `resolved_src` and `resolved_dst` only, so
+neither archive destination passes either. The plan-side check
+`resolve_unrooted_utf8` at `crates/app/core/src/plans/archive.rs:56-58` proves
+absolute-and-normal, which is not inside-a-root. An absolute out-of-root archive
+destination therefore still reaches `move_file`, and no `lstat` walk refuses a
+junction component on it.
+
+Closing that requires an archive-root policy decision, since an archive
+destination on another drive is a supported user configuration, plus root
+context threaded into the executor item loop. It is tracked on
+`astro-plan-zboex` and is out of scope here.
 
 ### The rule is implemented once, in `fs_pathsafe`
 
@@ -117,6 +178,11 @@ assembly, not root-relative resolution, and stays where it is.
    second join and no second root fallback.
 6. A launch whose working directory is outside every registered root, or which
    has no registered root at all, is refused with `cwd.outside_library_root`.
+7. `verify_cwd_containment`'s caller canonicalizes the roots and the working
+   folder through the same function, so the two sides carry the same Windows
+   prefix spelling.
+8. Fixture helpers that build platform-absolute roots are absent from a release
+   build.
 
 ## Tasks
 
@@ -126,6 +192,11 @@ assembly, not root-relative resolution, and stays where it is.
 - [x] `resolve_working_folder` returns `Result`; update callers and tests
 - [x] `resolve_archive_abs_path` returns `Result`; an unresolvable root id errors
 - [x] `verify_cwd_containment` uses `contained_in_any`; empty roots refuse
+- [x] Canonicalize both sides of the `verify_cwd_containment` comparison with
+      `dunce`, so a not-yet-created working folder compares against a
+      non-verbatim root
+- [x] Gate `fs_pathsafe::test_support` behind `cfg(test)` plus the default-off
+      `test-fixture` feature, activated in each consumer's dev-dependencies
 - [x] One regression test per LIVE finding, run red before the fix
 - [x] `cargo clippy` and `cargo nextest` for the six touched crates
 

--- a/specs/tiny/root-relative-path-containment.md
+++ b/specs/tiny/root-relative-path-containment.md
@@ -57,6 +57,19 @@ per-component `lstat` walk in `path_gate::resolve_and_validate`, which stops at
 the first component that does not exist because a non-existent component cannot
 be a link.
 
+### An absolute root means absolute on the running platform
+
+`Path::is_absolute` requires a drive or UNC prefix on Windows, so the
+Unix-shaped literal `/mnt/library` is a relative root there and every entry
+point answers `RootNotAbsolute`. Tests that assert a containment verdict on a
+made-up path build their roots through `fs_pathsafe::test_support::abs`, which
+prefixes `C:` on Windows and returns the path unchanged elsewhere.
+
+The prefix comparison is case-sensitive on every platform, while NTFS treats
+`C:\Library` and `C:\library` as one directory. A case difference therefore
+turns a contained path into `Escapes`: the divergence produces a refusal, never
+an admission.
+
 ### The rule is implemented once, in `fs_pathsafe`
 
 `fs_pathsafe` is the containment crate and is already a dependency of

--- a/specs/tiny/root-relative-path-containment.md
+++ b/specs/tiny/root-relative-path-containment.md
@@ -1,0 +1,122 @@
+# TinySpec: One rule for resolving a path against a root
+
+**Branch**: fix/containment-core
+**Date**: 2026-08-22
+**Complexity**: 5 (Full Spec route, speckit-bugfix)
+**Findings**: astro-plan-3v3r.1.12, .1.16, .5.20, .13.26 (LIVE);
+.8.21 (refuted as filed), .9.10 (already fixed by PR #1705)
+
+## What
+
+`resolve_item_path`, `resolve_working_folder`, `resolve_archive_abs_path`, and
+`verify_cwd_containment` each resolve a caller-supplied path against a library,
+project, or archive root. Each answers "the root is absent" by returning a path
+anyway, and each decides containment by `starts_with` on unnormalized text or
+not at all. A path outside every declared root therefore reaches a filesystem
+mutation and is recorded as a contained, reviewed action.
+
+| Site | Absent-root answer today | Containment check today |
+|------|--------------------------|-------------------------|
+| `crates/fs/executor/src/run/dispatch.rs:98` `resolve_item_path` | returns the relative path, resolved against the process cwd | none; the gate in `run/loop_.rs:161` uses a different root choice, so a destination with only `library_root` set is never gated |
+| `crates/project/structure/src/lib.rs:225` `resolve_working_folder` | returns the project root | none; an absolute value replaces the root, a relative `..` escapes it |
+| `crates/app/core/src/plans/archive.rs:34` `resolve_archive_abs_path` | returns the stored path unrooted, then trashes or deletes it | none; an unresolvable `from_root_id` takes the same branch as no root id |
+| `crates/workflow/profiles/src/launch.rs:238` `verify_cwd_containment` | an empty root list is reported contained | `Path::starts_with` on unnormalized text |
+
+## The rule (decision)
+
+**A path is usable only as a `ContainedPath`: the lexical normalization of the
+path joined onto the lexical normalization of its root, proven to start with
+that normalized root.**
+
+Resolving against an absent root is refused. The one legitimate rootless shape is
+an already-absolute, already-normal path, and the caller requests it by name
+rather than reaching it through a fallback arm:
+
+| Input | Result |
+|-------|--------|
+| root present, relative path that stays inside | `Ok`, the normalized join |
+| root present, relative path that escapes after normalization | `Err(Escapes)` |
+| root present, absolute path inside the root | `Ok`, the path itself |
+| root present, absolute path outside the root | `Err(Escapes)` |
+| root absent, relative path | `Err(RootMissing)` |
+| root absent, absolute path with `.` or `..` components | `Err(NotNormalized)` |
+| root absent, absolute normal path | `Ok`, via `resolve_unrooted` only |
+
+### The verdict is lexical, so a non-existent leaf is contained
+
+`std::fs::canonicalize` follows symlinks, which the Product Constraints forbid,
+and it fails on a path that does not exist. The verdict is therefore purely
+lexical, using `path-clean` (already a workspace dependency of `path_gate`), and
+the root is normalized as well: a `starts_with` against an unnormalized root is
+what accepts `/mnt/library/../../a`.
+
+A leaf that does not exist is the normal case for a write, and its lexical form
+alone decides containment. Symlink refusal stays where it already is, in the
+per-component `lstat` walk in `path_gate::resolve_and_validate`, which stops at
+the first component that does not exist because a non-existent component cannot
+be a link.
+
+### The rule is implemented once, in `fs_pathsafe`
+
+`fs_pathsafe` is the containment crate and is already a dependency of
+`fs_executor`, `app_core`, `fs_inventory`, and `app_inbox`. The rule is added
+there as `fs_pathsafe::contain`, and `path_gate::resolve_and_validate` keeps its
+symlink walk while delegating the join-and-contain step to it. The
+`check_assembled_path` guard in `patterns` (PR #1705) checks per-segment token
+assembly, not root-relative resolution, and stays where it is.
+
+## Per-finding verdict at head 4948b3ece
+
+| Finding | Verdict | Evidence read at this head |
+|---------|---------|----------------------------|
+| .1.12 | LIVE | `dispatch.rs:98-110` has both defective arms. `loop_.rs:165` gates the destination against `destination_root` only, while `dispatch.rs:36` joins `destination_root.or(library_root)` |
+| .1.16 | LIVE | `lib.rs:225-238` returns an absolute value as-is and joins a relative value unchecked |
+| .5.20 | LIVE | `archive.rs:34-43` conflates an unresolvable root id with no root id in `from_root_id.and_then(get)` |
+| .13.26 | LIVE | `launch.rs:242-252` returns `Ok` for empty roots and compares unnormalized text. The caller at `tool_launch.rs:281` canonicalizes the cwd but falls back to the raw path when canonicalize fails, which is exactly the not-yet-created destination |
+| .8.21 | refuted as filed | `loop_.rs:163,166` call `resolve_and_validate` one layer below the command handlers, by design. The finding's own metadata records "no command-layer caller exists, so TB-1 is a serde shape boundary with no value boundary". Its substance, a mutation reaching the filesystem ungated, is .1.12 and is fixed here |
+| .9.10 | already fixed | `resolver.rs:284` `check_assembled_path`, PR #1705 (squash 55229d8d9) |
+
+## Context
+
+| File | Role |
+|------|------|
+| `crates/fs/pathsafe/src/contain.rs` | Add: `ContainedPath`, `ContainmentError`, `resolve_in_root`, `resolve_unrooted`, `resolve_in_optional_root`, `contained_in_any` |
+| `crates/fs/executor/src/ops/path_gate.rs` | Modify: `resolve_and_validate` delegates the join-and-contain step, symlink walk unchanged |
+| `crates/fs/executor/src/run/loop_.rs` | Modify: resolve each side once and hand the resolved paths to `execute_item`, so no second root choice exists |
+| `crates/fs/executor/src/run/dispatch.rs` | Modify: `execute_item` consumes resolved paths, `resolve_item_path` deleted |
+| `crates/project/structure/src/lib.rs` | Modify: `resolve_working_folder` returns `Result` |
+| `crates/app/core/src/plans/archive.rs` | Modify: `resolve_archive_abs_path` returns `Result`, an unresolvable `from_root_id` is an error |
+| `crates/app/core/src/tool_launch.rs` | Modify: handle the two new `Result` values |
+| `crates/workflow/profiles/src/launch.rs` | Modify: `verify_cwd_containment` uses `contained_in_any`, an empty root list is refused |
+
+## Requirements
+
+1. No function resolves a path against a root without returning a containment
+   verdict.
+2. An absent root refuses. A rootless absolute path is accepted only through the
+   explicitly named entry point.
+3. Both the path and the root are lexically normalized before the prefix
+   comparison.
+4. No resolution path calls `canonicalize`, and a non-existent leaf is accepted.
+5. The executor resolves each item side exactly once, and `dispatch` performs no
+   second join and no second root fallback.
+6. A launch whose working directory is outside every registered root, or which
+   has no registered root at all, is refused with `cwd.outside_library_root`.
+
+## Tasks
+
+- [ ] Add `fs_pathsafe::contain` with a unit test for each of the seven rule rows
+- [ ] Route `path_gate::resolve_and_validate` through it, keeping the symlink walk
+- [ ] Resolve once in `run/loop_.rs`, delete `dispatch::resolve_item_path`
+- [ ] `resolve_working_folder` returns `Result`; update callers and tests
+- [ ] `resolve_archive_abs_path` returns `Result`; an unresolvable root id errors
+- [ ] `verify_cwd_containment` uses `contained_in_any`; empty roots refuse
+- [ ] One regression test per LIVE finding, run red before the fix
+- [ ] `cargo clippy` and `cargo nextest` for the six touched crates
+
+## Done When
+
+- [ ] Every LIVE finding has a test that fails at base 4948b3ece and passes here
+- [ ] All four rule cases (absent root, escape after normalization, absolute
+      where a root is expected, non-existent leaf) have a unit test
+- [ ] Touched-crate lint and test gates are green


### PR DESCRIPTION
## What

Four functions resolved a caller-supplied path against a library, project, or
archive root. Each answered "the root is absent" by returning a path anyway, and
each decided containment by `starts_with` on unnormalized text or not at all. A
path outside every declared root reached a filesystem mutation and was recorded
as a contained, reviewed action.

`fs_pathsafe::contain` now states one rule: a path is usable only as a
`ContainedPath`, the normalization of the path joined onto the normalization of
its root, proven to start with that normalized root. An absent root refuses, and
`resolve_unrooted` is the named opt-in for a pre-resolved absolute path.

The verdict is lexical. `canonicalize` follows symlinks (forbidden by the Product
Constraints) and fails on a path that does not exist yet, which is the normal
case for a write destination. Link refusal stays in `path_gate`'s per-component
`lstat` walk, which stops at the first component that does not exist.

## Sites

| Site | Change |
|------|--------|
| `crates/fs/executor/src/run/loop_.rs` | resolves each item side once; `dispatch` consumes the resolved pair, so the second join and second root fallback are gone |
| `crates/project/structure/src/lib.rs` | `resolve_working_folder` returns `Result` and keeps the source-view folder inside the project |
| `crates/app/core/src/plans/archive.rs` | an unresolvable `from_root_id` is an error, not the rootless shape; an uncontained item is a failed item |
| `crates/workflow/profiles/src/launch.rs` | `verify_cwd_containment` normalizes both sides and refuses an empty root list |

## Findings

| Finding | Verdict |
|---------|---------|
| astro-plan-3v3r.1.12 | fixed, 5 of 6 tests red at base |
| astro-plan-3v3r.1.16 | fixed, 2 of 2 red at base |
| astro-plan-3v3r.5.20 | fixed, 2 of 2 red at base |
| astro-plan-3v3r.13.26 | fixed, 2 of 2 red at base |
| astro-plan-3v3r.8.21 | refuted as filed: `resolve_and_validate` is called from `loop_.rs`, one layer below the command handlers, by design. Its substance is .1.12 and is fixed here |
| astro-plan-3v3r.9.10 | already fixed by #1705 (`check_assembled_path`) |

## Behavior changes

- A tool launch with no registered library root is refused with
  `cwd.outside_library_root` instead of treated as contained.
- An executor item with a relative path and no root is refused instead of
  resolving against the process working directory.

## Round 2

- `resolve_in_optional_root` is removed. It had no production caller, and the
  dead-caller ratchet failed on it. Wiring it into the executor's `Archive`
  action was rejected: that action's `archive_destination` is resolved zero
  times, which is a different item field and is filed as astro-plan-zboex.
- `path_gate::lexical_normalize` is deleted and its two `app_core` callers use
  `contain::normalize_utf8`, leaving one implementation of the lexical collapse.
  `crates/workflow/artifacts/src/project_mapping.rs` keeps a hand-rolled
  collapse that decides artifact-to-project attribution rather than containment;
  it is filed as astro-plan-ta7kn.
- Merged `origin/main` (7ace131bd, #1708) with no conflict. #1708 made
  `is_link_or_junction` fail closed on any non-`NotFound` stat error;
  `path_gate`'s walk already refuses non-`NotFound` errors as `path_invalid`, so
  the two agree. Neither calls the other because the walk must tell `NotFound`
  (stop walking) from other errors (refuse), which is what
  `is_link_or_junction_metadata` exists for. `contain` decides containment only.

## Round 3

CI was red only on `windows-latest`: 26 containment tests failed there while every
other lane passed. `Path::is_absolute` requires a drive or UNC prefix on Windows,
so the Unix-shaped fixture roots (`/mnt/library`, `/mnt/library/my_project`) are
relative on that platform and the rule answered `RootNotAbsolute` instead of the
verdict each test asserts. The refusal is the rule working; the fixtures were
wrong.

- No containment hole existed on Windows before or after this change. A missing
  prefix and a case-only difference both push the prefix comparison toward
  refusal, never toward admitting an uncontained path.
- `fs_pathsafe::test_support::abs` prefixes `C:` on Windows and is the single
  place that knows the rule; `app_core_projects::test_support::abs` now delegates
  to it.
- A resolved path carries the platform separator, so the assertions that compared
  rendered strings (`plans::archive`, `tool_launch` working dirs) compare `Path`
  components.
- The tiny spec records the platform rule under "An absolute root means absolute
  on the running platform".

## Round 4

The title states the rule this change implements rather than a guarantee about
every filesystem operation. Two destinations still reach the filesystem without
a containment verdict: `ExecutorItemAction::Archive`'s `archive_destination` and
`ExecutorItemAction::Trash`'s `fallback_archive_destination` go straight from
`crates/fs/executor/src/run/dispatch.rs:49-61` to `archive_op` and `trash_op`,
while `run/loop_.rs:179-182` applies `resolve_side` and `path_gate` to the
resolved source and destination only. Gating them needs an archive-root policy
decision, because an archive destination on another drive is a supported
configuration, plus root context threaded into the executor item loop. That work
stays on `astro-plan-zboex`, and the spec records the gap under "Archive and
trash destinations reach the filesystem ungated".

- `crates/app/core/src/tool_launch.rs:920` inserted the `registered_sources` row
  by raw SQL with the literal `/mnt/library`, which is relative on Windows, so
  `launch_accepts_cwd_under_registered_source_root` failed there while the other
  26 fixture sites went through the helper. The root is now bound through
  `fs_pathsafe::test_support::abs`.
- `fs_pathsafe::test_support` is gated behind `cfg(test)` plus a default-off
  `test-fixture` feature, activated in the dev-dependencies of `app_core`,
  `app_core_projects`, `project_structure`, and `workflow_profiles`. A plain
  `cargo build -p fs_pathsafe` emits no `test_support` symbol.
- `resolve_and_check_working_dir` canonicalizes the roots and the working folder
  with `dunce`. `std::fs::canonicalize` returns a Windows verbatim path for an
  existing root and fails on a working folder that does not exist yet, and that
  fallback keeps the raw spelling, so the prefix comparison rejected a
  legitimate working folder.
- The spec's platform section gives a verdict for NTFS case, separators,
  verbatim and UNC prefixes, drive-relative `C:foo`, 8.3 short names, and
  Unicode NFC against NFD. Each is an over-refusal with no user recovery path,
  recorded as an intended tradeoff under Principle IV.
- `astro-plan-3v3r.13.26` was absorbed by this change, not excluded:
  `crates/workflow/profiles/src/launch.rs:245-252` delegates to
  `contained_in_any` and refuses an empty root list, with tests at
  `launch.rs:309-345`. The merge step closes it.

Sibling containment findings that stay open and untouched here:
`astro-plan-zboex` (archive and trash destinations), `astro-plan-3v3r.8.37`
(`validate_reveal_path`), `astro-plan-3v3r.8.27` (`native.reveal`).

## Verification

- `cargo test` on `fs_pathsafe`, `fs_executor`, `project_structure`,
  `workflow_profiles`: 248 passed. `cargo test -p app_core`: 564 passed.
- `cargo clippy --all-targets -- -D warnings` on the same five crates: no issues.
- `cargo fmt --all -- --check`: clean. `just dead-callers`: no new dead pub fns.
- Round 3: `cargo nextest run --workspace`: 3182 passed, 31 skipped.
  `cargo clippy --all-targets -- -D warnings` on `fs_pathsafe`,
  `project_structure`, `workflow_profiles`, `app_core`, `app_core_projects`: no
  issues. Windows behaviour is verified by the CI lane, not locally.
- Round 4: `cargo nextest run` on `fs_pathsafe`, `project_structure`,
  `workflow_profiles`, `app_core_projects`: 239 passed. `cargo nextest run -p
  app_core -E 'test(tool_launch)'`: 21 passed. `cargo clippy --all-targets` on
  the five crates and `cargo fmt --all -- --check`: clean. `just dead-callers`:
  no new dead pub fns, 148 baselined. Windows behaviour is answered by the CI
  lane, not locally.
- Red-before proof ran against base `4948b3ece` in a detached `git archive` copy,
  not by reverting in place.

Work bead: astro-plan-tmwtz
Merge bead: astro-plan-syve3
Spec: `specs/tiny/root-relative-path-containment.md`

Tracks-Bead: astro-plan-tmwtz
Merge-Bead: astro-plan-syve3



