### PR TITLE
fix: total orders for separation comparators, manifest paging cursor, lease expiry, and rule tie-break

### DIFF
--- a/crates/app/inbox/src/cone_search.rs
+++ b/crates/app/inbox/src/cone_search.rs
@@ -333,9 +333,7 @@ pub async fn suggest(
     }
     // Display order stays nearest-first (FR-013) — `select_for_display` only
     // decided which candidates survive, not their order.
-    suggestions.sort_by(|a, b| {
-        a.separation_deg.partial_cmp(&b.separation_deg).unwrap_or(std::cmp::Ordering::Equal)
-    });
+    suggestions.sort_by(|a, b| a.separation_deg.total_cmp(&b.separation_deg));
 
     Ok(ConeSearchSuggestResponse {
         pointing: ConeSearchPointing {
@@ -384,14 +382,10 @@ fn in_field_indices(
 fn primary_index(candidates: &[ConeCandidate], in_field: &[usize]) -> Option<usize> {
     in_field.iter().copied().filter(|&i| !is_default_excluded(&candidates[i].identity)).min_by(
         |&a, &b| {
-            candidates[a]
-                .separation_deg
-                .partial_cmp(&candidates[b].separation_deg)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| {
-                    prominence_tier(&candidates[b].identity)
-                        .cmp(&prominence_tier(&candidates[a].identity))
-                })
+            candidates[a].separation_deg.total_cmp(&candidates[b].separation_deg).then_with(|| {
+                prominence_tier(&candidates[b].identity)
+                    .cmp(&prominence_tier(&candidates[a].identity))
+            })
         },
     )
 }
@@ -753,6 +747,26 @@ mod tests {
         ];
         let primary = primary_index(&candidates, &[0, 1]);
         assert_eq!(primary, Some(1), "NGC-tier must win the separation tie over niche");
+    }
+
+    #[test]
+    fn nan_separation_never_wins_the_primary_pick_or_depends_on_input_order() {
+        // `separation_deg` is copied straight off the resolver response and is
+        // never finiteness-checked, so a NaN reaches `primary_index`. Under a
+        // `partial_cmp(..).unwrap_or(Equal)` comparator every pair compares
+        // equal and `min_by` returns whichever candidate came first.
+        // Both candidates share a prominence tier, so the separation
+        // comparator is the only thing that can decide the pick.
+        let candidates = vec![
+            cone_candidate("NGC 1", simbad_resolver::ObjectType::Galaxy, "G", f64::NAN),
+            cone_candidate("NGC 2", simbad_resolver::ObjectType::Galaxy, "G", 0.5),
+        ];
+        assert_eq!(primary_index(&candidates, &[0, 1]), Some(1));
+        assert_eq!(
+            primary_index(&candidates, &[1, 0]),
+            Some(1),
+            "the finite-separation candidate must win regardless of input order"
+        );
     }
 
     #[test]

--- a/crates/app/inbox/src/cone_search.rs
+++ b/crates/app/inbox/src/cone_search.rs
@@ -32,7 +32,8 @@ use target_match::skymath as tm_skymath;
 use target_match::{rank, Constraint, SkyObject};
 use targeting::coords;
 use targeting_resolver::cone_search::{
-    dedup_candidates, is_default_excluded, prominence_tier, select_for_display, ConeCandidate,
+    dedup_candidates, is_default_excluded, prominence_tier, select_for_display, separation_order,
+    ConeCandidate,
 };
 use targeting_resolver::simbad::SimbadResolver;
 
@@ -333,7 +334,7 @@ pub async fn suggest(
     }
     // Display order stays nearest-first (FR-013) — `select_for_display` only
     // decided which candidates survive, not their order.
-    suggestions.sort_by(|a, b| a.separation_deg.total_cmp(&b.separation_deg));
+    suggestions.sort_by(|a, b| separation_order(a.separation_deg, b.separation_deg));
 
     Ok(ConeSearchSuggestResponse {
         pointing: ConeSearchPointing {
@@ -382,10 +383,12 @@ fn in_field_indices(
 fn primary_index(candidates: &[ConeCandidate], in_field: &[usize]) -> Option<usize> {
     in_field.iter().copied().filter(|&i| !is_default_excluded(&candidates[i].identity)).min_by(
         |&a, &b| {
-            candidates[a].separation_deg.total_cmp(&candidates[b].separation_deg).then_with(|| {
-                prominence_tier(&candidates[b].identity)
-                    .cmp(&prominence_tier(&candidates[a].identity))
-            })
+            separation_order(candidates[a].separation_deg, candidates[b].separation_deg).then_with(
+                || {
+                    prominence_tier(&candidates[b].identity)
+                        .cmp(&prominence_tier(&candidates[a].identity))
+                },
+            )
         },
     )
 }
@@ -767,6 +770,15 @@ mod tests {
             Some(1),
             "the finite-separation candidate must win regardless of input order"
         );
+
+        // A sign-NEGATIVE NaN is what x86-64 produces for an invalid operation,
+        // and `total_cmp` alone sorts it below -inf.
+        let negative_nan = vec![
+            cone_candidate("NGC 1", simbad_resolver::ObjectType::Galaxy, "G", -f64::NAN),
+            cone_candidate("NGC 2", simbad_resolver::ObjectType::Galaxy, "G", 0.5),
+        ];
+        assert_eq!(primary_index(&negative_nan, &[0, 1]), Some(1));
+        assert_eq!(primary_index(&negative_nan, &[1, 0]), Some(1));
     }
 
     #[test]

--- a/crates/domain/core/src/project/channel_map.rs
+++ b/crates/domain/core/src/project/channel_map.rs
@@ -56,7 +56,14 @@ pub struct ChannelIntegration {
 
 impl ChannelIntegration {
     /// Add one frame's exposure to the running totals.
+    ///
+    /// A non-finite exposure is skipped entirely, frame included: `max(0.0)`
+    /// neither filters `NaN` reliably nor filters `+inf` at all, and one such
+    /// frame would poison the channel total permanently.
     fn accumulate(&mut self, exposure_s: f64) {
+        if !exposure_s.is_finite() {
+            return;
+        }
         self.frame_count += 1;
         self.total_exposure_s += exposure_s.max(0.0);
     }
@@ -187,6 +194,18 @@ mod tests {
         let ha = m.get("Ha").unwrap();
         assert_eq!(ha.frame_count, 3);
         assert!((ha.total_exposure_s - 900.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn non_finite_exposures_are_skipped_and_not_counted() {
+        let frames = vec![
+            ChannelFrame::new("Ha", 300.0),
+            ChannelFrame::new("Ha", f64::NAN),
+            ChannelFrame::new("Ha", f64::INFINITY),
+        ];
+        let ha = ChannelMap::from_frames(&frames).get("Ha").unwrap().clone();
+        assert_eq!(ha.frame_count, 1);
+        assert!((ha.total_exposure_s - 300.0).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/domain/core/src/project/channel_map.rs
+++ b/crates/domain/core/src/project/channel_map.rs
@@ -30,8 +30,9 @@ pub struct ChannelFrame {
     /// An empty or whitespace-only label is treated as an unfiltered / unknown
     /// channel and keyed as `""` to preserve the frame count.
     pub label: String,
-    /// Integration time for this frame in seconds. Must be ≥ 0.0; negative
-    /// values are clamped to 0.0 on insertion.
+    /// Integration time for this frame in seconds. Must be ≥ 0.0 and finite;
+    /// negative and non-finite values contribute 0.0 on insertion, and the
+    /// frame is still counted.
     pub exposure_s: f64,
 }
 
@@ -57,15 +58,14 @@ pub struct ChannelIntegration {
 impl ChannelIntegration {
     /// Add one frame's exposure to the running totals.
     ///
-    /// A non-finite exposure is skipped entirely, frame included: `max(0.0)`
-    /// neither filters `NaN` reliably nor filters `+inf` at all, and one such
-    /// frame would poison the channel total permanently.
+    /// A non-finite exposure contributes 0.0 and the frame is still counted:
+    /// `max(0.0)` neither filters `NaN` reliably nor filters `+inf` at all, so
+    /// one such frame would otherwise poison the channel total permanently.
     fn accumulate(&mut self, exposure_s: f64) {
-        if !exposure_s.is_finite() {
-            return;
-        }
         self.frame_count += 1;
-        self.total_exposure_s += exposure_s.max(0.0);
+        if exposure_s.is_finite() {
+            self.total_exposure_s += exposure_s.max(0.0);
+        }
     }
 }
 
@@ -197,14 +197,14 @@ mod tests {
     }
 
     #[test]
-    fn non_finite_exposures_are_skipped_and_not_counted() {
+    fn non_finite_exposures_contribute_zero_but_stay_counted() {
         let frames = vec![
             ChannelFrame::new("Ha", 300.0),
             ChannelFrame::new("Ha", f64::NAN),
             ChannelFrame::new("Ha", f64::INFINITY),
         ];
         let ha = ChannelMap::from_frames(&frames).get("Ha").unwrap().clone();
-        assert_eq!(ha.frame_count, 1);
+        assert_eq!(ha.frame_count, 3, "an unreadable exposure header must not lose the frame");
         assert!((ha.total_exposure_s - 300.0).abs() < 1e-9);
     }
 

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
@@ -384,7 +384,7 @@ impl CommandLedger {
                 ClaimOutcome::PayloadMismatch
             } else if let Some(terminal) = row.terminal() {
                 ClaimOutcome::Replayed(terminal)
-            } else if row.lease_expires_at.as_deref().is_some_and(|expiry| expiry > now) {
+            } else if lease_is_active(row.lease_expires_at.as_deref(), now) {
                 ClaimOutcome::InProgress {
                     command_id: request.command_id.clone(),
                     operation: request.operation.clone(),
@@ -800,7 +800,7 @@ fn validate_lease_preconditions(row: &CommandRow, lease: &CommandLease, now: &st
     {
         return Err(CommandLedgerError::StaleFence);
     }
-    if row.lease_expires_at.as_deref().is_none_or(|expiry| expiry <= now) {
+    if !lease_is_active(row.lease_expires_at.as_deref(), now) {
         return Err(CommandLedgerError::LeaseExpired);
     }
     Ok(())
@@ -1092,6 +1092,23 @@ fn bounded_safe_string(value: &str) -> Result<String> {
     Ok(value.to_owned())
 }
 
+/// Whether a stored lease expiry is still in the future.
+///
+/// Both sides are parsed rather than compared as strings: [`add_ttl`] preserves
+/// the caller's UTC offset and subsecond digit count, so two equally valid
+/// RFC-3339 renderings of the same instant sort wrongly against each other. An
+/// unparseable stored expiry counts as ACTIVE so a live lease can never be
+/// stolen.
+fn lease_is_active(expiry: Option<&str>, now: &str) -> bool {
+    let Some(expiry) = expiry else { return false };
+    let (Ok(expiry), Ok(now)) =
+        (OffsetDateTime::parse(expiry, &Rfc3339), OffsetDateTime::parse(now, &Rfc3339))
+    else {
+        return true;
+    };
+    expiry > now
+}
+
 fn add_ttl(now: &str, ttl: Duration) -> Result<String> {
     let parsed = OffsetDateTime::parse(now, &Rfc3339)
         .map_err(|_| CommandLedgerError::InvalidInput("timestamp is not RFC3339".to_owned()))?;
@@ -1115,6 +1132,32 @@ mod tests {
     use serde_json::json;
     use tokio::sync::Barrier;
     use uuid::Uuid;
+
+    #[test]
+    fn lease_activity_ignores_rfc3339_rendering_differences() {
+        let now = "2026-01-01T10:00:00Z";
+
+        // Same instant as `now`, three legal renderings: none is still active.
+        assert!(!lease_is_active(Some("2026-01-01T10:00:00Z"), now));
+        assert!(!lease_is_active(Some("2026-01-01T12:00:00+02:00"), now));
+        assert!(!lease_is_active(Some("2026-01-01T10:00:00.000000Z"), now));
+
+        // Both expiries are one second past `now`, so both leases are live,
+        // yet both sort BELOW `now` as strings — a string comparison steals
+        // them.
+        let negative_offset = "2026-01-01T05:00:01-05:00";
+        let subsecond = "2026-01-01T10:00:00.5Z";
+        assert!(negative_offset < now);
+        assert!(subsecond < now);
+        assert!(lease_is_active(Some(negative_offset), now));
+        assert!(lease_is_active(Some(subsecond), now));
+    }
+
+    #[test]
+    fn an_unparseable_stored_expiry_counts_as_active() {
+        assert!(lease_is_active(Some("not-a-timestamp"), "2026-01-01T12:00:00Z"));
+        assert!(!lease_is_active(None, "2026-01-01T12:00:00Z"));
+    }
 
     async fn database() -> Database {
         let db = Database::in_memory().await.unwrap();

--- a/crates/persistence/plans/src/repositories/manifests.rs
+++ b/crates/persistence/plans/src/repositories/manifests.rs
@@ -66,16 +66,35 @@ pub async fn insert_manifest(pool: &SqlitePool, data: InsertManifest<'_>) -> DbR
     Ok(data.id.to_owned())
 }
 
+/// Separator between the two cursor components. An RFC-3339 timestamp cannot
+/// contain it, so a left-anchored split recovers the timestamp even when the id
+/// does.
+const CURSOR_SEP: char = '|';
+
+fn encode_cursor(timestamp: &str, id: &str) -> String {
+    format!("{timestamp}{CURSOR_SEP}{id}")
+}
+
+fn decode_cursor(cursor: &str) -> DbResult<(&str, &str)> {
+    match cursor.split_once(CURSOR_SEP) {
+        Some((ts, id)) if !ts.is_empty() && !id.is_empty() => Ok((ts, id)),
+        _ => Err(DbError::NotFound(format!("malformed manifest list cursor: {cursor}"))),
+    }
+}
+
 /// List manifests for a project, newest first, with cursor-based pagination.
 ///
-/// `cursor` is an opaque string (RFC-3339 timestamp of the last seen row).
-/// `limit` is clamped to 200.
+/// `cursor` is an opaque string carrying the whole sort key of the last seen
+/// row (`timestamp` and `id`), so rows sharing a timestamp are not skipped at a
+/// page boundary. `limit` is clamped to 200.
 ///
 /// Returns `(rows, next_cursor)` where `next_cursor` is `Some` when more
 /// results exist beyond the returned page.
 ///
 /// # Errors
-/// Returns `persistence_core::DbError::Database` on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure, and
+/// `persistence_core::DbError::NotFound` for a cursor this module did not
+/// produce.
 pub async fn list_manifests_for_project(
     pool: &SqlitePool,
     project_id: &str,
@@ -102,18 +121,22 @@ pub async fn list_manifests_for_project(
             .fetch_all(pool)
             .await?
         }
-        Some(after_ts) => {
+        Some(cursor) => {
+            let (after_ts, after_id) = decode_cursor(cursor)?;
             sqlx::query_as(
                 "\
                 SELECT id, project_id, reason, timestamp, path, version, body_json
                 FROM manifests
-                WHERE project_id = ? AND timestamp < ?
+                WHERE project_id = ?
+                  AND (timestamp < ? OR (timestamp = ? AND id < ?))
                 ORDER BY timestamp DESC, id DESC
                 LIMIT ?
                 ",
             )
             .bind(project_id)
             .bind(after_ts)
+            .bind(after_ts)
+            .bind(after_id)
             .bind(fetch_limit)
             .fetch_all(pool)
             .await?
@@ -125,7 +148,7 @@ pub async fn list_manifests_for_project(
     let limit_usize = limit as usize;
     if rows.len() > limit_usize {
         let page: Vec<ManifestRow> = rows.into_iter().take(limit_usize).collect();
-        let next_cursor = page.last().map(|r| r.timestamp.clone());
+        let next_cursor = page.last().map(|r| encode_cursor(&r.timestamp, &r.id));
         Ok((page, next_cursor))
     } else {
         Ok((rows, None))
@@ -228,5 +251,47 @@ mod tests {
             list_manifests_for_project(&pool, "proj-pag", cursor.as_deref(), 2).await.unwrap();
         assert_eq!(page2.len(), 1);
         assert!(cursor2.is_none(), "no more pages");
+    }
+
+    #[tokio::test]
+    async fn list_manifests_pagination_keeps_rows_sharing_one_timestamp() {
+        let pool = setup().await;
+        insert_project(&pool, "proj-tie").await;
+
+        for i in 0u32..3 {
+            sqlx::query(
+                "INSERT INTO manifests (id, project_id, reason, timestamp, path, version, body_json)
+                 VALUES (?,?,?,?,?,?,?)",
+            )
+            .bind(format!("m-{i:04}"))
+            .bind("proj-tie")
+            .bind("created")
+            .bind("2026-01-01T00:00:00Z")
+            .bind(format!("notes/m-{i}.md"))
+            .bind(1i64)
+            .bind("{}")
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let (page1, cursor) = list_manifests_for_project(&pool, "proj-tie", None, 2).await.unwrap();
+        let (page2, _) =
+            list_manifests_for_project(&pool, "proj-tie", cursor.as_deref(), 2).await.unwrap();
+
+        let mut seen: Vec<String> =
+            page1.iter().chain(page2.iter()).map(|r| r.id.clone()).collect();
+        seen.sort();
+        assert_eq!(seen, vec!["m-0000", "m-0001", "m-0002"]);
+    }
+
+    #[tokio::test]
+    async fn list_manifests_rejects_a_cursor_it_did_not_produce() {
+        let pool = setup().await;
+        insert_project(&pool, "proj-bad").await;
+        let err = list_manifests_for_project(&pool, "proj-bad", Some("2026-01-01T00:00:00Z"), 2)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DbError::NotFound(_)));
     }
 }

--- a/crates/sessions/src/clustering.rs
+++ b/crates/sessions/src/clustering.rs
@@ -148,6 +148,9 @@ pub enum UnassignedReason {
     MissingOpticTrain,
     MissingPointing,
     MissingRotation,
+    /// Geometry is present but a component is not finite, so it cannot take
+    /// part in a tolerance comparison.
+    UnusableGeometry,
 }
 
 /// The clustering outcome for one session.
@@ -252,6 +255,17 @@ type ClusterableSession = (EntityId, Pointing, f32, Option<f64>);
 /// used to seed an existing framing's accumulator from its declared
 /// `member_session_ids`' *actual* geometry (never from input-order luck).
 type SessionGeom = (Pointing, f32, Option<f64>);
+/// Whether every geometry component can take part in a tolerance comparison.
+///
+/// A comparison against `NaN` is false, so an ungated non-finite component
+/// passes the envelope check and propagates into the representative rotation.
+fn geometry_is_finite(pointing: &Pointing, rotation_deg: f32, fov: Option<f64>) -> bool {
+    pointing.ra_deg.is_finite()
+        && pointing.dec_deg.is_finite()
+        && rotation_deg.is_finite()
+        && fov.is_none_or(f64::is_finite)
+}
+
 type SplitResult = (
     BTreeMap<EntityId, Assignment>,
     BTreeMap<(EntityId, String), Vec<ClusterableSession>>,
@@ -267,17 +281,6 @@ type SplitResult = (
 /// ones, so `cluster_partition` can seed existing framings' representatives
 /// from their real members (rather than leaving them unseeded, or double-
 /// counting a member that also appears in the clusterable set).
-/// Whether every geometry component can take part in a tolerance comparison.
-///
-/// A comparison against `NaN` is false, so an ungated non-finite component
-/// passes the envelope check and propagates into the representative rotation.
-fn geometry_is_finite(pointing: &Pointing, rotation_deg: f32, fov: Option<f64>) -> bool {
-    pointing.ra_deg.is_finite()
-        && pointing.dec_deg.is_finite()
-        && rotation_deg.is_finite()
-        && fov.is_none_or(f64::is_finite)
-}
-
 fn split_known_members_and_null_geometry(
     sessions: &[SessionGeometry],
     member_framing_of: &BTreeMap<EntityId, EntityId>,
@@ -329,17 +332,10 @@ fn split_known_members_and_null_geometry(
             );
             continue;
         };
-        if !pointing.ra_deg.is_finite() || !pointing.dec_deg.is_finite() {
+        if !geometry_is_finite(&pointing, rotation_deg, session.fov_diagonal_deg) {
             resolved.insert(
                 session.session_id,
-                Assignment::Unassigned(UnassignedReason::MissingPointing),
-            );
-            continue;
-        }
-        if !rotation_deg.is_finite() || session.fov_diagonal_deg.is_some_and(|f| !f.is_finite()) {
-            resolved.insert(
-                session.session_id,
-                Assignment::Unassigned(UnassignedReason::MissingRotation),
+                Assignment::Unassigned(UnassignedReason::UnusableGeometry),
             );
             continue;
         }
@@ -683,18 +679,12 @@ mod tests {
         let result = derive_clustering(&sessions, &[], &params());
 
         assert!(result.new_framings.is_empty());
-        assert!(matches!(
-            assignment_for(&result, 1),
-            Assignment::Unassigned(UnassignedReason::MissingPointing)
-        ));
-        assert!(matches!(
-            assignment_for(&result, 2),
-            Assignment::Unassigned(UnassignedReason::MissingRotation)
-        ));
-        assert!(matches!(
-            assignment_for(&result, 3),
-            Assignment::Unassigned(UnassignedReason::MissingRotation)
-        ));
+        for session in 1..=3 {
+            assert!(matches!(
+                assignment_for(&result, session),
+                Assignment::Unassigned(UnassignedReason::UnusableGeometry)
+            ));
+        }
     }
 
     // ── multi-night/multi-filter collapse ───────────────────────────────────

--- a/crates/sessions/src/clustering.rs
+++ b/crates/sessions/src/clustering.rs
@@ -267,6 +267,17 @@ type SplitResult = (
 /// ones, so `cluster_partition` can seed existing framings' representatives
 /// from their real members (rather than leaving them unseeded, or double-
 /// counting a member that also appears in the clusterable set).
+/// Whether every geometry component can take part in a tolerance comparison.
+///
+/// A comparison against `NaN` is false, so an ungated non-finite component
+/// passes the envelope check and propagates into the representative rotation.
+fn geometry_is_finite(pointing: &Pointing, rotation_deg: f32, fov: Option<f64>) -> bool {
+    pointing.ra_deg.is_finite()
+        && pointing.dec_deg.is_finite()
+        && rotation_deg.is_finite()
+        && fov.is_none_or(f64::is_finite)
+}
+
 fn split_known_members_and_null_geometry(
     sessions: &[SessionGeometry],
     member_framing_of: &BTreeMap<EntityId, EntityId>,
@@ -277,7 +288,10 @@ fn split_known_members_and_null_geometry(
 
     for session in sessions {
         if let (Some(pointing), Some(rotation_deg)) = (session.pointing, session.rotation_deg) {
-            if session.target_id.is_some() && session.optic_train_key.is_some() {
+            if geometry_is_finite(&pointing, rotation_deg, session.fov_diagonal_deg)
+                && session.target_id.is_some()
+                && session.optic_train_key.is_some()
+            {
                 geometry_by_id
                     .insert(session.session_id, (pointing, rotation_deg, session.fov_diagonal_deg));
             }
@@ -315,6 +329,20 @@ fn split_known_members_and_null_geometry(
             );
             continue;
         };
+        if !pointing.ra_deg.is_finite() || !pointing.dec_deg.is_finite() {
+            resolved.insert(
+                session.session_id,
+                Assignment::Unassigned(UnassignedReason::MissingPointing),
+            );
+            continue;
+        }
+        if !rotation_deg.is_finite() || session.fov_diagonal_deg.is_some_and(|f| !f.is_finite()) {
+            resolved.insert(
+                session.session_id,
+                Assignment::Unassigned(UnassignedReason::MissingRotation),
+            );
+            continue;
+        }
         clusterable.push((
             session.session_id,
             target_id,
@@ -641,6 +669,32 @@ mod tests {
 
     fn assignment_for(result: &ClusteringResult, byte: u8) -> &Assignment {
         &result.assignments.iter().find(|(sid, _)| *sid == id(byte)).expect("session present").1
+    }
+
+    #[test]
+    fn non_finite_geometry_is_unassigned_rather_than_clustered() {
+        // Every tolerance comparison against NaN is false, so an ungated NaN
+        // passes the envelope check and reaches the representative rotation.
+        let sessions = vec![
+            geom(1, 10, "scope-a|cam-a", f64::NAN, 20.0, 0.0, Some(2.0)),
+            geom(2, 10, "scope-a|cam-a", 100.0, 20.0, f32::NAN, Some(2.0)),
+            geom(3, 10, "scope-a|cam-a", 100.0, 20.0, 0.0, Some(f64::INFINITY)),
+        ];
+        let result = derive_clustering(&sessions, &[], &params());
+
+        assert!(result.new_framings.is_empty());
+        assert!(matches!(
+            assignment_for(&result, 1),
+            Assignment::Unassigned(UnassignedReason::MissingPointing)
+        ));
+        assert!(matches!(
+            assignment_for(&result, 2),
+            Assignment::Unassigned(UnassignedReason::MissingRotation)
+        ));
+        assert!(matches!(
+            assignment_for(&result, 3),
+            Assignment::Unassigned(UnassignedReason::MissingRotation)
+        ));
     }
 
     // ── multi-night/multi-filter collapse ───────────────────────────────────

--- a/crates/targeting/resolver/src/cone_search.rs
+++ b/crates/targeting/resolver/src/cone_search.rs
@@ -25,6 +25,17 @@ pub struct ConeCandidate {
     pub separation_deg: f64,
 }
 
+/// Total, nearest-first order on angular separation that keeps every
+/// non-finite value LAST.
+///
+/// `f64::total_cmp` alone orders NaN by its sign bit, and the x86-64
+/// invalid-operation QNaN is sign-negative, so a bare `total_cmp` sorts that
+/// NaN below `-inf` and hands it a nearest-to-centre pick.
+#[must_use]
+pub fn separation_order(a: f64, b: f64) -> std::cmp::Ordering {
+    (!a.is_finite()).cmp(&!b.is_finite()).then_with(|| a.total_cmp(&b))
+}
+
 /// Catalogue-prominence tier (OQ-1). Declared low → high so `derive(Ord)`'s
 /// declaration-order comparison matches "more prominent wins": `Messier`/
 /// common-name outranks `Ngc`, which outranks `Ic`, then the Sharpless/
@@ -153,7 +164,7 @@ pub fn dedup_candidates(candidates: Vec<ConeCandidate>) -> Vec<ConeCandidate> {
                 .min_by(|a, b| {
                     prominence_tier(&b.identity)
                         .cmp(&prominence_tier(&a.identity))
-                        .then_with(|| a.separation_deg.total_cmp(&b.separation_deg))
+                        .then_with(|| separation_order(a.separation_deg, b.separation_deg))
                 })
                 .expect("groups are never empty")
         })
@@ -198,9 +209,9 @@ pub fn select_for_display(
         (is_default_excluded(identity), std::cmp::Reverse(prominence_tier(identity)))
     };
     ranked.sort_by(|&a, &b| {
-        rank_key(a)
-            .cmp(&rank_key(b))
-            .then_with(|| candidates[a].separation_deg.total_cmp(&candidates[b].separation_deg))
+        rank_key(a).cmp(&rank_key(b)).then_with(|| {
+            separation_order(candidates[a].separation_deg, candidates[b].separation_deg)
+        })
     });
     if ranked.len() > limit {
         if let Some(pos) = primary.and_then(|p| ranked.iter().position(|&i| i == p)) {
@@ -381,6 +392,20 @@ mod tests {
         assert_eq!(out.len(), 2);
     }
 
+    #[test]
+    fn separation_order_puts_both_nan_signs_last() {
+        use std::cmp::Ordering;
+        // Every non-finite value sorts after every finite one, whatever its
+        // sign bit. `-inf` is itself non-finite, so it is on the same side.
+        for unusable in [f64::NAN, -f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert_eq!(separation_order(unusable, 0.5), Ordering::Greater);
+            assert_eq!(separation_order(unusable, -0.5), Ordering::Greater);
+            assert_eq!(separation_order(0.5, unusable), Ordering::Less);
+        }
+        assert_eq!(separation_order(0.1, 0.2), Ordering::Less);
+        assert_eq!(separation_order(0.2, 0.2), Ordering::Equal);
+    }
+
     // ── select_for_display (#698) ─────────────────────────────────────────────
 
     // Every niche entry sits nearer to centre than the galaxy (0.000_833).
@@ -454,7 +479,13 @@ mod tests {
                 "HII",
                 &[&designation],
             );
-            let sep = if n % 3 == 0 { f64::NAN } else { f64::from(n) * 0.0001 };
+            // Both NaN signs: x86-64 produces a sign-negative QNaN for an
+            // invalid operation, and `total_cmp` alone sorts that below -inf.
+            let sep = match n % 4 {
+                0 => f64::NAN,
+                1 => -f64::NAN,
+                _ => f64::from(n) * 0.0001,
+            };
             candidates.push(candidate(niche, sep));
         }
 
@@ -483,7 +514,7 @@ mod tests {
         let with_nan_first = vec![
             candidate(
                 identity(Some(1), designation, None, ObjectType::Galaxy, "G", &[designation]),
-                f64::NAN,
+                -f64::NAN,
             ),
             candidate(
                 identity(Some(1), designation, None, ObjectType::Galaxy, "G", &[designation]),
@@ -498,10 +529,9 @@ mod tests {
 
         assert_eq!(first.len(), 1);
         assert_eq!(last.len(), 1);
-        assert_eq!(
-            first[0].separation_deg.is_nan(),
-            last[0].separation_deg.is_nan(),
-            "group collapse must not depend on where the NaN sat in the input"
+        assert!(
+            !first[0].separation_deg.is_nan() && !last[0].separation_deg.is_nan(),
+            "the finite-separation candidate must represent the group in both input orders"
         );
     }
 

--- a/crates/targeting/resolver/src/cone_search.rs
+++ b/crates/targeting/resolver/src/cone_search.rs
@@ -151,13 +151,9 @@ pub fn dedup_candidates(candidates: Vec<ConeCandidate>) -> Vec<ConeCandidate> {
         .map(|g| {
             g.into_iter()
                 .min_by(|a, b| {
-                    prominence_tier(&b.identity).cmp(&prominence_tier(&a.identity)).then_with(
-                        || {
-                            a.separation_deg
-                                .partial_cmp(&b.separation_deg)
-                                .unwrap_or(std::cmp::Ordering::Equal)
-                        },
-                    )
+                    prominence_tier(&b.identity)
+                        .cmp(&prominence_tier(&a.identity))
+                        .then_with(|| a.separation_deg.total_cmp(&b.separation_deg))
                 })
                 .expect("groups are never empty")
         })
@@ -202,12 +198,9 @@ pub fn select_for_display(
         (is_default_excluded(identity), std::cmp::Reverse(prominence_tier(identity)))
     };
     ranked.sort_by(|&a, &b| {
-        rank_key(a).cmp(&rank_key(b)).then_with(|| {
-            candidates[a]
-                .separation_deg
-                .partial_cmp(&candidates[b].separation_deg)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
+        rank_key(a)
+            .cmp(&rank_key(b))
+            .then_with(|| candidates[a].separation_deg.total_cmp(&candidates[b].separation_deg))
     });
     if ranked.len() > limit {
         if let Some(pos) = primary.and_then(|p| ranked.iter().position(|&i| i == p)) {
@@ -439,6 +432,76 @@ mod tests {
         assert!(
             selected.contains(&0),
             "the Messier-catalogued galaxy must survive the response-limit cut"
+        );
+    }
+
+    #[test]
+    fn nan_separation_neither_panics_nor_reorders_by_input_order() {
+        // `slice::sort_by` has an unconditional total-order detector, so a
+        // `partial_cmp(..).unwrap_or(Equal)` tie-break panics here rather than
+        // merely misordering. The candidate count is above the insertion-sort
+        // threshold so the detector actually runs.
+        let galaxy =
+            identity(Some(1), "M 51", None, ObjectType::Galaxy, "Sy2", &["M 51", "NGC 5194"]);
+        let mut candidates = vec![candidate(galaxy, 0.000_833)];
+        for n in 0..24 {
+            let designation = format!("[HL2008] {n}");
+            let niche = identity(
+                Some(100 + i64::from(n)),
+                &designation,
+                None,
+                ObjectType::EmissionNebula,
+                "HII",
+                &[&designation],
+            );
+            let sep = if n % 3 == 0 { f64::NAN } else { f64::from(n) * 0.0001 };
+            candidates.push(candidate(niche, sep));
+        }
+
+        let ascending: Vec<usize> = (0..candidates.len()).collect();
+        let descending: Vec<usize> = ascending.iter().rev().copied().collect();
+
+        let from_ascending = select_for_display(&candidates, &ascending, Some(0), 8);
+        let from_descending = select_for_display(&candidates, &descending, Some(0), 8);
+
+        assert!(
+            from_ascending.contains(&0),
+            "the Messier-catalogued galaxy must survive alongside NaN separations"
+        );
+        assert_eq!(
+            from_ascending, from_descending,
+            "selection must not depend on the order candidates arrived in"
+        );
+    }
+
+    #[test]
+    fn nan_separation_does_not_collapse_a_dedup_group_by_input_order() {
+        // `dedup_candidates` collapses each group with `min_by`, which does not
+        // panic but does return the first element when the comparator claims
+        // every pair is equal.
+        let designation = "NGC 5194";
+        let with_nan_first = vec![
+            candidate(
+                identity(Some(1), designation, None, ObjectType::Galaxy, "G", &[designation]),
+                f64::NAN,
+            ),
+            candidate(
+                identity(Some(1), designation, None, ObjectType::Galaxy, "G", &[designation]),
+                0.5,
+            ),
+        ];
+        let mut with_nan_last = with_nan_first.clone();
+        with_nan_last.reverse();
+
+        let first = dedup_candidates(with_nan_first);
+        let last = dedup_candidates(with_nan_last);
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(last.len(), 1);
+        assert_eq!(
+            first[0].separation_deg.is_nan(),
+            last[0].separation_deg.is_nan(),
+            "group collapse must not depend on where the NaN sat in the input"
         );
     }
 

--- a/crates/workflow/artifacts/src/classifier.rs
+++ b/crates/workflow/artifacts/src/classifier.rs
@@ -45,14 +45,16 @@ pub struct ClassificationResult {
 /// against the supplied rule list.
 ///
 /// The rule with the **highest priority** that matches wins. On a tie the
-/// rule earlier in the slice wins (stable sort). If no rule matches the
+/// rule earlier in the slice wins. If no rule matches the
 /// fallback is returned: `kind=intermediate`, `confidence=0.1`.
 ///
 /// Rows with `classification_source = manual_override` are skipped by the
 /// caller (T015) before invoking this function.
 #[must_use]
 pub fn classify(file_name: &str, rules: &[ArtifactRule]) -> ClassificationResult {
-    let winner = rules.iter().filter(|r| r.matches(file_name)).max_by_key(|r| r.priority);
+    // `max_by_key` returns the LAST maximum, so iterate in reverse to make the
+    // earliest declared rule win a priority tie.
+    let winner = rules.iter().filter(|r| r.matches(file_name)).rev().max_by_key(|r| r.priority);
 
     match winner {
         Some(rule) => ClassificationResult {
@@ -111,6 +113,35 @@ mod tests {
         assert!(result.confidence < 0.2, "confidence={}", result.confidence);
         assert!(matches!(result.source, ClassificationSource::Fallback));
         assert!(result.matched_rule_id.is_none());
+    }
+
+    #[test]
+    fn equal_priority_tie_goes_to_the_earlier_rule() {
+        // `default_rules` has genuine priority ties and its own sort is stable,
+        // so declaration order is the only thing separating tied rules.
+        let rules = vec![
+            ArtifactRule {
+                id: "earlier",
+                tool: "test",
+                match_kind: MatchKind::Prefix,
+                pattern: "master",
+                kind: ArtifactKind::Master,
+                confidence: 0.9,
+                priority: 100,
+            },
+            ArtifactRule {
+                id: "later",
+                tool: "test",
+                match_kind: MatchKind::Prefix,
+                pattern: "master",
+                kind: ArtifactKind::Intermediate,
+                confidence: 0.5,
+                priority: 100,
+            },
+        ];
+        let result = classify("master_dark.xisf", &rules);
+        assert_eq!(result.matched_rule_id, Some("earlier"));
+        assert_eq!(result.kind, ArtifactKind::Master);
     }
 
     #[test]


### PR DESCRIPTION
## Policy

Every comparison in this diff has a total order, so no input can make a
comparator disagree with itself. One answer per boundary:

| Boundary | Answer |
| --- | --- |
| Sort comparator | Order non-finite values last, then by `f64::total_cmp`. `total_cmp` alone orders `NaN` by its sign bit, and the x86-64 invalid-operation QNaN is sign-negative, so `total_cmp` on its own sorts that `NaN` below `-inf`. |
| Keyset cursor | Carry the whole `ORDER BY` key. A cursor this module did not produce returns an error. |
| Datetime guard | Parse both sides and compare instants. An unparseable stored expiry counts as active, so a live lease cannot be stolen. |
| Accumulator or geometry input | Gate on `is_finite` at the input boundary and classify the result as unknown, without dropping the record. A comparison against `NaN` is false, so a guard written as a comparison admits the value it was written to reject. |

## What changes

`targeting_resolver::cone_search::separation_order` defines one nearest-first
order over angular separation and keeps every non-finite value last. All four
separation sorts use it: the `dedup_candidates` group collapse and the
`select_for_display` tie-break in `targeting_resolver`, and the nearest-first
display sort and `primary_index` in `app_core_inbox::cone_search`. Since Rust
1.81 `slice::sort_by` carries an unconditional total-order detector, so a `NaN`
separation aborted the process inside `core::slice::sort` rather than returning a
wrong order. `separation_deg` is copied off the resolver response and is never
finiteness-checked; the production entry point is `target.cone_search.suggest`.

`persistence_plans::manifests` pages on the full sort key. The query orders by
`timestamp DESC, id DESC` but the keyset predicate was `timestamp < ?` and the
cursor was the timestamp alone, so rows sharing the boundary timestamp were
skipped. The cursor now encodes `timestamp` and `id`, and
`list_manifests_for_project` returns `DbError::NotFound` for a cursor it did not
produce. `ManifestListRequest.cursor` and `ManifestListResponse.next_cursor`
stay opaque `Option<String>`, so no contract or schema changes.

`persistence_lifecycle::command_ledger` compares lease expiry as an instant. Both
guards call one `lease_is_active` helper. `add_ttl` round-trips through
`OffsetDateTime` and preserves the caller's UTC offset and subsecond digit count,
so two equally valid RFC-3339 renderings of one instant sorted wrongly against
each other as strings.

`workflow_artifacts::classifier` implements the earlier-rule-wins tie-break its
doc comment already stated. `Iterator::max_by_key` returns the last maximum, and
`default_rules` has ten rules in two priority ties, so declaration order was the
only thing separating them.

`domain_core::project::channel_map` and `sessions::clustering` gate non-finite
input without discarding the record:

- A non-finite exposure contributes 0.0 and the frame stays counted, matching the
  clamp `ChannelFrame` documents for negative values.
- A session whose geometry is present but not finite is `Unassigned` with the new
  `UnassignedReason::UnusableGeometry`, separate from the missing-pointing and
  missing-rotation cases.

**Neither is reachable from production today.** `derive_clustering` has no caller
outside its own module and its `crates/sessions/src/lib.rs` re-export
(`scripts/dead-callers-baseline.txt:42`). `ChannelMap` has no consumer outside
`crates/domain/core/src/project/mod.rs`. They are fixed because the invariant is
the same. They are not user-facing bugs.

## Beads

| Bead | Site |
| --- | --- |
| `astro-plan-3v3r.10.21` | `crates/targeting/resolver/src/cone_search.rs` `select_for_display` |
| `astro-plan-3v3r.10.41` | the same defect as `.10.21` |
| `astro-plan-3v3r.10.22` | `dedup_candidates` and `primary_index`, the non-panicking half of the same comparator |
| `astro-plan-3v3r.3.16` | `crates/persistence/plans/src/repositories/manifests.rs` |
| `astro-plan-3v3r.4.26` | `crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs` |
| `astro-plan-3v3r.13.27` | `crates/workflow/artifacts/src/classifier.rs` |
| `astro-plan-3v3r.13.25` | `crates/sessions/src/clustering.rs`, not reachable from production |
| `astro-plan-3v3r.13.33` | `crates/domain/core/src/project/channel_map.rs`, not reachable from production |

## Follow-up

`crates/app/inbox/src/attribution.rs:243` sorts on `match_score` with the same
non-total comparator. A concurrent branch also edits that file, so the one-line fix is filed
separately.

Work bead: astro-plan-5u310
Merge bead: astro-plan-oxz2x
