### PR TITLE
fix(sql): bind plans.list filters as parameters and match frame_ids via json_each

### DIFF
--- a/crates/app/core/src/frame_inventory/mod.rs
+++ b/crates/app/core/src/frame_inventory/mod.rs
@@ -188,20 +188,16 @@ pub(crate) async fn owning_session_frame_type(
     pool: &SqlitePool,
     frame_id: &str,
 ) -> Result<(Option<String>, RawFrameType), ContractError> {
-    let like = format!("%\"{frame_id}\"%");
-
     if let Some(session_id) =
-        persistence_core::repositories::q_core::find_acquisition_session_id_by_frame_like(
-            pool, &like,
-        )
-        .await
-        .map_err(db_err)?
+        persistence_core::repositories::q_core::find_acquisition_session_id_by_frame(pool, frame_id)
+            .await
+            .map_err(db_err)?
     {
         return Ok((Some(session_id), RawFrameType::Light));
     }
 
     if let Some((session_id, kind)) =
-        persistence_core::repositories::q_core::find_calibration_session_by_frame_like(pool, &like)
+        persistence_core::repositories::q_core::find_calibration_session_by_frame(pool, frame_id)
             .await
             .map_err(db_err)?
     {

--- a/crates/persistence/calibration/src/repositories/calibration_assignment.rs
+++ b/crates/persistence/calibration/src/repositories/calibration_assignment.rs
@@ -218,13 +218,18 @@ pub async fn master_artifact_state(pool: &SqlitePool, master_id: &str) -> DbResu
 /// PATH B: does `master_id`'s own `calibration_session` currently have any
 /// member frame (`frame_ids`) whose `file_record.state = 'missing'`?
 ///
+/// The `CASE` skips a row whose `frame_ids` is not valid JSON, which
+/// `json_each` would otherwise raise on and fail the whole listing. Row
+/// multiplicity is irrelevant here because the result is `COUNT(*) > 0`.
+///
 /// # Errors
 /// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn master_has_missing_source_frame(pool: &SqlitePool, master_id: &str) -> DbResult<bool> {
     let (count,): (i64,) = sqlx::query_as(
         "SELECT COUNT(*)
          FROM calibration_session cs
-         JOIN json_each(cs.frame_ids) je
+         JOIN json_each(
+             CASE WHEN json_valid(cs.frame_ids) THEN cs.frame_ids ELSE '[]' END) je
          JOIN file_record fr ON fr.id = je.value
          WHERE cs.id = ? AND fr.state = 'missing'",
     )
@@ -462,6 +467,36 @@ mod tests {
 
         let rows = find_by_source_frame(&pool, "f1").await.unwrap();
         assert_eq!(rows.len(), 1, "one assignment, not one row per array element");
+    }
+
+    /// A populated `file_record` is required: with that table empty the planner
+    /// satisfies the join without ever evaluating `json_each`, and an unguarded
+    /// predicate then passes for the wrong reason.
+    #[tokio::test]
+    async fn master_has_missing_source_frame_skips_malformed_frame_ids() {
+        let pool = setup().await;
+        insert_master(&pool, "m-bad", "oops").await;
+        sqlx::query(
+            "INSERT INTO library_root (id, label, current_path, kind, state, created_at) \
+             VALUES ('root-1', 'R', '/tmp/r', 'local', 'active', '2026-01-01T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO file_record \
+             (id, root_id, relative_path, size_bytes, mtime, state, first_seen_at, last_seen_at) \
+             VALUES ('f1', 'root-1', 'a.fits', 1, '2026-01-01T00:00:00Z', 'missing', \
+                     '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let has = master_has_missing_source_frame(&pool, "m-bad")
+            .await
+            .expect("a corrupt row must not fail the listing");
+        assert!(!has);
     }
 
     /// `frame_ids` has no `json_valid` CHECK. An unguarded `json_each` raises

--- a/crates/persistence/calibration/src/repositories/calibration_assignment.rs
+++ b/crates/persistence/calibration/src/repositories/calibration_assignment.rs
@@ -247,15 +247,15 @@ pub async fn find_by_source_frame(
     pool: &SqlitePool,
     frame_id: &str,
 ) -> DbResult<Vec<CalibrationAssignmentRow>> {
-    let like = format!("%\"{frame_id}\"%");
     let rows: Vec<(String, String, String, String, f64, i64, String, String)> = sqlx::query_as(
         "SELECT ca.id, ca.session_id, ca.calibration_type, ca.master_id, ca.confidence,
                 ca.was_override, ca.mismatched_dimensions, ca.assigned_at
          FROM calibration_assignment ca
          JOIN calibration_session cs ON cs.id = ca.master_id
-         WHERE cs.frame_ids LIKE ?",
+         JOIN json_each(cs.frame_ids) je
+         WHERE je.value = ?",
     )
-    .bind(like)
+    .bind(frame_id)
     .fetch_all(pool)
     .await
     .map_err(DbError::Database)?;
@@ -407,5 +407,41 @@ mod tests {
         let result =
             upsert(&pool, params("a-df", "ses-001", "dark_flat", "m-1", 1.0, false, &[])).await;
         assert!(result.is_err(), "dark_flat should be rejected by DB CHECK constraint");
+    }
+
+    async fn insert_master(pool: &SqlitePool, master_id: &str, frame_ids: &str) {
+        sqlx::query(
+            "INSERT INTO calibration_session (id, session_key, frame_ids, kind, created_at) \
+             VALUES (?, ?, ?, 'dark', '2026-01-01T00:00:00Z')",
+        )
+        .bind(master_id)
+        .bind(master_id)
+        .bind(frame_ids)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// `_` and `%` are `LIKE` wildcards, so a pattern built from a frame id
+    /// containing either matched masters that do not list that frame.
+    #[tokio::test]
+    async fn find_by_source_frame_rejects_wildcard_collisions() {
+        let pool = setup().await;
+        insert_master(&pool, "m-other", r#"["fx1","frame-9"]"#).await;
+        upsert(&pool, params("a-1", "ses-001", "dark", "m-other", 1.0, false, &[])).await.unwrap();
+
+        assert!(find_by_source_frame(&pool, "f_1").await.unwrap().is_empty());
+        assert!(find_by_source_frame(&pool, "f%").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_by_source_frame_finds_exact_member_with_metacharacters() {
+        let pool = setup().await;
+        insert_master(&pool, "m-1", r#"["a_b"]"#).await;
+        upsert(&pool, params("a-1", "ses-001", "dark", "m-1", 1.0, false, &[])).await.unwrap();
+
+        let rows = find_by_source_frame(&pool, "a_b").await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].master_id, "m-1");
     }
 }

--- a/crates/persistence/calibration/src/repositories/calibration_assignment.rs
+++ b/crates/persistence/calibration/src/repositories/calibration_assignment.rs
@@ -241,6 +241,11 @@ pub async fn master_has_missing_source_frame(pool: &SqlitePool, master_id: &str)
 /// `calibration_match.source_missing` / `.source_recovered` audit emission
 /// to exactly the assignments a raw-frame reconcile outcome affects.
 ///
+/// `EXISTS` rather than a `json_each` join: nothing stops `frame_ids` listing
+/// the same id twice, and a join would then return the assignment once per
+/// occurrence. The `CASE` skips a row whose `frame_ids` is not valid JSON,
+/// which `json_each` would otherwise raise on and fail the whole query.
+///
 /// # Errors
 /// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_by_source_frame(
@@ -252,8 +257,10 @@ pub async fn find_by_source_frame(
                 ca.was_override, ca.mismatched_dimensions, ca.assigned_at
          FROM calibration_assignment ca
          JOIN calibration_session cs ON cs.id = ca.master_id
-         JOIN json_each(cs.frame_ids) je
-         WHERE je.value = ?",
+         WHERE EXISTS (SELECT 1 FROM json_each(
+                           CASE WHEN json_valid(cs.frame_ids)
+                                THEN cs.frame_ids ELSE '[]' END) je
+                       WHERE je.value = ?)",
     )
     .bind(frame_id)
     .fetch_all(pool)
@@ -443,5 +450,37 @@ mod tests {
         let rows = find_by_source_frame(&pool, "a_b").await.unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].master_id, "m-1");
+    }
+
+    /// Nothing stops `frame_ids` listing an id twice; a `json_each` join would
+    /// return the assignment once per occurrence.
+    #[tokio::test]
+    async fn find_by_source_frame_does_not_duplicate_on_a_repeated_id() {
+        let pool = setup().await;
+        insert_master(&pool, "m-1", r#"["f1","f1"]"#).await;
+        upsert(&pool, params("a-1", "ses-001", "dark", "m-1", 1.0, false, &[])).await.unwrap();
+
+        let rows = find_by_source_frame(&pool, "f1").await.unwrap();
+        assert_eq!(rows.len(), 1, "one assignment, not one row per array element");
+    }
+
+    /// `frame_ids` has no `json_valid` CHECK. An unguarded `json_each` raises
+    /// on a malformed row and fails the whole query.
+    #[tokio::test]
+    async fn find_by_source_frame_skips_malformed_frame_ids() {
+        let pool = setup().await;
+        insert_master(&pool, "m-bad", "oops").await;
+        insert_master(&pool, "m-empty", "").await;
+        insert_master(&pool, "m-good", r#"["f1"]"#).await;
+        upsert(&pool, params("a-bad", "ses-bad", "dark", "m-bad", 1.0, false, &[])).await.unwrap();
+        upsert(&pool, params("a-good", "ses-001", "dark", "m-good", 1.0, false, &[]))
+            .await
+            .unwrap();
+
+        let rows = find_by_source_frame(&pool, "f1")
+            .await
+            .expect("a corrupt row must not fail the lookup");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].master_id, "m-good");
     }
 }

--- a/crates/persistence/calibration/src/repositories/equipment.rs
+++ b/crates/persistence/calibration/src/repositories/equipment.rs
@@ -242,7 +242,7 @@ pub async fn delete_camera(pool: &SqlitePool, id: &str) -> DbResult<()> {
     ensure_row_affected(result.rows_affected(), "camera", id)
 }
 
-/// Find a camera by alias. Searches the JSON aliases array using LIKE.
+/// Find a camera by alias. Matches an exact member of the JSON aliases array.
 ///
 /// # Errors
 ///

--- a/crates/persistence/core/src/repositories/q_core.rs
+++ b/crates/persistence/core/src/repositories/q_core.rs
@@ -103,6 +103,10 @@ pub async fn file_records_by_root(
 /// `json_each` compares decoded array elements, so an id containing `%`, `_`,
 /// or `"` matches itself and nothing else.
 ///
+/// `frame_ids` carries no `json_valid` CHECK and `json_each` raises on a
+/// malformed value, which fails the whole query rather than the one row. The
+/// `CASE` substitutes an empty array so a corrupt row is skipped instead.
+///
 /// # Errors
 /// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_acquisition_session_id_by_frame(
@@ -111,7 +115,9 @@ pub async fn find_acquisition_session_id_by_frame(
 ) -> DbResult<Option<String>> {
     let row: Option<(String,)> = sqlx::query_as(
         "SELECT id FROM acquisition_session \
-         WHERE EXISTS (SELECT 1 FROM json_each(acquisition_session.frame_ids) je \
+         WHERE EXISTS (SELECT 1 FROM json_each( \
+                           CASE WHEN json_valid(acquisition_session.frame_ids) \
+                                THEN acquisition_session.frame_ids ELSE '[]' END) je \
                        WHERE je.value = ?) \
          LIMIT 1",
     )
@@ -124,6 +130,9 @@ pub async fn find_acquisition_session_id_by_frame(
 /// `(session id, kind)` of the `calibration_session` whose `frame_ids` JSON
 /// array contains `frame_id` as an exact member.
 ///
+/// Guards `json_each` against a malformed `frame_ids` value for the reason
+/// given on [`find_acquisition_session_id_by_frame`].
+///
 /// # Errors
 /// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_calibration_session_by_frame(
@@ -132,7 +141,9 @@ pub async fn find_calibration_session_by_frame(
 ) -> DbResult<Option<(String, String)>> {
     let row: Option<(String, String)> = sqlx::query_as(
         "SELECT id, kind FROM calibration_session \
-         WHERE EXISTS (SELECT 1 FROM json_each(calibration_session.frame_ids) je \
+         WHERE EXISTS (SELECT 1 FROM json_each( \
+                           CASE WHEN json_valid(calibration_session.frame_ids) \
+                                THEN calibration_session.frame_ids ELSE '[]' END) je \
                        WHERE je.value = ?) \
          LIMIT 1",
     )
@@ -1304,5 +1315,44 @@ mod tests {
 
         let found = find_calibration_session_by_frame(db.pool(), "a_b").await.unwrap();
         assert_eq!(found, Some(("c-1".to_owned(), "dark".to_owned())));
+    }
+
+    /// `frame_ids` has no `json_valid` CHECK. An unguarded `json_each` raises
+    /// on a malformed row and fails the whole query, losing the sessions that
+    /// are intact.
+    #[tokio::test]
+    async fn acquisition_lookup_skips_malformed_frame_ids() {
+        let db = setup_db().await;
+        insert_acquisition_session(db.pool(), "s-bad", "oops").await;
+        insert_acquisition_session(db.pool(), "s-empty", "").await;
+        insert_acquisition_session(db.pool(), "s-good", r#"["f1"]"#).await;
+
+        let found = find_acquisition_session_id_by_frame(db.pool(), "f1")
+            .await
+            .expect("a corrupt row must not fail the lookup");
+        assert_eq!(found.as_deref(), Some("s-good"));
+    }
+
+    #[tokio::test]
+    async fn calibration_lookup_skips_malformed_frame_ids() {
+        let db = setup_db().await;
+        insert_calibration_session(db.pool(), "c-bad", "oops").await;
+        insert_calibration_session(db.pool(), "c-empty", "").await;
+        insert_calibration_session(db.pool(), "c-good", r#"["f1"]"#).await;
+
+        let found = find_calibration_session_by_frame(db.pool(), "f1")
+            .await
+            .expect("a corrupt row must not fail the lookup");
+        assert_eq!(found, Some(("c-good".to_owned(), "dark".to_owned())));
+    }
+
+    /// A repeated id in the array must not yield the session twice.
+    #[tokio::test]
+    async fn acquisition_lookup_returns_one_session_for_a_repeated_id() {
+        let db = setup_db().await;
+        insert_acquisition_session(db.pool(), "s-1", r#"["f1","f1"]"#).await;
+
+        let found = find_acquisition_session_id_by_frame(db.pool(), "f1").await.unwrap();
+        assert_eq!(found.as_deref(), Some("s-1"));
     }
 }

--- a/crates/persistence/core/src/repositories/q_core.rs
+++ b/crates/persistence/core/src/repositories/q_core.rs
@@ -97,37 +97,48 @@ pub async fn file_records_by_root(
     Ok(rows)
 }
 
-/// Id of the `acquisition_session` whose `frame_ids` JSON array contains a
-/// given frame id, matched via `LIKE`.
+/// Id of the `acquisition_session` whose `frame_ids` JSON array contains
+/// `frame_id` as an exact member.
+///
+/// `json_each` compares decoded array elements, so an id containing `%`, `_`,
+/// or `"` matches itself and nothing else.
 ///
 /// # Errors
 /// Returns `persistence_core::DbError::Database` on query failure.
-pub async fn find_acquisition_session_id_by_frame_like(
+pub async fn find_acquisition_session_id_by_frame(
     pool: &SqlitePool,
-    like_pattern: &str,
+    frame_id: &str,
 ) -> DbResult<Option<String>> {
-    let row: Option<(String,)> =
-        sqlx::query_as("SELECT id FROM acquisition_session WHERE frame_ids LIKE ? LIMIT 1")
-            .bind(like_pattern)
-            .fetch_optional(pool)
-            .await?;
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT id FROM acquisition_session \
+         WHERE EXISTS (SELECT 1 FROM json_each(acquisition_session.frame_ids) je \
+                       WHERE je.value = ?) \
+         LIMIT 1",
+    )
+    .bind(frame_id)
+    .fetch_optional(pool)
+    .await?;
     Ok(row.map(|(id,)| id))
 }
 
 /// `(session id, kind)` of the `calibration_session` whose `frame_ids` JSON
-/// array contains a given frame id, matched via `LIKE`.
+/// array contains `frame_id` as an exact member.
 ///
 /// # Errors
 /// Returns `persistence_core::DbError::Database` on query failure.
-pub async fn find_calibration_session_by_frame_like(
+pub async fn find_calibration_session_by_frame(
     pool: &SqlitePool,
-    like_pattern: &str,
+    frame_id: &str,
 ) -> DbResult<Option<(String, String)>> {
-    let row: Option<(String, String)> =
-        sqlx::query_as("SELECT id, kind FROM calibration_session WHERE frame_ids LIKE ? LIMIT 1")
-            .bind(like_pattern)
-            .fetch_optional(pool)
-            .await?;
+    let row: Option<(String, String)> = sqlx::query_as(
+        "SELECT id, kind FROM calibration_session \
+         WHERE EXISTS (SELECT 1 FROM json_each(calibration_session.frame_ids) je \
+                       WHERE je.value = ?) \
+         LIMIT 1",
+    )
+    .bind(frame_id)
+    .fetch_optional(pool)
+    .await?;
     Ok(row)
 }
 
@@ -1202,5 +1213,96 @@ mod tests {
         let db = setup_db().await;
         let ids = project_ids_for_session(db.pool(), "no-such").await.unwrap();
         assert!(ids.is_empty());
+    }
+
+    async fn insert_acquisition_session(pool: &SqlitePool, id: &str, frame_ids: &str) {
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at) \
+             VALUES (?, ?, ?, '2026-01-01T00:00:00Z')",
+        )
+        .bind(id)
+        .bind(id)
+        .bind(frame_ids)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_calibration_session(pool: &SqlitePool, id: &str, frame_ids: &str) {
+        sqlx::query(
+            "INSERT INTO calibration_session (id, session_key, frame_ids, kind, created_at) \
+             VALUES (?, ?, ?, 'dark', '2026-01-01T00:00:00Z')",
+        )
+        .bind(id)
+        .bind(id)
+        .bind(frame_ids)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// `_` is a single-character `LIKE` wildcard, so a pattern built from
+    /// `f_1` also matched a session holding only `fx1`.
+    #[tokio::test]
+    async fn acquisition_lookup_rejects_underscore_wildcard_collision() {
+        let db = setup_db().await;
+        insert_acquisition_session(db.pool(), "s-other", r#"["fx1"]"#).await;
+
+        let found = find_acquisition_session_id_by_frame(db.pool(), "f_1").await.unwrap();
+        assert_eq!(found, None);
+    }
+
+    /// `%` matches any run of characters, so a pattern built from `f%` matched
+    /// every session.
+    #[tokio::test]
+    async fn acquisition_lookup_rejects_percent_wildcard_collision() {
+        let db = setup_db().await;
+        insert_acquisition_session(db.pool(), "s-other", r#"["frame-9"]"#).await;
+
+        let found = find_acquisition_session_id_by_frame(db.pool(), "f%").await.unwrap();
+        assert_eq!(found, None);
+    }
+
+    /// An id that is a substring of a genuine member is not a member.
+    #[tokio::test]
+    async fn acquisition_lookup_rejects_prefix_collision() {
+        let db = setup_db().await;
+        insert_acquisition_session(db.pool(), "s-other", r#"["frame-1-extra"]"#).await;
+
+        assert_eq!(find_acquisition_session_id_by_frame(db.pool(), "frame-1").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn acquisition_lookup_finds_exact_member_with_metacharacters() {
+        let db = setup_db().await;
+        insert_acquisition_session(db.pool(), "s-1", r#"["a_b","c%d"]"#).await;
+
+        assert_eq!(
+            find_acquisition_session_id_by_frame(db.pool(), "a_b").await.unwrap().as_deref(),
+            Some("s-1")
+        );
+        assert_eq!(
+            find_acquisition_session_id_by_frame(db.pool(), "c%d").await.unwrap().as_deref(),
+            Some("s-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn calibration_lookup_rejects_wildcard_and_prefix_collisions() {
+        let db = setup_db().await;
+        insert_calibration_session(db.pool(), "c-other", r#"["fx1","frame-1-extra"]"#).await;
+
+        assert_eq!(find_calibration_session_by_frame(db.pool(), "f_1").await.unwrap(), None);
+        assert_eq!(find_calibration_session_by_frame(db.pool(), "f%").await.unwrap(), None);
+        assert_eq!(find_calibration_session_by_frame(db.pool(), "frame-1").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn calibration_lookup_finds_exact_member_with_metacharacters() {
+        let db = setup_db().await;
+        insert_calibration_session(db.pool(), "c-1", r#"["a_b"]"#).await;
+
+        let found = find_calibration_session_by_frame(db.pool(), "a_b").await.unwrap();
+        assert_eq!(found, Some(("c-1".to_owned(), "dark".to_owned())));
     }
 }

--- a/crates/persistence/lifecycle/src/repositories/settings.rs
+++ b/crates/persistence/lifecycle/src/repositories/settings.rs
@@ -126,9 +126,10 @@ pub async fn get_all_raw(pool: &SqlitePool) -> DbResult<Vec<(String, Value)>> {
 ///
 /// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_all_by_prefix(pool: &SqlitePool, prefix: &str) -> DbResult<Vec<(String, Value)>> {
-    // SQLite LIKE pattern: append '%' to the prefix. The prefix itself may
-    // contain literal '%' or '_' — escape them so they are matched literally.
-    let pattern = format!("{}%", prefix.replace('%', "\\%").replace('_', "\\_"));
+    // The prefix may contain LIKE metacharacters; escape them so they match
+    // literally. `escape_like` escapes the backslash itself, which a bare
+    // `%`/`_` replacement does not.
+    let pattern = format!("{}%", persistence_core::repositories::sql::escape_like(prefix));
     let rows: Vec<(String, Json<Value>)> = sqlx::query_as(
         "SELECT key, value FROM settings WHERE key LIKE ? ESCAPE '\\' ORDER BY key ASC",
     )
@@ -340,6 +341,32 @@ mod tests {
         let db = setup_db().await;
         let result = get_raw(db.pool(), "nonexistent_key").await.unwrap();
         assert!(result.is_none());
+    }
+
+    /// A prefix ending in a backslash left the escape character dangling under
+    /// the previous `%`/`_`-only replacement, so `\_` was read as an escaped
+    /// wildcard instead of a literal backslash followed by a wildcard.
+    #[tokio::test]
+    async fn get_all_by_prefix_treats_metacharacters_literally() {
+        let db = setup_db().await;
+        let v = serde_json::json!(1);
+        for key in
+            ["a_b.one", "axb.two", "c%d.three", "cQd.four", "e\\_f.five", "e\\Qf.six", "eXf.seven"]
+        {
+            set_raw(db.pool(), key, &v).await.unwrap();
+        }
+
+        let underscore = get_all_by_prefix(db.pool(), "a_b.").await.unwrap();
+        assert_eq!(underscore.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>(), vec!["a_b.one"]);
+
+        let percent = get_all_by_prefix(db.pool(), "c%d.").await.unwrap();
+        assert_eq!(percent.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>(), vec!["c%d.three"]);
+
+        let backslash = get_all_by_prefix(db.pool(), "e\\_f.").await.unwrap();
+        assert_eq!(
+            backslash.iter().map(|(k, _)| k.as_str()).collect::<Vec<_>>(),
+            vec!["e\\_f.five"]
+        );
     }
 
     #[tokio::test]

--- a/crates/persistence/plans/src/repositories/plans.rs
+++ b/crates/persistence/plans/src/repositories/plans.rs
@@ -276,22 +276,22 @@ pub async fn list_plans(
     created_after: Option<&str>,
     limit: i64,
 ) -> DbResult<Vec<PlanRow>> {
-    // Build a dynamic query. SQLite does not support array binding, so we
-    // validate the filter values (already validated by the use case) and
-    // interpolate a fixed IN clause.
+    // SQLite does not support array binding, so the IN clauses are built from
+    // the filter lengths only. No caller bytes reach the SQL text; every filter
+    // value is bound below, in the order the placeholders appear.
+    let placeholders = |n: usize| -> String { vec!["?"; n].join(",") };
+
     let state_clause = if state_filter.is_empty() {
         // Default: all non-discarded states.
         "state != 'discarded'".to_owned()
     } else {
-        let quoted: Vec<String> = state_filter.iter().map(|s| format!("'{s}'")).collect();
-        format!("state IN ({})", quoted.join(","))
+        format!("state IN ({})", placeholders(state_filter.len()))
     };
 
     let origin_clause = if origin_filter.is_empty() {
         String::new()
     } else {
-        let quoted: Vec<String> = origin_filter.iter().map(|s| format!("'{s}'")).collect();
-        format!("AND origin IN ({})", quoted.join(","))
+        format!("AND origin IN ({})", placeholders(origin_filter.len()))
     };
 
     let date_clause = if created_after.is_some() { "AND created_at >= ?" } else { "" };
@@ -307,6 +307,12 @@ pub async fn list_plans(
     );
 
     let mut q = sqlx::query_as::<_, PlanRow>(sqlx::AssertSqlSafe(&*sql));
+    for state in state_filter {
+        q = q.bind(state);
+    }
+    for origin in origin_filter {
+        q = q.bind(origin);
+    }
     if let Some(after) = created_after {
         q = q.bind(after);
     }
@@ -725,6 +731,49 @@ mod tests {
         let rows = list_plans(db.pool(), &["draft".to_owned()], &[], None, 100).await.unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].id, "p1");
+    }
+
+    /// State, origin, and `created_after` placeholders appear in that order in
+    /// the SQL text; a bind order that disagrees silently returns wrong rows.
+    #[tokio::test]
+    async fn list_plans_combines_state_origin_and_created_after_filters() {
+        let db = setup_db().await;
+        for (id, origin) in [("p-keep", "cleanup"), ("p-origin", "archive"), ("p-state", "cleanup")]
+        {
+            let mut plan = sample_plan(id);
+            plan.origin = origin;
+            plan.plan_type = origin;
+            insert_plan(db.pool(), &plan).await.unwrap();
+        }
+        update_plan_state(db.pool(), "p-state", "ready_for_review").await.unwrap();
+
+        let rows = list_plans(
+            db.pool(),
+            &["draft".to_owned()],
+            &["cleanup".to_owned()],
+            Some("2000-01-01T00:00:00Z"),
+            100,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(rows.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(), vec!["p-keep"]);
+    }
+
+    /// Filter values are bound, so SQL metacharacters are matched as data and
+    /// cannot extend the WHERE clause past the non-discarded default.
+    #[tokio::test]
+    async fn list_plans_filter_values_cannot_inject_sql() {
+        let db = setup_db().await;
+        insert_plan(db.pool(), &sample_plan("p1")).await.unwrap();
+        insert_plan(db.pool(), &sample_plan("p2")).await.unwrap();
+        soft_delete_plan(db.pool(), "p2", "2026-06-01T00:00:00Z").await.unwrap();
+
+        let rows = list_plans(db.pool(), &["draft') OR 1=1 --".to_owned()], &[], None, 100)
+            .await
+            .expect("a hostile filter value is data, not SQL");
+
+        assert!(rows.is_empty(), "no plan has that literal state");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changes

In `plans.list`, caller-controlled strings reached SQLite as SQL text; they now bind as parameters. In the `frame_ids` lookups, an inexact `LIKE` membership test against a JSON array column is replaced by an exact comparison of decoded array elements; the frame id there was interpolated into a `LIKE` pattern that was itself bound, so it never entered SQL text. The defects are independent of each other.

### plans.list filter binding

`list_plans` built its `state` and `origin` `IN` clauses with `format!("'{s}'")` over raw caller strings. The contract type is a bare `Option<Vec<String>>` (`crates/contracts/core/src/plans.rs`), reached from the Tauri `plans.list` command, and `crates/app/core/src/plans/read.rs` passes the values through without validation. A filter value containing a quote extended the `WHERE` clause and bypassed the default `state != 'discarded'` guard, returning soft-deleted plans.

The clauses now carry placeholders derived from the filter lengths only. No caller bytes enter the SQL text. Values bind in SQL text order: every state, every origin, `created_after`, then `limit`.

### frame_ids membership

These sites tested JSON-array membership with `frame_ids LIKE '%"id"%'`:

| Site | Change |
| --- | --- |
| `crates/persistence/core/src/repositories/q_core.rs` `find_acquisition_session_id_by_frame` | `EXISTS (SELECT 1 FROM json_each(...) je WHERE je.value = ?)` |
| `crates/persistence/core/src/repositories/q_core.rs` `find_calibration_session_by_frame` | `EXISTS (SELECT 1 FROM json_each(...) je WHERE je.value = ?)` |
| `crates/persistence/calibration/src/repositories/calibration_assignment.rs` `find_by_source_frame` | `WHERE EXISTS (SELECT 1 FROM json_each(...) je WHERE je.value = ?)` |

`_` and `%` are `LIKE` wildcards, so a pattern built from a frame id containing either matched sessions that do not list that frame. An id containing `"` or `\` produced the opposite error, a false negative, because the column stores JSON-encoded strings. Frame ids are UUIDv4 (`domain_core::ids::new_id`), so neither the wildcard collision nor the quoted-id false negative was reachable in production data. `json_each` compares decoded array elements, so the predicate is now exact regardless of id shape.

Frame-to-session attribution is a Tier-1 record under constitution principle V: it encodes a user decision that cannot be re-derived from the filesystem. The membership test must be exact in both directions, so a change that removes false positives while leaving false negatives does not close the hole.

`frame_ids` carries no `json_valid` CHECK, and `json_each` raises on a malformed value, which fails the whole query rather than excluding the one row as `LIKE` did. Every `json_each` call over `frame_ids` in `persistence/core` and `persistence/calibration` wraps the column in `CASE WHEN json_valid(...) THEN ... ELSE '[]' END`, so a corrupt row is skipped. That covers the three membership predicates above plus `master_has_missing_source_frame`, which serves the calibration-master listing. The same failure remains at nine query sites outside this change, tracked by `astro-plan-p3vor` together with the absence of any user-facing signal that a row was skipped: `persistence/targets/src/repositories/inventory.rs:161`, `:192`, `:349`, `:421`; `persistence/calibration/src/repositories/equipment.rs:258` and `:381`, both over `aliases`; `persistence/plans/src/repositories/projects/sources.rs:56`; `persistence/targets/src/repositories/targets.rs:59`, which reaches the column through `json_array_length` rather than `json_each` and raises the same way; and the `calibration_master_view` definition at `persistence/core/migrations/0001_initial_schema.sql:3200`, which applies `json_extract` to `calibration_session.frame_ids`. The first two of the `inventory.rs` queries also apply `json_extract` to the same column at `:165` and `:196`, so guarding all nine sites means guarding eleven expressions.

`0001_initial_schema.sql` is frozen by text and checksum in `persistence/core/tests/baseline_invariants.rs`, so the view cannot be edited in place; guarding it requires a new migration that drops and recreates the view. That migration is not part of this change. `json_each(?)` over a bound parameter needs no guard, at `calibration_assignment.rs:320`, `artifacts.rs:231`, `:255`, `:275`, `plan_apply.rs:860` and `:940`: the application serialises that value itself.

`find_by_source_frame` uses `EXISTS` rather than a `json_each` join: nothing stops `frame_ids` listing an id twice, and a join returns the assignment once per occurrence. `master_has_missing_source_frame` keeps its join because its result is `COUNT(*) > 0`, which multiplicity cannot change.

Escaping the `LIKE` pattern instead was rejected. The column stores JSON-encoded strings, so an escaped pattern fails to match a member that is genuinely present.

The two `q_core` functions lose their `_like` suffix and take a frame id rather than a pattern, so the signature no longer invites a caller-built pattern. Both call sites in `crates/app/core/src/frame_inventory/mod.rs` drop their `format!` line.

### settings prefix escape

`settings::get_all_by_prefix` replaced `%` and `_` by hand and paired that with `ESCAPE '\'`, never escaping the backslash. It now calls `persistence_core::repositories::sql::escape_like`, which escapes the backslash first.

## Tests

The third column states, per test, whether it fails against the implementation at the base commit. A test that passes at base pins behaviour the new implementation could otherwise regress; it does not reproduce a defect.

| Test | Proves | Fails at base |
| --- | --- | --- |
| `acquisition_lookup_rejects_underscore_wildcard_collision` | `f_1` no longer matches a session listing only `fx1` | yes |
| `acquisition_lookup_rejects_percent_wildcard_collision` | `f%` no longer matches an unrelated session | yes |
| `calibration_lookup_rejects_wildcard_and_prefix_collisions` | the same wildcard cases on `calibration_session` | yes |
| `find_by_source_frame_rejects_wildcard_collisions` | `f_1` and `f%` match no assignment | yes |
| `list_plans_filter_values_cannot_inject_sql` | `draft') OR 1=1 --` returns no rows | yes |
| `get_all_by_prefix_treats_metacharacters_literally` | prefix `e\_f.` matches `e\_f.five` and not `e\Qf.six` | yes |
| `master_has_missing_source_frame_skips_malformed_frame_ids` | a `frame_ids` of `oops` does not fail the calibration-master listing | yes |
| `acquisition_lookup_skips_malformed_frame_ids` | a row holding `oops` or `""` does not fail the lookup | no, see below |
| `calibration_lookup_skips_malformed_frame_ids` | the same on `calibration_session` | no, see below |
| `find_by_source_frame_skips_malformed_frame_ids` | the same on the assignment lookup | no, see below |
| `acquisition_lookup_rejects_prefix_collision` | `frame-1` does not match `frame-1-extra` | no |
| `acquisition_lookup_finds_exact_member_with_metacharacters` | ids `a_b` and `c%d` still match themselves | no |
| `calibration_lookup_finds_exact_member_with_metacharacters` | exact match survives on `calibration_session` | no |
| `find_by_source_frame_finds_exact_member_with_metacharacters` | id `a_b` still resolves its assignment | no |
| `acquisition_lookup_returns_one_session_for_a_repeated_id` | `["f1","f1"]` yields one session | no |
| `find_by_source_frame_does_not_duplicate_on_a_repeated_id` | `["f1","f1"]` yields one assignment | no |
| `list_plans_combines_state_origin_and_created_after_filters` | bind order across all three filters | no |

Wildcard expansion, the `plans.list` injection, the settings backslash escape, and the unguarded `json_each` in `master_has_missing_source_frame` are the defects present at the base commit.

The three `skips_malformed_frame_ids` tests on the membership predicates pass at base and fail against the intermediate `json_each` form added earlier in this branch. At base those sites used `LIKE`, which excluded a malformed row silently; the guard restores that outcome.

The remaining tests that pass at base pin properties the rewrite could have broken. The JSON quotes anchored the base pattern, so substring collision was never reachable. A `LIKE` test against the whole column cannot duplicate a row, and `find_acquisition_session_id_by_frame` returns `Option` under `LIMIT 1`, so neither repeated-id test reproduces a base defect; both guard the `json_each` form against the multiplicity a table-valued join introduces, which is why `find_by_source_frame` uses `EXISTS`. The combined-filter test pins bind order in the placeholder form, which the base interpolation had no parameters to misorder.

No schema change. The migration chain is untouched.

Work beads: `astro-plan-3v3r.3.13`, `astro-plan-3v3r.12.32`, `astro-plan-3v3r.12.31`, `astro-plan-3v3r.4.28`.
Merge bead: `astro-plan-tvw3p`.

Tracks-Bead: astro-plan-fwg3h
Merge-Bead: astro-plan-tvw3p


