### PR TITLE
test(persistence): pin the sqlx migration-failure behaviour the backup refutation rests on

### DIFF
--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -300,7 +300,8 @@ mod tests {
     /// reachable here. A migration that opts out of the transaction would make
     /// it reachable, and would need its own user-facing repair message rather
     /// than the "written by a different revision" wording this classifier
-    /// produces.
+    /// produces. [`every_migration_runs_inside_a_transaction`] enforces that
+    /// precondition.
     #[test]
     fn divergence_detail_ignores_unrelated_failures() {
         assert!(super::migration_divergence_detail(&super::DbError::NotImplemented).is_none());
@@ -308,6 +309,34 @@ mod tests {
             sqlx::migrate::MigrateError::Dirty(71)
         ))
         .is_none());
+    }
+
+    /// Enforces the precondition that makes a partially-applied migration
+    /// impossible on SQLite, and with it the `Dirty` arm's absence from
+    /// [`super::migration_divergence_detail`].
+    ///
+    /// A migration file marked `-- no-transaction` sets `Migration::no_tx`, and
+    /// sqlx then runs that script outside a transaction.
+    #[test]
+    fn every_migration_runs_inside_a_transaction() {
+        let opted_out: Vec<i64> = super::Database::migrator()
+            .iter()
+            .filter(|migration| migration.no_tx)
+            .map(|migration| migration.version)
+            .collect();
+
+        assert!(
+            opted_out.is_empty(),
+            "migrations {opted_out:?} opt out of the per-migration transaction. \
+             Such a migration can fail partway and leave the schema partially \
+             applied, which makes MigrateError::Dirty reachable and leaves a \
+             failed migration with no rollback material. The constitution's \
+             unclean-shutdown constraint then requires a verified pre-migration \
+             backup and an explicit user resume-or-repair prompt, plus a \
+             migration_divergence_detail arm wording Dirty as a partial apply \
+             rather than a build mismatch. Satisfy those before deleting this \
+             assertion."
+        );
     }
 
     #[tokio::test]
@@ -404,6 +433,27 @@ mod tests {
 
         assert!(!dest.exists(), "no file may be created for a rejected backup");
         assert!(err.to_string().contains("no-such-dir"), "error must name the destination: {err}");
+    }
+
+    /// The pre-migration backup names its destination after the app version, so
+    /// a second launch on the same version aims at an existing backup. SQLite
+    /// refuses that destination ("output file already exists"), which preserves
+    /// the earlier rollback material rather than overwriting it.
+    #[tokio::test]
+    async fn backup_to_rejects_an_existing_destination_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = file_backed_db(dir.path()).await;
+        let dest = dir.path().join("already-there.sqlite3");
+        db.backup_to(&dest).await.expect("first backup");
+        let first = std::fs::read(&dest).expect("read the first backup");
+
+        let err = db.backup_to(&dest).await.expect_err("an existing destination must fail");
+
+        assert_eq!(
+            std::fs::read(&dest).expect("destination still readable"),
+            first,
+            "a rejected backup must leave the earlier backup byte-for-byte: {err}"
+        );
     }
 
     /// With a `Database::in_memory()` source, `VACUUM INTO` reports success and

--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -293,15 +293,17 @@ mod tests {
         }
     }
 
-    /// `MigrateError::Dirty` names a partially-applied migration, which sqlx
-    /// only produces on databases without transactional DDL. `sqlx-sqlite` runs
-    /// each migration script and its `_sqlx_migrations` bookkeeping in one
-    /// transaction, so a failing script rolls back and no `Dirty` state is
-    /// reachable here. A migration that opts out of the transaction would make
-    /// it reachable, and would need its own user-facing repair message rather
-    /// than the "written by a different revision" wording this classifier
-    /// produces. [`every_migration_runs_inside_a_transaction`] enforces that
-    /// precondition.
+    /// `MigrateError::Dirty` reports a `_sqlx_migrations` row with
+    /// `success = false`. This build never records one: `execute_migration`
+    /// inserts `success` as a `TRUE` literal, and a script that fails inserts
+    /// nothing at all, so a database this build wrote cannot produce `Dirty`.
+    /// [`a_failed_migration_records_no_row`] pins that dependency behaviour.
+    ///
+    /// `Dirty` does still arrive from a `success = false` row written by another
+    /// tool, such as an older sqlx or the sqlx CLI, and this classifier returns
+    /// `None` for it. That is a diagnosis gap rather than a custody one: sqlx
+    /// reads the dirty version before applying anything, so the migration never
+    /// starts. Tracked on astro-plan-00yw0.
     #[test]
     fn divergence_detail_ignores_unrelated_failures() {
         assert!(super::migration_divergence_detail(&super::DbError::NotImplemented).is_none());
@@ -311,12 +313,10 @@ mod tests {
         .is_none());
     }
 
