### PR TITLE
fix: keep user-supplied values out of command and option position

### DIFF
--- a/.github/workflows/e2e-alert.yml
+++ b/.github/workflows/e2e-alert.yml
@@ -39,12 +39,13 @@ jobs:
         id: workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          # Fetch the workflow run to extract metadata
-          RUN_ID="${{ github.event.workflow_run.id }}"
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
-          COMMIT_SHA="${{ github.event.workflow_run.head_commit }}"
+          RUN_URL="https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}"
+          COMMIT_SHA="$HEAD_SHA"
           SHORT_SHA="${COMMIT_SHA:0:7}"
 
           {
@@ -58,14 +59,14 @@ jobs:
         id: failed_jobs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ steps.workflow.outputs.run_id }}
         run: |
           set -euo pipefail
-          RUN_ID="${{ steps.workflow.outputs.run_id }}"
-
           # Query the GitHub API for all jobs in the workflow run
           JOBS=$(gh api \
             --method GET \
-            "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" \
+            "repos/${REPOSITORY}/actions/runs/${RUN_ID}/jobs" \
             --jq '.jobs[] | select(.conclusion == "failure") | .name' \
             2>/dev/null || echo "")
 

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -489,7 +489,10 @@ pub async fn launch(
         },
         file: None,
     };
-    let argv = render(&config.profile.args_template, &ctx);
+    let argv = match render(&config.profile.args_template, &ctx) {
+        Ok(argv) => argv,
+        Err(e) => return Ok(error_response("args.operand_not_absolute", e)),
+    };
     let args_hash = compute_args_hash(&config.executable_path, &argv);
 
     // bundle_id from Settings (override) or seeded default

--- a/crates/workflow/profiles/src/args.rs
+++ b/crates/workflow/profiles/src/args.rs
@@ -5,8 +5,7 @@
 //!
 //! Renders a `&[ArgsToken]` against a substitution context, returning a
 //! `Vec<String>` of concrete CLI arguments. Only the closed token vocabulary
-//! `{folder}` and `{file}` is supported; unknown patterns are rejected at
-//! parse time.
+//! `{folder}` and `{file}` is supported.
 //!
 //! Constitution III: this module only builds argv; it never spawns processes.
 
@@ -27,56 +26,41 @@ pub struct RenderContext<'a> {
 /// replaced with the corresponding context field. If a token's field is `None`
 /// in the context the argument is simply omitted (not an error).
 ///
