### PR TITLE
fix: refuse to plan a move when two frames would land on the same file path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "unicode-normalization",
  "uuid",
 ]
 

--- a/apps/desktop/messages/en-GB.json
+++ b/apps/desktop/messages/en-GB.json
@@ -253,6 +253,7 @@
   "err_inbox_invalid_destination_root": "That destination library isn't valid.",
   "err_inbox_item_no_plan": "There's no plan for this item yet.",
   "err_inbox_item_not_found": "That inbox item could not be found.",
+  "err_inbox_destination_collision": "Two or more files would end up at the same destination path. Rename them, or add a token to the naming pattern that tells them apart.",
   "err_inbox_missing_path_attributes": "This item is missing the details needed to plan a move.",
   "err_inbox_no_destination_root": "Choose a destination library before continuing.",
   "err_internal_audit": "Couldn't record this action to the history log. Please try again.",

--- a/apps/desktop/messages/pt-BR.json
+++ b/apps/desktop/messages/pt-BR.json
@@ -253,6 +253,7 @@
   "err_inbox_invalid_destination_root": "Essa biblioteca de destino não é válida.",
   "err_inbox_item_no_plan": "Ainda não há plano para este item.",
   "err_inbox_item_not_found": "Esse item da caixa de entrada não pôde ser encontrado.",
+  "err_inbox_destination_collision": "Dois ou mais arquivos terminariam no mesmo caminho de destino. Renomeie-os ou adicione ao padrão de nomes um token que os diferencie.",
   "err_inbox_missing_path_attributes": "Faltam a este item os detalhes necessários para planejar uma movimentação.",
   "err_inbox_no_destination_root": "Escolha uma biblioteca de destino antes de continuar.",
   "err_internal_audit": "Não foi possível registrar esta ação no histórico. Tente novamente.",

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -3872,7 +3872,13 @@ export type ErrorCode = "validation.request_envelope_invalid" | "dev_mode.disabl
  *  Cross-cutting across categories — an inbox root inside a light-frames
  *  root is still an overlap.
  */
-"path.overlaps_existing" | "inbox.item.not_found" | "inbox.has.open.plan" | "inbox.item.no_plan" | "inbox.no_destination_root" | "inbox.destination_root_required" | "inbox.invalid_destination_root" | "inbox.missing_path_attributes" | "inbox.destination_collision" | "metadata.unreadable" | "classification.ambiguous" | "classification.stale" | "pattern.unset" | "pattern.empty" | "pattern.invalid" | "pattern.invalid.unicode" | "token.unknown" | "file.not_found" | "note.content_too_large" | "session.not_found" | "session.mixed_state" | "operation.handler_duplicate" | "operation.not_found" | 
+"path.overlaps_existing" | "inbox.item.not_found" | "inbox.has.open.plan" | "inbox.item.no_plan" | "inbox.no_destination_root" | "inbox.destination_root_required" | "inbox.invalid_destination_root" | "inbox.missing_path_attributes" | 
+/**
+ *  `inbox.confirm`: two or more source files resolve onto one destination
+ *  path, so the plan cannot be applied without one item claiming another's
+ *  path. Refused at plan-build time (Constitution II).
+ */
+"inbox.destination_collision" | "metadata.unreadable" | "classification.ambiguous" | "classification.stale" | "pattern.unset" | "pattern.empty" | "pattern.invalid" | "pattern.invalid.unicode" | "token.unknown" | "file.not_found" | "note.content_too_large" | "session.not_found" | "session.mixed_state" | "operation.handler_duplicate" | "operation.not_found" | 
 /**  Plan approval is outstanding (sent as `ContractError`, not `TransitionError`). */
 "plan.approval_required" | "plan.approval.stale" | 
 /**

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -3872,7 +3872,7 @@ export type ErrorCode = "validation.request_envelope_invalid" | "dev_mode.disabl
  *  Cross-cutting across categories — an inbox root inside a light-frames
  *  root is still an overlap.
  */
