### PR TITLE
docs: align the Sessions requirements with the shipped automatic session model

### DIFF
--- a/specs/027-frontend-implementation/contracts/tauri-commands.md
+++ b/specs/027-frontend-implementation/contracts/tauri-commands.md
@@ -34,8 +34,8 @@ This document defines the command interface that the frontend depends on. The ac
 | Command | Args | Returns | Used By |
 |---------|------|---------|---------|
 | `sessions.transition` | `{ id, action, metadata? }` | `Result<Session>` | Review queue, detail |
-| `sessions.split` | `{ id, split_at_index }` | `Result<{ original: Session, new: Session }>` | Sessions toolbar bulk action |
-| `sessions.merge` | `{ ids }` | `Result<Session>` | Sessions toolbar bulk action |
+| `sessions.split` | `{ id, split_at_index }` | `Result<{ original: Session, new: Session }>` | none -- SUPERSEDED with FR-015 |
+| `sessions.merge` | `{ ids }` | `Result<Session>` | none -- SUPERSEDED with FR-015 |
 | `projects.create_plan` | `{ wizard_state }` | `FilesystemPlan` | Wizard step 6 |
 | `plans.approve` | `{ id, delete_acknowledged? }` | `Result<Plan>` | Plan review |
 | `plans.apply` | `{ id }` | `OperationHandle` | Plan review |
@@ -47,6 +47,11 @@ This document defines the command interface that the frontend depends on. The ac
 | `scan.start` | `{ root_ids? }` | `OperationHandle` | Setup, Data sources |
 | `preferences.set` | `{ key, value }` | `Result<void>` | Density, sidebar, views |
 | `tour.complete_step` | `{ step }` | `Result<void>` | Tour |
+
+`sessions.split` and `sessions.merge` are registered fixture stubs returning
+hardcoded sessions (spec 029 FR-005, T021). No frontend module invokes either
+one, so no product flow depends on their result shapes. Their removal is tracked
+outside this specification.
 
 ## Native API Commands (Tauri built-in)
 

--- a/specs/027-frontend-implementation/spec.md
+++ b/specs/027-frontend-implementation/spec.md
@@ -231,7 +231,31 @@ As a user tracking what happened in my library, I open the Audit log to see an i
 - **FR-012**: Sessions MUST support 4 group-by modes (target, month, filter, optical train) selectable via chip row above the table. Group-by changes only visual grouping, not the data.
 - **FR-013**: Sessions MUST support a Calendar view toggle showing 3 months of day cells with session cards. Clicking a day MUST filter the list to that night.
 - **FR-014**: Sessions MUST show that a session can be linked to multiple projects in the "Projects (re-used)" column.
-- **FR-015**: Sessions toolbar MUST provide bulk actions (Confirm, Split, Merge, Use in project) that operate on multi-selected rows (checkbox + Shift-click range select).
+- **FR-015** [SUPERSEDED by spec 041 FR-051 and spec 062]
+
+  RETIRED: the Sessions page does not offer bulk row actions, and its table does
+  not support multi-row selection. The session model replaces the four bulk
+  actions:
+
+  - Session membership is automatic. Applying a reviewable plan groups light
+    frames into a session keyed by capture identity: target, filter, binning,
+    gain, and observing night (spec 035 FR-016).
+  - A session is homogeneous under one capture identity, so it does not offer a
+    split point, and frames sharing a capture identity already occupy one
+    session. Mixed input is reviewed as multiple immutable session items
+    (spec 062).
+  - Sessions are derived, already-confirmed inventory (spec 041 FR-051), so no
+    Confirm action applies to a session row.
+  - A session reaches a project through the project-creation wizard's session
+    selection.
+
+  Panel and mosaic relations are proposed and accepted individually in the
+  Sessions detail surface (spec 062 FR-044). Those change logical group
+  identity, not session membership.
+
+  Original requirement, preserved for history: Sessions toolbar MUST provide
+  bulk actions (Confirm, Split, Merge, Use in project) that operate on
+  multi-selected rows (checkbox + Shift-click range select).
 
 **Session Detail**
 

--- a/specs/027-frontend-implementation/spec.md
+++ b/specs/027-frontend-implementation/spec.md
@@ -249,9 +249,11 @@ As a user tracking what happened in my library, I open the Audit log to see an i
   - A session reaches a project through the project-creation wizard's session
     selection.
 
-  Panel and mosaic relations are proposed and accepted individually in the
-  Sessions detail surface (spec 062 FR-044). Those change logical group
-  identity, not session membership.
+  Panel and mosaic split, merge, and identity change belong to logical group
+  identity, not session membership. Spec 062 FR-044 requires each such change to
+  create a new group identity linked to a retired predecessor. Spec 062 US2
+  specifies the surface for those changes; its Tauri commands have no backend
+  handlers, tracked by bead astro-plan-ic9h.20.
 
   Original requirement, preserved for history: Sessions toolbar MUST provide
   bulk actions (Confirm, Split, Merge, Use in project) that operate on


### PR DESCRIPTION
## Summary

- The Sessions requirements asked for a toolbar with bulk Confirm, Split, Merge,
  and Use-in-project actions over multi-selected rows. The product has none of
  them, and the requirement blocked the all-specs-implemented release gate.
- That requirement is marked superseded and now states the shipped session
  model. No product behaviour changed in this PR.

## What the product does

- `crates/app/targets/src/ingest_sessions.rs:1-30` folds each applied light
  frame into an `acquisition_session` keyed by target, filter, binning, gain,
  and observing night. Session membership is automatic.
- `apps/desktop/src/features/sessions/SessionsPage.tsx:14-30` documents a
  toolbar of search plus a group-by control. The Sessions feature has no row
  checkbox and no range select.
- `apps/desktop/src-tauri/src/commands/sessions.rs:128-170` holds
  `sessions.split` and `sessions.merge` as fixture stubs returning hardcoded
  counts. No frontend module invokes either.

## Spec Context

- `specs/027-frontend-implementation/spec.md` FR-015 keeps its id and its
  original text, marked SUPERSEDED by spec 041 FR-051 and spec 062, following
  the retirement style spec 041 uses for US5. The note records four properties
  of the session model: automatic capture-identity keying (spec 035 FR-016), one
  homogeneous capture identity per session so there is no split point, derived
  already-confirmed inventory so no Confirm applies (spec 041 FR-051), and
  project attachment through the project-creation wizard.
- The note also places panel and mosaic split, merge, and identity change on
  logical group identity rather than session membership (spec 062 FR-044). Spec
  062 US2 specifies the surface for those changes; its Tauri commands have no
  backend handlers, tracked by bead astro-plan-ic9h.20.
- The spec 027 command contract marks both commands as superseded with no caller
  and records their spec 029 T021 stub origin.
- Task T038 of spec 027 still describes the bulk toolbar. Its file is read-only
  legacy under the beads workspace guard, and no task bead asserts the behaviour.
- Follow-ups: `astro-plan-i09vh` removes the dead stubs, bindings, mocks, and
  stub tests. `astro-plan-6lt63` covers FR-017 and FR-020 to FR-024, which still
  describe the removed session review lifecycle.
- Merge bead `astro-plan-2qzxj`. Work bead `astro-plan-ci707`.