-/// Returns the rendered argument list.
-#[must_use]
-pub fn render(template: &[ArgsToken], ctx: &RenderContext<'_>) -> Vec<String> {
+/// A substituted `Folder`/`File` value must be an absolute path: a relative value
+/// whose first segment begins with `-` is read as an option by the callee's own
+/// argument parser. Neither Siril nor PixInsight documents a `--` end-of-options
+/// token, so absoluteness is the enforceable form of the operand boundary.
+///
+/// # Errors
+///
+/// Returns a descriptive string when a substituted `Folder`/`File` value is not
+/// an absolute path.
+pub fn render(template: &[ArgsToken], ctx: &RenderContext<'_>) -> Result<Vec<String>, String> {
     let mut out = Vec::with_capacity(template.len());
     for token in template {
         match token {
             ArgsToken::Literal(s) => out.push(s.clone()),
             ArgsToken::Folder => {
                 if let Some(f) = ctx.folder {
-                    out.push(f.to_owned());
+                    out.push(absolute_operand("{folder}", f)?);
                 }
             }
             ArgsToken::File => {
                 if let Some(f) = ctx.file {
-                    out.push(f.to_owned());
+                    out.push(absolute_operand("{file}", f)?);
                 }
             }
         }
     }
-    out
+    Ok(out)
 }
 
-/// Parse a simple space-delimited template string into `ArgsToken` values.
-///
-/// Token grammar:
-/// - `{folder}` → `ArgsToken::Folder`
-/// - `{file}`   → `ArgsToken::File`
-/// - anything else → `ArgsToken::Literal`
-///
-/// Returns `Err` when an unrecognised `{...}` placeholder is found.
-///
-/// # Errors
-///
-/// Returns a descriptive string when the template contains an unknown `{…}` token.
-pub fn parse(template: &str) -> Result<Vec<ArgsToken>, String> {
-    let mut out = Vec::new();
-    for part in template.split_whitespace() {
-        let token = match part {
-            "{folder}" => ArgsToken::Folder,
-            "{file}" => ArgsToken::File,
-            other if other.starts_with('{') && other.ends_with('}') => {
-                return Err(format!(
-                    "unknown args-template token '{other}'; only {{folder}} and {{file}} are allowed (R3)"
-                ));
-            }
-            other => ArgsToken::Literal(other.to_owned()),
-        };
-        out.push(token);
+fn absolute_operand(token: &str, value: &str) -> Result<String, String> {
+    if std::path::Path::new(value).is_absolute() {
+        Ok(value.to_owned())
+    } else {
+        Err(format!("args-template token '{token}' requires an absolute path; got '{value}' (R3)"))
     }
-    Ok(out)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -89,69 +73,50 @@ mod tests {
     fn render_folder_token() {
         let tokens = &[ArgsToken::Folder];
         let ctx = RenderContext { folder: Some("/mnt/library/project"), file: None };
-        assert_eq!(render(tokens, &ctx), vec!["/mnt/library/project"]);
+        assert_eq!(render(tokens, &ctx).unwrap(), vec!["/mnt/library/project"]);
     }
 
     #[test]
     fn render_file_token() {
         let tokens = &[ArgsToken::File];
         let ctx = RenderContext { folder: None, file: Some("/mnt/library/project/capture.fit") };
-        assert_eq!(render(tokens, &ctx), vec!["/mnt/library/project/capture.fit"]);
+        assert_eq!(render(tokens, &ctx).unwrap(), vec!["/mnt/library/project/capture.fit"]);
     }
 
     #[test]
     fn render_literal_token() {
         let tokens = &[ArgsToken::Literal("--open".to_owned()), ArgsToken::Folder];
         let ctx = RenderContext { folder: Some("/a/b"), file: None };
-        assert_eq!(render(tokens, &ctx), vec!["--open", "/a/b"]);
+        assert_eq!(render(tokens, &ctx).unwrap(), vec!["--open", "/a/b"]);
     }
 
     #[test]
     fn render_omits_missing_folder() {
         let tokens = &[ArgsToken::Folder];
         let ctx = RenderContext { folder: None, file: None };
-        assert_eq!(render(tokens, &ctx), Vec::<String>::new());
+        assert_eq!(render(tokens, &ctx).unwrap(), Vec::<String>::new());
     }
 
     #[test]
     fn render_empty_template_returns_empty() {
-        assert_eq!(render(&[], &RenderContext::default()), Vec::<String>::new());
+        assert_eq!(render(&[], &RenderContext::default()).unwrap(), Vec::<String>::new());
     }
 
     #[test]
-    fn parse_folder_token() {
-        let tokens = parse("{folder}").unwrap();
-        assert_eq!(tokens, vec![ArgsToken::Folder]);
+    fn render_rejects_relative_folder_operand() {
+        let tokens = &[ArgsToken::Folder];
+        let ctx = RenderContext { folder: Some("-rf"), file: None };
+        let err = render(tokens, &ctx).unwrap_err();
+        assert!(err.contains("{folder}"), "err: {err}");
+        assert!(err.contains("absolute"), "err: {err}");
     }
 
     #[test]
-    fn parse_file_token() {
-        let tokens = parse("{file}").unwrap();
-        assert_eq!(tokens, vec![ArgsToken::File]);
-    }
-
-    #[test]
-    fn parse_literal() {
-        let tokens = parse("--open").unwrap();
-        assert_eq!(tokens, vec![ArgsToken::Literal("--open".to_owned())]);
-    }
-
-    #[test]
-    fn parse_unknown_token_returns_err() {
-        let err = parse("{unknown}").unwrap_err();
-        assert!(err.contains("unknown"), "err: {err}");
-    }
-
-    #[test]
-    fn parse_empty_string_returns_empty() {
-        assert_eq!(parse("").unwrap(), vec![]);
-    }
-
-    #[test]
-    fn render_empty_template() {
-        // An empty args template renders to an empty vec.
-        let ctx = RenderContext { folder: Some("/project"), file: None };
-        assert_eq!(render(&[], &ctx), Vec::<String>::new());
+    fn render_rejects_relative_file_operand() {
+        let tokens = &[ArgsToken::File];
+        let ctx = RenderContext { folder: None, file: Some("capture.fit") };
+        let err = render(tokens, &ctx).unwrap_err();
+        assert!(err.contains("{file}"), "err: {err}");
     }
 
     #[test]
@@ -159,18 +124,18 @@ mod tests {
         use crate::seed;
         let profile = seed::find("siril").unwrap();
         let ctx = RenderContext { folder: Some("/mnt/lib/siril_project"), file: None };
-        let argv = render(&profile.args_template, &ctx);
+        let argv = render(&profile.args_template, &ctx).unwrap();
         assert_eq!(argv, vec!["/mnt/lib/siril_project"]);
     }
 
     #[test]
     fn render_pixinsight_bare_no_args() {
-        // #778: PixInsight can't open a bare folder path — launch bare (no
+        // #778: PixInsight can't open a bare folder path -- launch bare (no
         // args) rather than pass a broken {folder} token.
         use crate::seed;
         let profile = seed::find("pixinsight").unwrap();
         let ctx = RenderContext { folder: Some("/mnt/lib/pi_project"), file: None };
-        let argv = render(&profile.args_template, &ctx);
+        let argv = render(&profile.args_template, &ctx).unwrap();
         assert_eq!(argv, Vec::<String>::new());
     }
 }

--- a/crates/workflow/profiles/src/args.rs
+++ b/crates/workflow/profiles/src/args.rs
@@ -69,25 +69,37 @@ fn absolute_operand(token: &str, value: &str) -> Result<String, String> {
 mod tests {
     use super::*;
 
+    // `render` requires an absolute operand, and absoluteness is platform-defined:
+    // a POSIX literal has no drive prefix, so `is_absolute` is false on Windows.
+    #[cfg(windows)]
+    const ABS_DIR: &str = r"C:\mnt\library\project";
+    #[cfg(not(windows))]
+    const ABS_DIR: &str = "/mnt/library/project";
+
+    #[cfg(windows)]
+    const ABS_FILE: &str = r"C:\mnt\library\project\capture.fit";
+    #[cfg(not(windows))]
+    const ABS_FILE: &str = "/mnt/library/project/capture.fit";
+
     #[test]
     fn render_folder_token() {
         let tokens = &[ArgsToken::Folder];
-        let ctx = RenderContext { folder: Some("/mnt/library/project"), file: None };
-        assert_eq!(render(tokens, &ctx).unwrap(), vec!["/mnt/library/project"]);
+        let ctx = RenderContext { folder: Some(ABS_DIR), file: None };
+        assert_eq!(render(tokens, &ctx).unwrap(), vec![ABS_DIR]);
     }
 
     #[test]
     fn render_file_token() {
         let tokens = &[ArgsToken::File];
-        let ctx = RenderContext { folder: None, file: Some("/mnt/library/project/capture.fit") };
-        assert_eq!(render(tokens, &ctx).unwrap(), vec!["/mnt/library/project/capture.fit"]);
+        let ctx = RenderContext { folder: None, file: Some(ABS_FILE) };
+        assert_eq!(render(tokens, &ctx).unwrap(), vec![ABS_FILE]);
     }
 
     #[test]
     fn render_literal_token() {
         let tokens = &[ArgsToken::Literal("--open".to_owned()), ArgsToken::Folder];
-        let ctx = RenderContext { folder: Some("/a/b"), file: None };
-        assert_eq!(render(tokens, &ctx).unwrap(), vec!["--open", "/a/b"]);
+        let ctx = RenderContext { folder: Some(ABS_DIR), file: None };
+        assert_eq!(render(tokens, &ctx).unwrap(), vec!["--open", ABS_DIR]);
     }
 
     #[test]
@@ -119,13 +131,22 @@ mod tests {
         assert!(err.contains("{file}"), "err: {err}");
     }
 
+    // A rooted POSIX path lacks a drive prefix, so Windows must reject it rather
+    // than hand the tool a path the OS cannot resolve.
+    #[cfg(windows)]
+    #[test]
+    fn render_rejects_a_rooted_path_without_a_drive_prefix() {
+        let ctx = RenderContext { folder: Some("/mnt/library/project"), file: None };
+        assert!(render(&[ArgsToken::Folder], &ctx).is_err());
+    }
+
     #[test]
     fn render_siril_folder() {
         use crate::seed;
         let profile = seed::find("siril").unwrap();
-        let ctx = RenderContext { folder: Some("/mnt/lib/siril_project"), file: None };
+        let ctx = RenderContext { folder: Some(ABS_DIR), file: None };
         let argv = render(&profile.args_template, &ctx).unwrap();
-        assert_eq!(argv, vec!["/mnt/lib/siril_project"]);
+        assert_eq!(argv, vec![ABS_DIR]);
     }
 
     #[test]
@@ -134,7 +155,7 @@ mod tests {
         // args) rather than pass a broken {folder} token.
         use crate::seed;
         let profile = seed::find("pixinsight").unwrap();
-        let ctx = RenderContext { folder: Some("/mnt/lib/pi_project"), file: None };
+        let ctx = RenderContext { folder: Some(ABS_DIR), file: None };
         let argv = render(&profile.args_template, &ctx).unwrap();
         assert_eq!(argv, Vec::<String>::new());
     }

--- a/crates/workflow/profiles/src/discover.rs
+++ b/crates/workflow/profiles/src/discover.rs
@@ -59,7 +59,7 @@ fn spotlight_discover() -> Vec<DiscoveryResult> {
     let mut results: Vec<DiscoveryResult> = Vec::new();
     for &(tool_id, bundle_id, exe) in MACOS_TOOLS {
         let query = format!("kMDItemCFBundleIdentifier == '{bundle_id}'");
-        let Ok(out) = Command::new("mdfind").arg(&query).output() else { continue };
+        let Ok(out) = Command::new("/usr/bin/mdfind").arg(&query).output() else { continue };
         if !out.status.success() {
             continue;
         }

--- a/crates/workflow/profiles/src/launch.rs
+++ b/crates/workflow/profiles/src/launch.rs
@@ -158,7 +158,7 @@ fn spawn_platform(req: SpawnRequest) -> Result<SpawnResult, LaunchError> {
 
     if let Some(ref bid) = req.bundle_id {
         // Use `open -b <bundle_id> --args <argv>` for .app bundles (R-BundleId).
-        let mut cmd = std::process::Command::new("open");
+        let mut cmd = std::process::Command::new("/usr/bin/open");
         cmd.args(["-b", bid.as_str()]);
         if !req.args.is_empty() {
             cmd.arg("--args");

--- a/crates/workflow/profiles/tests/real_spawn_stub.rs
+++ b/crates/workflow/profiles/tests/real_spawn_stub.rs
@@ -91,7 +91,7 @@ fn real_spawn_anchors_cwd_to_project_root_when_no_source_view() {
     let profile = seed::find("pixinsight").unwrap();
     assert!(!profile.supports_open_folder);
     let working_dir = resolve_working_folder(&project_root, None).unwrap();
-    let rendered = render(&profile.args_template, &RenderContext::default());
+    let rendered = render(&profile.args_template, &RenderContext::default()).unwrap();
 
     let observed = spawn_and_observe(&working_dir, &rendered, &tmp.path().join("pi.record"));
 
@@ -113,7 +113,8 @@ fn real_spawn_anchors_cwd_and_argv_to_source_view_folder() {
     let working_dir = resolve_working_folder(&project_root, Some("_source_view")).unwrap();
     let folder = working_dir.to_string_lossy().into_owned();
     let rendered =
-        render(&profile.args_template, &RenderContext { folder: Some(&folder), file: None });
+        render(&profile.args_template, &RenderContext { folder: Some(&folder), file: None })
+            .unwrap();
 
     let observed = spawn_and_observe(&working_dir, &rendered, &tmp.path().join("siril.record"));
 

--- a/crates/workflow/profiles/tests/spawn_program_paths.rs
+++ b/crates/workflow/profiles/tests/spawn_program_paths.rs
@@ -1,0 +1,30 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Every process this crate spawns names its program by absolute path, so the
+//! program that runs is not selected by the inherited `PATH`.
+//!
+//! Asserted against the source text: the macOS spawn sites are `cfg`-gated and
+//! reach the real OS, so there is no seam at which a test can observe the
+//! resolved program without spawning a binary (constitution III).
+
+const SOURCES: &[(&str, &str)] = &[
+    ("discover.rs", include_str!("../src/discover.rs")),
+    ("launch.rs", include_str!("../src/launch.rs")),
+];
+
+#[test]
+fn every_spawned_program_is_an_absolute_path() {
+    for (name, src) in SOURCES {
+        for (offset, _) in src.match_indices("Command::new(\"") {
+            let program = src[offset + "Command::new(\"".len()..]
+                .split('"')
+                .next()
+                .expect("a literal program name is terminated by a quote");
+            assert!(
+                program.starts_with('/'),
+                "{name}: spawns '{program}' by bare program name; use an absolute path",
+            );
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -132,7 +132,7 @@ hygiene-pub:
 # Public API surface of one crate (read, not pass/fail).
 hygiene-api CRATE:
     @command -v cargo-public-api >/dev/null 2>&1 || { echo "cargo-public-api not installed: cargo install cargo-public-api"; exit 1; }
-    cargo public-api -p "{{CRATE}}"
+    cargo public-api -p {{quote(CRATE)}}
 
 # All non-interactive hygiene sweeps.
 hygiene: hygiene-deps hygiene-pub
@@ -199,7 +199,7 @@ tauri-dev:
 # The bridge is unauthenticated and reaches every command handler; BIND defaults
 # to loopback and takes an address (0.0.0.0) only for cross-host validation.
 tauri-dev-mcp bind="127.0.0.1":
-    cd apps/desktop && PV_MCP_BRIDGE_ENABLE=1 PV_MCP_BRIDGE_BIND="{{bind}}" pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-tools
+    cd apps/desktop && PV_MCP_BRIDGE_ENABLE=1 PV_MCP_BRIDGE_BIND={{quote(bind)}} pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-tools
 
 # Clean build artifacts
 clean:
@@ -207,16 +207,16 @@ clean:
 
 # Speckit workflows (requires specify CLI)
 speckit-full FEATURE INTEGRATION="codex":
-    specify workflow run speckit-full -i "feature_name={{FEATURE}}" -i "integration={{INTEGRATION}}"
+    specify workflow run speckit-full -i feature_name={{quote(FEATURE)}} -i integration={{quote(INTEGRATION)}}
 
 speckit-bugfix ISSUE INTEGRATION="codex":
-    specify workflow run speckit-bugfix -i "issue_number={{ISSUE}}" -i "integration={{INTEGRATION}}"
+    specify workflow run speckit-bugfix -i issue_number={{quote(ISSUE)}} -i integration={{quote(INTEGRATION)}}
 
 speckit-tinyspec FEATURE INTEGRATION="codex":
-    specify workflow run speckit-tinyspec -i "feature_name={{FEATURE}}" -i "integration={{INTEGRATION}}"
+    specify workflow run speckit-tinyspec -i feature_name={{quote(FEATURE)}} -i integration={{quote(INTEGRATION)}}
 
 speckit-resume RUN_ID:
-    specify workflow resume "{{RUN_ID}}"
+    specify workflow resume {{quote(RUN_ID)}}
 
 speckit-status:
     specify workflow status

--- a/justfile
+++ b/justfile
@@ -132,7 +132,7 @@ hygiene-pub:
 # Public API surface of one crate (read, not pass/fail).
 hygiene-api CRATE:
     @command -v cargo-public-api >/dev/null 2>&1 || { echo "cargo-public-api not installed: cargo install cargo-public-api"; exit 1; }
-    cargo public-api -p {{CRATE}}
+    cargo public-api -p "{{CRATE}}"
 
 # All non-interactive hygiene sweeps.
 hygiene: hygiene-deps hygiene-pub
@@ -199,7 +199,7 @@ tauri-dev:
 # The bridge is unauthenticated and reaches every command handler; BIND defaults
 # to loopback and takes an address (0.0.0.0) only for cross-host validation.
 tauri-dev-mcp bind="127.0.0.1":
-    cd apps/desktop && PV_MCP_BRIDGE_ENABLE=1 PV_MCP_BRIDGE_BIND={{bind}} pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-tools
+    cd apps/desktop && PV_MCP_BRIDGE_ENABLE=1 PV_MCP_BRIDGE_BIND="{{bind}}" pnpm tauri dev --config src-tauri/tauri.dev.conf.json --features dev-tools
 
 # Clean build artifacts
 clean:
@@ -207,16 +207,16 @@ clean:
 
 # Speckit workflows (requires specify CLI)
 speckit-full FEATURE INTEGRATION="codex":
-    specify workflow run speckit-full -i feature_name={{FEATURE}} -i integration={{INTEGRATION}}
+    specify workflow run speckit-full -i "feature_name={{FEATURE}}" -i "integration={{INTEGRATION}}"
 
 speckit-bugfix ISSUE INTEGRATION="codex":
-    specify workflow run speckit-bugfix -i issue_number={{ISSUE}} -i integration={{INTEGRATION}}
+    specify workflow run speckit-bugfix -i "issue_number={{ISSUE}}" -i "integration={{INTEGRATION}}"
 
 speckit-tinyspec FEATURE INTEGRATION="codex":
-    specify workflow run speckit-tinyspec -i feature_name={{FEATURE}} -i integration={{INTEGRATION}}
+    specify workflow run speckit-tinyspec -i "feature_name={{FEATURE}}" -i "integration={{INTEGRATION}}"
 
 speckit-resume RUN_ID:
-    specify workflow resume {{RUN_ID}}
+    specify workflow resume "{{RUN_ID}}"
 
 speckit-status:
     specify workflow status


### PR DESCRIPTION
A user- or event-supplied value reached a callee as something other than one fully substituted argv element or one quoted shell word, at the five call sites below. Each is fixed at the point where the value is still distinguishable from a literal.

## Rendered tool arguments reject a non-absolute operand

`workflow_profiles::args::render` returns `Result<Vec<String>, String>` and rejects a `{folder}` or `{file}` substitution whose value is not an absolute path. A relative value whose first path segment begins with `-` is read as an option by the launched tool's own argument parser. `crates/app/core/src/tool_launch.rs` answers the rejection with the `error_response` shape already used for the containment and database failures in that function, so the user sees a typed `ToolLaunchError` with code `args.operand_not_absolute`.

Reachability: the `{folder}` value comes from `tool_launch.rs`, which canonicalizes the project path but falls back to the raw spelling when canonicalization fails. A library path whose first segment begins with `-` is legal on every supported platform. Only the seeded siril profile has an operand; the pixinsight and planetary_suite templates are empty. No caller passes a relative operand today, so the guard tightens validation without changing a working launch.

A literal `--` end-of-options token is not used. Neither Siril nor PixInsight documents one, so a `--` would either be rejected as a stray argument or ignored. Absoluteness is checkable without knowing the callee's CLI.

## The unused args-template parser is deleted

`args::parse` rejected an unknown `{...}` token only when the whole whitespace-delimited part both started with `{` and ended with `}`. `A{folder}` matched the literal arm instead and reached child argv with the braces intact, which the module doc said could not happen.

Reachability: none. `parse` had zero callers in the workspace outside its own test module (`rg "args::"` returns `tool_launch.rs`, a doc link, and one integration test, all for `render`). This is a public-surface fix with no production caller, so hardening the function would have closed the finding while changing nothing reachable.

## The macOS helper spawns name an absolute path

`crates/workflow/profiles/src/discover.rs` spawns `/usr/bin/mdfind` and `crates/workflow/profiles/src/launch.rs` spawns `/usr/bin/open`. The sibling spawns at `launch.rs:146`, `:180`, and `:191` name the program from `req.executable` rather than by bare name, so the new test only has to constrain the two literal program names. Nothing validates `req.executable` itself as absolute. `rg 'Command::new("' crates/workflow/` now returns no bare program name.

Reachability: reaching either one requires having already set `PATH` for the app's own process. Both binaries ship at those paths on every supported macOS release. This is hardening, not a live bug.

Both helpers stay detached and unsupervised. A missing `/usr/bin/open` maps to `io::ErrorKind::NotFound` at `launch.rs:167`, then `LaunchError::SpawnFailed`, then the typed `ToolLaunchError` already handled at `tool_launch.rs:354`, which is the same mapping a bare name that is absent from `PATH` produced. `open -b` still returns no pid and the launch row's `pid` stays nullable.

`apps/desktop/src-tauri/src/commands/native.rs:155` spawns `xdg-open` by bare name. It is the same defect class and is left alone: it falls outside this change's scope, and a distribution may ship `xdg-open` outside `/usr/bin`.

## The justfile quotes every recipe-parameter substitution

`just` substitutes parameters textually and then runs the line with `sh`, so an unquoted value that contains `;` arrives as shell syntax. Each substitution now passes through just's `quote()` function, which emits one single-quoted word and escapes an embedded quote. Double quotes only relocate the boundary. A value containing `"` closes the quote, and the rest of the value is read as shell syntax.

Each quoted substitution:

| Substitution | Value | Relies on word splitting |
| --- | --- | --- |
| `{{CRATE}}` | crate name | no |
| `{{FEATURE}}` | feature name | no |
| `{{INTEGRATION}}` | integration name | no |
| `{{ISSUE}}` | issue number | no |
| `{{RUN_ID}}` | run id | no |
| `{{bind}}` | bind address | no |

Every one is one operand, so quoting doesn't change the argument count.

Measured on just 1.50.0. `just --dry-run speckit-bugfix '1; touch /tmp/pwn'` printed `-i issue_number=1; touch /tmp/pwn -i integration=codex` before the change, where `;` is a command separator, and prints `-i issue_number='1; touch /tmp/pwn' -i integration='codex'` after. The double-quote vector `just --dry-run speckit-bugfix '1"; touch /tmp/pv-pwn-probe; echo "'` prints `-i issue_number='1"; touch /tmp/pv-pwn-probe; echo "'`, and `just --dry-run hygiene-api 'x"; id; echo "'` prints `cargo public-api -p 'x"; id; echo "'`. In each the whole value is one word.

## The E2E alert workflow passes event data through env

`.github/workflows/e2e-alert.yml` routes `workflow_run.id` and the head sha through each step's existing `env:` block instead of expanding them into the `run:` body, matching what the step already did for its token. No `github.event` expansion remains in a `run:` body. The remaining matches are the job `if:`, the step's `env:` block, and two comments.

Reachability: the job `if:` requires `head_branch == 'main'`, so influencing `workflow_run.id` needs push rights on main.

The same line had a second defect. The field read was `workflow_run.head_commit`, which is a payload object rather than a string. GitHub renders a non-primitive expression as the literal text `Object`, so `SHORT_SHA` was `Object` and every issue this workflow filed was titled `main L3 E2E red @ Object`. The field is now `head_sha`. That also means the measured escape through `head_commit` never survived expression evaluation. This change is hardening plus a title fix; no exploited hole was closed.

No job or step name changed. `actionlint .github/workflows/e2e-alert.yml` exits 0.

## Verification

| Command | Exit |
| --- | --- |
| `cargo fmt --all` | 0 |
| `cargo clippy -p workflow_profiles --all-targets` | 0 |
| `cargo test -p workflow_profiles` (35 tests) | 0 |
| `cargo check -p app_core --all-targets` | 0 |
| `cargo clippy -p app_core --all-targets` | 0 |
| `actionlint .github/workflows/e2e-alert.yml` | 0 |
| `just --dry-run speckit-bugfix '1; touch /tmp/pwn'` | 0 |

The `render` unit tests take their absolute operand from a `#[cfg(windows)]` fixture pair, `ABS_DIR` and `ABS_FILE`. A rooted POSIX literal has no drive prefix, so `Path::is_absolute` returns false for it on Windows and the guard rejects it. A Windows-only test asserts that rejection. The Windows lane is verified by CI rather than locally.

Each property below was probed against the unmodified source first and failed there:

| Property | Base result |
| --- | --- |
| a relative `{folder}` value does not reach argv | failed |
| an embedded `A{folder}` placeholder is rejected | failed |
| `every_spawned_program_is_an_absolute_path` | failed |

The justfile and workflow fixes are covered by the dry-run and `rg` checks above rather than by a test.

## Beads

Tracks-Bead: astro-plan-840tq
Tracks-Bead: astro-plan-3v3r.13.35
Tracks-Bead: astro-plan-3v3r.13.36
Tracks-Bead: astro-plan-3v3r.13.40
Tracks-Bead: astro-plan-3v3r.16.24
Tracks-Bead: astro-plan-3v3r.17.8
Merge-Bead: astro-plan-26spc
Closes-Bead: astro-plan-3v3r.13.35
Closes-Bead: astro-plan-3v3r.13.36
Closes-Bead: astro-plan-3v3r.13.40
Closes-Bead: astro-plan-3v3r.16.24
Closes-Bead: astro-plan-3v3r.17.8