-    /// Enforces the precondition that makes a partially-applied migration
-    /// impossible on SQLite, and with it the `Dirty` arm's absence from
-    /// [`super::migration_divergence_detail`].
-    ///
-    /// A migration file marked `-- no-transaction` sets `Migration::no_tx`, and
-    /// sqlx then runs that script outside a transaction.
+    /// Keeps a partially-applied schema unreachable. A migration file starting
+    /// with `-- no-transaction` sets `Migration::no_tx`, and sqlx then runs that
+    /// script outside a transaction, so a failure partway leaves the statements
+    /// it already ran in place.
     #[test]
     fn every_migration_runs_inside_a_transaction() {
         let opted_out: Vec<i64> = super::Database::migrator()
@@ -328,14 +328,73 @@ mod tests {
         assert!(
             opted_out.is_empty(),
             "migrations {opted_out:?} opt out of the per-migration transaction. \
-             Such a migration can fail partway and leave the schema partially \
-             applied, which makes MigrateError::Dirty reachable and leaves a \
-             failed migration with no rollback material. The constitution's \
-             unclean-shutdown constraint then requires a verified pre-migration \
-             backup and an explicit user resume-or-repair prompt, plus a \
-             migration_divergence_detail arm wording Dirty as a partial apply \
-             rather than a build mismatch. Satisfy those before deleting this \
-             assertion."
+             Such a migration can fail partway and leave the schema half built, \
+             and because a failed migration records no bookkeeping row, nothing \
+             marks the database as partially applied and \
+             migration_divergence_detail has no error to classify. Recovery then \
+             depends entirely on the pre-migration backup. The constitution's \
+             unclean-shutdown constraint requires a verified backup and an \
+             explicit user resume-or-repair prompt before a migration may run in \
+             that state. Satisfy those before deleting this assertion."
+        );
+    }
+
+    /// Pins the sqlx behaviour that keeps `MigrateError::Dirty` out of reach:
+    /// a failed migration leaves no `_sqlx_migrations` row, so no
+    /// `success = false` row exists for `dirty_version` to find.
+    ///
+    /// This is a property of the sqlx version this workspace resolves, not of
+    /// this crate, so a sqlx upgrade that starts recording failed migrations
+    /// turns this red. That is the point: it is the moment to re-examine whether
+    /// a partially-applied migration needs a user-facing repair path.
+    #[tokio::test]
+    async fn a_failed_migration_records_no_row() {
+        use std::borrow::Cow;
+
+        let failing = sqlx::migrate::Migrator {
+            migrations: Cow::Owned(vec![
+                sqlx::migrate::Migration::new(
+                    1,
+                    Cow::Borrowed("create probe"),
+                    sqlx::migrate::MigrationType::Simple,
+                    sqlx::SqlStr::from_static("CREATE TABLE probe (id INTEGER);"),
+                    false,
+                ),
+                sqlx::migrate::Migration::new(
+                    2,
+                    Cow::Borrowed("collide with probe"),
+                    sqlx::migrate::MigrationType::Simple,
+                    sqlx::SqlStr::from_static("CREATE TABLE probe (id INTEGER);"),
+                    false,
+                ),
+            ]),
+            ..sqlx::migrate::Migrator::DEFAULT
+        };
+
+        let db = super::Database::in_memory().await.expect("in-memory connect");
+        let mut conn = db.pool().acquire().await.expect("acquire");
+
+        let error = failing.run(&mut *conn).await.expect_err("migration 2 must fail");
+        assert!(
+            matches!(error, sqlx::migrate::MigrateError::ExecuteMigration(_, 2)),
+            "a failing script must surface as ExecuteMigration: {error:?}"
+        );
+
+        let dirty_rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE success = FALSE")
+                .fetch_one(&mut *conn)
+                .await
+                .expect("count dirty rows");
+        assert_eq!(dirty_rows, 0, "a failed migration must record no bookkeeping row");
+
+        let rerun = failing.run(&mut *conn).await.expect_err("migration 2 must fail again");
+        assert!(
+            !matches!(rerun, sqlx::migrate::MigrateError::Dirty(_)),
+            "without a dirty row sqlx must not escalate to Dirty: {rerun:?}"
+        );
+        assert!(
+            super::migration_divergence_detail(&super::DbError::Migration(rerun)).is_none(),
+            "a failed script is not a divergent history"
         );
     }
 

--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -293,6 +293,14 @@ mod tests {
         }
     }
 