-"path.overlaps_existing" | "inbox.item.not_found" | "inbox.has.open.plan" | "inbox.item.no_plan" | "inbox.no_destination_root" | "inbox.destination_root_required" | "inbox.invalid_destination_root" | "inbox.missing_path_attributes" | "metadata.unreadable" | "classification.ambiguous" | "classification.stale" | "pattern.unset" | "pattern.empty" | "pattern.invalid" | "pattern.invalid.unicode" | "token.unknown" | "file.not_found" | "note.content_too_large" | "session.not_found" | "session.mixed_state" | "operation.handler_duplicate" | "operation.not_found" | 
+"path.overlaps_existing" | "inbox.item.not_found" | "inbox.has.open.plan" | "inbox.item.no_plan" | "inbox.no_destination_root" | "inbox.destination_root_required" | "inbox.invalid_destination_root" | "inbox.missing_path_attributes" | "inbox.destination_collision" | "metadata.unreadable" | "classification.ambiguous" | "classification.stale" | "pattern.unset" | "pattern.empty" | "pattern.invalid" | "pattern.invalid.unicode" | "token.unknown" | "file.not_found" | "note.content_too_large" | "session.not_found" | "session.mixed_state" | "operation.handler_duplicate" | "operation.not_found" | 
 /**  Plan approval is outstanding (sent as `ContractError`, not `TransitionError`). */
 "plan.approval_required" | "plan.approval.stale" | 
 /**

--- a/apps/desktop/src/lib/error-messages.ts
+++ b/apps/desktop/src/lib/error-messages.ts
@@ -44,6 +44,7 @@ export const ERROR_MESSAGES: Record<ErrorCode, () => string> = {
   'inbox.no_destination_root': m.err_inbox_no_destination_root,
   'inbox.destination_root_required': m.err_inbox_destination_root_required,
   'inbox.invalid_destination_root': m.err_inbox_invalid_destination_root,
+  'inbox.destination_collision': m.err_inbox_destination_collision,
   'inbox.missing_path_attributes': m.err_inbox_missing_path_attributes,
   'metadata.unreadable': m.err_metadata_unreadable,
   'classification.ambiguous': m.err_classification_ambiguous,

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -48,6 +48,7 @@ simbad-resolver = "0.5.0"
 time = { workspace = true }
 tokio.workspace = true
 tracing = { workspace = true }
+unicode-normalization.workspace = true
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -1066,6 +1066,16 @@ mod tests {
         persistence_core::test_support::setup_db().await
     }
 
+    /// Count plans sitting in one lifecycle state. `ready_for_review` is the
+    /// only state `plans.approve` accepts, so it is the appliability probe.
+    async fn count_plans_in_state(pool: &SqlitePool, state: &str) -> i64 {
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM plans WHERE state = ?")
+            .bind(state)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
     /// Write a minimal single-block FITS file from the optional cards the
     /// destination-pattern tests care about. The `write_fits*` helpers below
     /// are thin presets over this.
@@ -1309,6 +1319,63 @@ mod tests {
 
         assert_eq!(resp.plan_state, "ready_for_review");
         assert_eq!(resp.items_total, 3);
+    }
+
+    /// Two frames captured in different session folders share a basename and
+    /// carry identical pattern tokens, so the rendered destination is the same
+    /// path for both. Applying that plan overwrites one frame with the other
+    /// (Constitution I: the frames are user-owned source material; Constitution
+    /// II: a plan that overwrites silently is not reviewable), so confirm must
+    /// refuse to build it.
+    #[tokio::test]
+    async fn confirm_refuses_two_files_that_resolve_onto_one_destination() {
+        let tmp = tempfile::tempdir().unwrap();
+        for session in ["session-a", "session-b"] {
+            let dir = tmp.path().join(session);
+            std::fs::create_dir_all(&dir).unwrap();
+            write_fits(
+                &dir,
+                "light_001.fits",
+                "Light Frame",
+                Some("M42"),
+                Some("Ha"),
+                Some("2026-01-12T22:00:00"),
+            );
+        }
+
+        let db = test_db().await;
+        setup_classified_item(
+            &db,
+            "item-collide",
+            "classified",
+            Some("light"),
+            "sig-collide",
+            &["session-a/light_001.fits", "session-b/light_001.fits"],
+        )
+        .await;
+
+        let err = confirm(
+            db.pool(),
+            &make_bus(&db),
+            ConfirmRequest {
+                inbox_item_id: "item-collide".to_owned(),
+                content_signature: "sig-collide".to_owned(),
+                destructive_destination: None,
+                root_absolute_path: tmp.path().to_owned(),
+                root_id: None,
+                chosen_attribution: None,
+            },
+        )
+        .await
+        .expect_err("two files on one destination must not produce a plan");
+
+        assert_eq!(err.code, ErrorCode::InboxDestinationCollision);
+        assert_eq!(
+            count_plans_in_state(db.pool(), "ready_for_review").await,
+            0,
+            "the collision must not reach apply through a reviewable plan"
+        );
+        assert!(inbox_repo::get_plan_link(db.pool(), "item-collide").await.unwrap().is_none());
     }
 
     /// Build one classified sibling sub-item under `sg_id`.
@@ -3000,6 +3067,62 @@ mod tests {
             Some("framing-attr2"),
             "the apply-path must persist the pick on the plan confirm() itself created"
         );
+    }
+
+    /// Frame-to-framing attribution is a Tier-1 record (Constitution V): it
+    /// cannot be re-derived from the filesystem. A confirm whose attribution
+    /// fails must therefore leave nothing appliable behind, or the frames move
+    /// with the user's decision missing.
+    #[tokio::test]
+    async fn failed_attribution_leaves_no_appliable_plan() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fits(
+            tmp.path(),
+            "light_001.fits",
+            "Light Frame",
+            Some("M42"),
+            Some("Ha"),
+            Some("2025-10-10T22:00:00"),
+        );
+        let db = test_db().await;
+        setup_classified_item(
+            &db,
+            "item-attr-fail",
+            "classified",
+            Some("light"),
+            "sig-attr-fail",
+            &["light_001.fits"],
+        )
+        .await;
+
+        let err = confirm(
+            db.pool(),
+            &make_bus(&db),
+            ConfirmRequest {
+                inbox_item_id: "item-attr-fail".to_owned(),
+                content_signature: "sig-attr-fail".to_owned(),
+                destructive_destination: None,
+                root_absolute_path: tmp.path().to_owned(),
+                root_id: None,
+                chosen_attribution: Some(contracts_core::framing::ChosenAttributionDto {
+                    kind: contracts_core::framing::ChosenAttributionKind::AddToFraming,
+                    project_id: None,
+                    framing_id: Some("framing-does-not-exist".to_owned()),
+                }),
+            },
+        )
+        .await
+        .expect_err("a failed Tier-1 attribution must fail the confirm");
+
+        assert_eq!(err.code, ErrorCode::FramingNotFound);
+        assert_eq!(
+            count_plans_in_state(db.pool(), "ready_for_review").await,
+            0,
+            "a failed attribution must leave no appliable plan"
+        );
+        assert!(inbox_repo::get_plan_link(db.pool(), "item-attr-fail").await.unwrap().is_none());
+        let item = inbox_repo::get_inbox_item(db.pool(), "item-attr-fail").await.unwrap();
+        assert_ne!(item.state, "plan_open");
     }
 
     // ── #1342: equipment resolution on the ingest path ────────────────────

--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -59,6 +59,7 @@ use persistence_lifecycle::repositories::settings as settings_repo;
 use persistence_plans::repositories::plans as plans_repo;
 use serde_json::json;
 use sqlx::SqlitePool;
+use unicode_normalization::UnicodeNormalization;
 use uuid::Uuid;
 
 use app_core_errors::db_internal_ctx;
@@ -712,45 +713,61 @@ fn reject_if_missing_path_attrs(
     .with_details(json!({ "files": files })))
 }
 
-/// Fail with `InboxDestinationCollision` if two resolved rows claim one
-/// `(to_root_id, to_relative_path)`.
+/// Case-folded, NFC-normalized destination path, used as the collision key.
 ///
-/// A per-item overwrite check at apply time cannot catch this: the second item
-/// overwrites what the first item just wrote, so nothing pre-existing is in the
-/// way. The frames are irreplaceable (Constitution I) and a plan whose own items
-/// overwrite each other is not reviewable (Constitution II), so the plan is
-/// refused rather than resolved to a winner.
+/// APFS and NTFS resolve two paths differing only in case to one file, and APFS
+/// also compares NFC and NFD spellings as equal, so a byte comparison would pass
+/// rows that name one file on the volumes this app targets.
+fn destination_key(dest_rel: &str) -> String {
+    dest_rel.nfc().collect::<String>().to_lowercase()
+}
+
+/// Fail with `InboxDestinationCollision` if two resolved rows claim one
+/// destination root and [`destination_key`].
+///
+/// A per-item overwrite check at apply time cannot catch a same-plan collision:
+/// nothing pre-existing is in the way when the first item runs. The executor
+/// then refuses the second item (`fs_executor::ops::move_op`,
+/// `conflict.destination_exists`), which leaves the item's frames half-moved
+/// with the plan failed partway. Constitution II puts that decision in the
+/// reviewable plan instead, so confirm refuses to build one.
 fn reject_if_destinations_collide(resolved: &[ResolvedRow]) -> Result<(), ContractError> {
-    let mut by_dest: BTreeMap<(&str, &str), Vec<&str>> = BTreeMap::new();
+    let mut by_dest: BTreeMap<(&str, String), Vec<&ResolvedRow>> = BTreeMap::new();
     for row in resolved {
         by_dest
-            .entry((row.to_root_id.as_str(), row.dest_rel.as_str()))
+            .entry((row.to_root_id.as_str(), destination_key(&row.dest_rel)))
             .or_default()
-            .push(row.source_rel.as_str());
+            .push(row);
     }
-    let collisions: Vec<((&str, &str), Vec<&str>)> =
-        by_dest.into_iter().filter(|(_, sources)| sources.len() > 1).collect();
+    let collisions: Vec<((&str, String), Vec<&ResolvedRow>)> =
+        by_dest.into_iter().filter(|(_, rows)| rows.len() > 1).collect();
     if collisions.is_empty() {
         return Ok(());
     }
 
     let details: Vec<serde_json::Value> = collisions
         .iter()
-        .map(|((root_id, dest), sources)| {
-            json!({ "toRootId": root_id, "toRelativePath": dest, "sourcePaths": sources })
+        .map(|((root_id, _), rows)| {
+            let items: Vec<serde_json::Value> = rows
+                .iter()
+                .map(|r| json!({ "sourcePath": r.source_rel, "toRelativePath": r.dest_rel }))
+                .collect();
+            json!({ "toRootId": root_id, "items": items })
         })
         .collect();
     let summary = collisions
         .iter()
-        .map(|((_, dest), sources)| format!("{dest} <- {}", sources.join(", ")))
+        .map(|(_, rows)| {
+            rows.iter()
+                .map(|r| format!("{} -> {}", r.source_rel, r.dest_rel))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
         .collect::<Vec<_>>()
         .join("; ");
     Err(ContractError::new(
         ErrorCode::InboxDestinationCollision,
-        format!(
-            "These files resolve onto the same destination, so moving them would overwrite one \
-             with another: {summary}"
-        ),
+        format!("These files claim one destination path, so the plan cannot be applied: {summary}"),
         ErrorSeverity::Blocking,
         false,
     )
@@ -1377,21 +1394,17 @@ mod tests {
         assert_eq!(resp.items_total, 3);
     }
 
-    /// Two frames captured in different session folders share a basename and
-    /// carry identical pattern tokens, so the rendered destination is the same
-    /// path for both. Applying that plan overwrites one frame with the other
-    /// (Constitution I: the frames are user-owned source material; Constitution
-    /// II: a plan that overwrites silently is not reviewable), so confirm must
-    /// refuse to build it.
-    #[tokio::test]
-    async fn confirm_refuses_two_files_that_resolve_onto_one_destination() {
+    /// Confirm one inbox item holding two light frames, one per session folder,
+    /// under identical pattern tokens. Returns the confirm error and asserts
+    /// that nothing appliable was left behind.
+    async fn confirm_two_session_frames(item_id: &str, names: (&str, &str)) -> ContractError {
         let tmp = tempfile::tempdir().unwrap();
-        for session in ["session-a", "session-b"] {
+        for (session, name) in [("session-a", names.0), ("session-b", names.1)] {
             let dir = tmp.path().join(session);
             std::fs::create_dir_all(&dir).unwrap();
             write_fits(
                 &dir,
-                "light_001.fits",
+                name,
                 "Light Frame",
                 Some("M42"),
                 Some("Ha"),
@@ -1400,13 +1413,14 @@ mod tests {
         }
 
         let db = test_db().await;
+        let files = [format!("session-a/{}", names.0), format!("session-b/{}", names.1)];
         setup_classified_item(
             &db,
-            "item-collide",
+            item_id,
             "classified",
             Some("light"),
             "sig-collide",
-            &["session-a/light_001.fits", "session-b/light_001.fits"],
+            &[files[0].as_str(), files[1].as_str()],
         )
         .await;
 
@@ -1414,7 +1428,7 @@ mod tests {
             db.pool(),
             &make_bus(&db),
             ConfirmRequest {
-                inbox_item_id: "item-collide".to_owned(),
+                inbox_item_id: item_id.to_owned(),
                 content_signature: "sig-collide".to_owned(),
                 destructive_destination: None,
                 root_absolute_path: tmp.path().to_owned(),
@@ -1425,13 +1439,48 @@ mod tests {
         .await
         .expect_err("two files on one destination must not produce a plan");
 
-        assert_eq!(err.code, ErrorCode::InboxDestinationCollision);
         assert_eq!(
             count_plans_in_state(db.pool(), "ready_for_review").await,
             0,
             "the collision must not reach apply through a reviewable plan"
         );
-        assert!(inbox_repo::get_plan_link(db.pool(), "item-collide").await.unwrap().is_none());
+        assert!(inbox_repo::get_plan_link(db.pool(), item_id).await.unwrap().is_none());
+        err
+    }
+
+    /// Two frames captured in different session folders share a basename and
+    /// carry identical pattern tokens, so the rendered destination is the same
+    /// path for both. Applying that plan fails partway: `move_op` refuses the
+    /// second item with `conflict.destination_exists`, leaving the item's frames
+    /// half-moved. Constitution II puts that decision in the reviewable plan, so
+    /// confirm must refuse to build one.
+    #[tokio::test]
+    async fn confirm_refuses_two_files_that_resolve_onto_one_destination() {
+        let err =
+            confirm_two_session_frames("item-collide", ("light_001.fits", "light_001.fits")).await;
+        assert_eq!(err.code, ErrorCode::InboxDestinationCollision);
+    }
+
+    /// The byte comparison this replaces treats each pair below as two paths.
+    /// APFS resolves both pairs to one file, NTFS the first. Only the case pair
+    /// is reachable end to end: the filesystem normalizes the Unicode pair
+    /// before `file_name()` sees it.
+    #[test]
+    fn destination_key_folds_case_and_normalizes_unicode() {
+        assert_ne!("m42/Light_001.fits", "m42/light_001.fits");
+        assert_eq!(destination_key("m42/Light_001.fits"), destination_key("m42/light_001.fits"));
+        assert_ne!("m42/cafe\u{301}.fits", "m42/caf\u{e9}.fits");
+        assert_eq!(destination_key("m42/cafe\u{301}.fits"), destination_key("m42/caf\u{e9}.fits"));
+    }
+
+    /// APFS and NTFS resolve two destinations differing only in case to one
+    /// file, so the gate compares case-folded keys rather than bytes.
+    #[tokio::test]
+    async fn confirm_refuses_two_files_whose_destinations_differ_only_in_case() {
+        let err =
+            confirm_two_session_frames("item-collide-case", ("light_001.fits", "LIGHT_001.fits"))
+                .await;
+        assert_eq!(err.code, ErrorCode::InboxDestinationCollision);
     }
 
     /// Build one classified sibling sub-item under `sg_id`.

--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -142,6 +142,7 @@ pub struct ResolvedDestination {
 /// - `classification.ambiguous` — action/classification mismatch or no classified files.
 /// - `classification.stale` — signature drift detected.
 /// - `pattern.unset` — naming pattern is unset or fails to resolve required tokens.
+/// - `inbox.destination_collision` — two files resolve onto one destination path.
 /// - `attribution.not_light_frame` — `chosen_attribution` was supplied for a
 ///   non-light item (spec 008 Q27 F-Framing-10).
 /// - `attribution.geometry_unavailable` — `chosen_attribution` requires
@@ -275,6 +276,9 @@ pub async fn confirm(
     // 8d. US9 gate: reject if any file is missing a path-load-bearing attribute.
     reject_if_missing_path_attrs(&missing_by_file)?;
 
+    // 8e. Self-collision gate: refuse before any plan row exists.
+    reject_if_destinations_collide(&resolved_items)?;
+
     // 10. Build the plan.
     // A move-only split is non-destructive from the user perspective but the
     // plans table CHECK constraint only accepts the canonical 'archive' | 'trash'
@@ -323,12 +327,31 @@ pub async fn confirm(
         insert_plan_items_batch(pool, &plan_id, &item.root_id, &resolved_items, &root_paths)
             .await?;
 
-    // 12. Transition plan to ready_for_review
+    // 12. Attribution apply-path (spec 008 Q27, F-Framing-10/6, FR-022): the
+    // plan row and its items now exist, so the pick can be persisted
+    // (`plans.chosen_framing_id`) for `ingest_sessions` to bind once the real
+    // session is created. Creates the framing/project the kind requires and
+    // honors the F-Framing-6 completed-project reopen.
+    //
+    // Ordered before the three writes below, not after: frame-to-framing
+    // attribution is a Tier-1 record (Constitution V) that the filesystem cannot
+    // re-derive, and those writes are what make the plan appliable. Running them
+    // first left a `ready_for_review` plan on a failed attribution, so the frames
+    // could move with the user's decision missing. The plan stays in `draft` on
+    // failure, which `plans.approve` refuses.
+    let attribution_applied = match (&item_geometry, &req.chosen_attribution) {
+        (Some(geometry), Some(chosen)) => {
+            attribution::apply_chosen_attribution(pool, bus, &plan_id, geometry, chosen).await?
+        }
+        _ => None,
+    };
+
+    // 13. Transition plan to ready_for_review
     plans_repo::update_plan_state(pool, &plan_id, PlanState::ReadyForReview.as_str())
         .await
         .map_err(|e| db_internal_ctx(e, "transition plan to ready_for_review"))?;
 
-    // 13. Create plan link and update item state
+    // 14. Create plan link and update item state
     inbox_repo::insert_plan_link(pool, &req.inbox_item_id, &plan_id)
         .await
         .map_err(|e| db_internal_ctx(e, "insert plan link"))?;
@@ -339,18 +362,6 @@ pub async fn confirm(
     inbox_repo::update_inbox_item_state(pool, &req.inbox_item_id, "plan_open")
         .await
         .map_err(|e| db_internal_ctx(e, "mark inbox item plan_open"))?;
-
-    // 14. Attribution apply-path (spec 008 Q27, F-Framing-10/6, FR-022): the
-    // plan now exists, so the pick can be persisted (`plans.chosen_framing_id`)
-    // for `ingest_sessions` to bind once the real session is created. Creates
-    // the framing/project the kind requires and honors the F-Framing-6
-    // completed-project reopen.
-    let attribution_applied = match (&item_geometry, &req.chosen_attribution) {
-        (Some(geometry), Some(chosen)) => {
-            attribution::apply_chosen_attribution(pool, bus, &plan_id, geometry, chosen).await?
-        }
-        _ => None,
-    };
 
     // 15. Publish `inventory.confirmed` (best-effort; durable writes above already
     //     succeeded — a bus failure must not surface as Fatal).
@@ -699,6 +710,51 @@ fn reject_if_missing_path_attrs(
         false,
     )
     .with_details(json!({ "files": files })))
+}
+
+/// Fail with `InboxDestinationCollision` if two resolved rows claim one
+/// `(to_root_id, to_relative_path)`.
+///
+/// A per-item overwrite check at apply time cannot catch this: the second item
+/// overwrites what the first item just wrote, so nothing pre-existing is in the
+/// way. The frames are irreplaceable (Constitution I) and a plan whose own items
+/// overwrite each other is not reviewable (Constitution II), so the plan is
+/// refused rather than resolved to a winner.
+fn reject_if_destinations_collide(resolved: &[ResolvedRow]) -> Result<(), ContractError> {
+    let mut by_dest: BTreeMap<(&str, &str), Vec<&str>> = BTreeMap::new();
+    for row in resolved {
+        by_dest
+            .entry((row.to_root_id.as_str(), row.dest_rel.as_str()))
+            .or_default()
+            .push(row.source_rel.as_str());
+    }
+    let collisions: Vec<((&str, &str), Vec<&str>)> =
+        by_dest.into_iter().filter(|(_, sources)| sources.len() > 1).collect();
+    if collisions.is_empty() {
+        return Ok(());
+    }
+
+    let details: Vec<serde_json::Value> = collisions
+        .iter()
+        .map(|((root_id, dest), sources)| {
+            json!({ "toRootId": root_id, "toRelativePath": dest, "sourcePaths": sources })
+        })
+        .collect();
+    let summary = collisions
+        .iter()
+        .map(|((_, dest), sources)| format!("{dest} <- {}", sources.join(", ")))
+        .collect::<Vec<_>>()
+        .join("; ");
+    Err(ContractError::new(
+        ErrorCode::InboxDestinationCollision,
+        format!(
+            "These files resolve onto the same destination, so moving them would overwrite one \
+             with another: {summary}"
+        ),
+        ErrorSeverity::Blocking,
+        false,
+    )
+    .with_details(json!({ "collisions": details })))
 }
 
 /// Publish `inventory.confirmed` to the event bus (spec 056).

--- a/crates/contracts/core/src/error_code.rs
+++ b/crates/contracts/core/src/error_code.rs
@@ -119,8 +119,8 @@ pub enum ErrorCode {
     #[serde(rename = "inbox.missing_path_attributes")]
     InboxMissingPathAttributes,
     /// `inbox.confirm`: two or more source files resolve onto one destination
-    /// path, so applying the plan would overwrite one with another
-    /// (Constitution I/II). Refused at plan-build time.
+    /// path, so the plan cannot be applied without one item claiming another's
+    /// path. Refused at plan-build time (Constitution II).
     #[serde(rename = "inbox.destination_collision")]
     InboxDestinationCollision,
 

--- a/crates/contracts/core/src/error_code.rs
+++ b/crates/contracts/core/src/error_code.rs
@@ -118,6 +118,11 @@ pub enum ErrorCode {
     InboxInvalidDestinationRoot,
     #[serde(rename = "inbox.missing_path_attributes")]
     InboxMissingPathAttributes,
+    /// `inbox.confirm`: two or more source files resolve onto one destination
+    /// path, so applying the plan would overwrite one with another
+    /// (Constitution I/II). Refused at plan-build time.
+    #[serde(rename = "inbox.destination_collision")]
+    InboxDestinationCollision,
 
     // ── Metadata / classification ────────────────────────────────────────────
     #[serde(rename = "metadata.unreadable")]


### PR DESCRIPTION
## Summary

- Confirming an inbox item that held two frames with the same file name in
  different session folders produced a plan whose two items pointed at one
  destination path, for example `M42/Ha/2026-01-12/light/light_001.fits`.
  Applying it moved the first frame, then failed the second with
  `conflict.destination_exists`, leaving the item's frames split between the
  source and the library with the plan failed partway. Confirm now refuses the
  item and names every destination that two files claim, so no such plan is
  offered for review.
- Confirming a light item with an attribution pick that failed left a plan the
  user could still approve and apply. Applying it moved the frames with no
  session or target attribution recorded, and that record cannot be recovered
  from the files. A failed attribution now leaves nothing to approve.

No frame was destroyed by either defect. `crates/fs/executor/src/ops/move_op.rs:102`
refuses an occupied destination before it renames, so the second item failed
instead of overwriting the first.

## What changed

- Confirm groups the resolved destinations by root and by a case-folded,
  NFC-normalized path before it creates the plan. Two or more files on one key
  fail with `inbox.destination_collision`, listing each source path and the
  destination it claims. Rename the files, or add a token to the naming pattern
  that tells the sessions apart. The key is folded because APFS and NTFS resolve
  two paths differing only in case to one file, and APFS also compares NFC and
  NFD spellings as equal. Folding applies on every platform, deliberately: on
  Linux and case-sensitive macOS volumes, where two destinations differing only
  in case are two separate files, confirm refuses the item rather than planning
  both moves.
- The attribution pick is applied before the plan becomes reviewable. A failed
  pick leaves a plan that `plans.approve` rejects, doesn't write an inbox plan
  link, and keeps the inbox item in its previous state.

## Scope of the collision

Both files had to sit inside one confirmable item and resolve to the same
pattern-rendered directory, which means the same target, filter, capture date and
frame type. A naming pattern that already separates sessions was never exposed.

## Tests

| Test | Pins |
| --- | --- |
| `confirm_refuses_two_files_that_resolve_onto_one_destination` | byte-equal destinations are refused, with no `ready_for_review` plan and no plan link |
| `confirm_refuses_two_files_whose_destinations_differ_only_in_case` | a case-only destination pair is refused on any volume, including case-sensitive CI |
| `destination_key_folds_case_and_normalizes_unicode` | case and NFC/NFD pairs that a byte comparison treats as two paths |
| `failed_attribution_leaves_no_appliable_plan` | a failed attribution leaves a plan `plans.approve` rejects, doesn't write a plan link, and keeps the item's state |

The first and last fail against 7ace131bd (`cargo nextest run`, exit 100). The
first needs the `error_code.rs` variant to compile, so commit ca3567e45 carries
the tests and that variant together, without the guard or the reordering.

## Verification

| Check | Exit |
| --- | --- |
| `cargo clippy --workspace --all-targets -- -D warnings` | 0 |
| `cargo nextest run -p app_core_inbox` (249 passed) | 0 |
| `cargo fmt --check` | 0 |
| `cargo test -p desktop_shell --test bindings` | 0 |
| `pnpm lint` (apps/desktop) | 0 |

The bindings test and `pnpm lint` ran at 450b755a; round 2 changed no
`apps/desktop` file and no type that reaches the generated bindings.

Tracks-Bead: astro-plan-7ejk7
Tracks-Bead: astro-plan-3v3r.6.14
Tracks-Bead: astro-plan-3v3r.6.12
Merge-Bead: astro-plan-bd2a1