+    /// `MigrateError::Dirty` names a partially-applied migration, which sqlx
+    /// only produces on databases without transactional DDL. `sqlx-sqlite` runs
+    /// each migration script and its `_sqlx_migrations` bookkeeping in one
+    /// transaction, so a failing script rolls back and no `Dirty` state is
+    /// reachable here. A migration that opts out of the transaction would make
+    /// it reachable, and would need its own user-facing repair message rather
+    /// than the "written by a different revision" wording this classifier
+    /// produces.
     #[test]
     fn divergence_detail_ignores_unrelated_failures() {
         assert!(super::migration_divergence_detail(&super::DbError::NotImplemented).is_none());


### PR DESCRIPTION
## Summary

- Adds `a_failed_migration_records_no_row`, which pins what sqlx writes to `_sqlx_migrations` when a migration script fails.
- Adds `every_migration_runs_inside_a_transaction`, which asserts that no migration in the compiled-in set opts out of its per-migration transaction.
- Adds `backup_to_rejects_an_existing_destination_file`, covering the destination case the suite left open.
- Adjudicates a P0 chain finding: the pre-migration backup writes nothing, and a resulting partially-applied migration cannot be diagnosed. The chain is refuted and the guards make the refutation executable. One narrow diagnosis gap survives on its own bead.

## `MigrateError::Dirty` reachability

`MigrateError::Dirty` reports a `_sqlx_migrations` row with `success = false` (`sqlx-core-0.9.0/src/migrate/migrator.rs:248-251`, reading `sqlx-sqlite-0.9.0/src/migrate.rs:109-123`). This build never writes such a row: `execute_migration` inserts `success` as a `TRUE` literal and inserts nothing at all when the script fails (`sqlx-sqlite-0.9.0/src/migrate.rs:249-272`).

That is why `migration_divergence_detail` omits a `Dirty` arm. The invariant belongs to sqlx rather than to this crate, so an upgrade that starts recording failed migrations can break it while every other test passes. `a_failed_migration_records_no_row` builds a `Migrator` whose second migration collides with the first and asserts that sqlx reports the failure as `ExecuteMigration`, that it writes no `success = false` row, that a rerun declines to escalate to `Dirty`, and that `migration_divergence_detail` returns `None`.

## The transaction guard

A migration file starting with `-- no-transaction` sets `Migration::no_tx` (`sqlx-core-0.9.0/src/migrate/source.rs:234`) and sqlx then runs that script outside a transaction. A failure partway leaves the statements it already ran in place, and since a failed migration doesn't record a bookkeeping row, nothing marks the database as partially applied. Recovery depends entirely on the pre-migration backup.

The test reads the public `no_tx` flag through `Database::migrator()`, the same static that `migrate_uncached` runs, so it binds to the production migrator. Verified failing: prepending the marker to `0003_plans_destination_root.sql` turns it red and names version 3.

## VACUUM INTO ruling

Measured against a file-backed source database. `VACUUM INTO` fails rather than silently no-opping for every destination case:

| Destination | Result |
|---|---|
| Directory absent | code 14, `unable to open database` |
| Existing non-database file | code 26, `file is not a database`; the file keeps its bytes |
| Existing database | code 1, `output file already exists`; the earlier backup survives |
| In-memory source | statement reports success without writing the file; the post-condition rejects it |

Relying on the statement's error is sufficient for a file-backed source, and the post-condition at `crates/persistence/core/src/lib.rs:212-217` covers the one case where the statement misreports. `backup_to` begins at `:204`; `:243` is `migrator()`.

The claimed endpoint, whole-database loss with no recovery path, does not hold: a failed migration script rolls back and the schema stays unchanged.

## Filed separately

- astro-plan-00yw0 (P3): `migration_divergence_detail` returns `None` for a `Dirty` database written by another sqlx tool. The compiled-in migration set cannot constrain a foreign writer, so no test here enforces it away. It costs no data, because sqlx reads the dirty version before applying anything.
- astro-plan-d6glj (P3): `run_pre_migration_backup` demotes a backup failure to a warning and boot migrates anyway (`apps/desktop/src-tauri/src/lib.rs:523-530`, `:590-594`).

## Verification

- `cargo nextest run -p persistence_core`: exit 0, 56 of 56 passed
- `cargo clippy -p persistence_core --all-targets`: clean, exit 0
- `cargo fmt --all`: exit 0

Tracks-Bead: astro-plan-f8g21
Merge-Bead: astro-plan-b4ci9
