### PR TITLE
fix: corrupt FITS files and a damaged target-resolution cache report an error instead of crashing the app

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,6 +3477,7 @@ version = "0.1.0"
 dependencies = [
  "fits-header",
  "metadata_core",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/metadata/fits/Cargo.toml
+++ b/crates/metadata/fits/Cargo.toml
@@ -11,5 +11,8 @@ path = "src/lib.rs"
 metadata_core = { path = "../core" }
 fits-header = "0.4.2"
 
+[dev-dependencies]
+tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/metadata/fits/src/lib.rs
+++ b/crates/metadata/fits/src/lib.rs
@@ -69,7 +69,8 @@ impl MetadataExtractor for FitsExtractor {
 
         // `fits-header` 0.4.2 lossy-decodes the block and then slices the
         // resulting `String` at fixed byte offsets (`parse.rs:38`, `:47`,
-        // `:92`, `:98`). A non-ASCII byte widens to a 3-byte U+FFFD, so those
+        // `:61`, `:92`, `:98`). A non-ASCII byte widens to a 3-byte U+FFFD, so
+        // those
         // offsets can land inside a char and panic. Containing that here
         // depends on panics unwinding: the release profile in the workspace
         // `Cargo.toml` deliberately keeps the default `panic = "unwind"`.

--- a/crates/metadata/fits/src/lib.rs
+++ b/crates/metadata/fits/src/lib.rs
@@ -19,10 +19,11 @@
 //! handle at all — including one that panics inside `fits-header` — yields
 //! [`MetadataExtractError::Parse`]; [`FitsExtractor::extract`] never panics.
 //!
-//! A header that `fits-header` mis-parses without failing is NOT detectable
-//! here: the crate lossy-decodes each card before slicing it at fixed offsets,
-//! so one invalid byte shifts every later field and can yield a wrong keyword
-//! and value with no panic and no error.
+//! A silent mis-parse passes through this adapter undetected, because it does
+//! not validate that the header block is ASCII: `fits-header` lossy-decodes
+//! each card before slicing it at fixed offsets, so one invalid UTF-8 byte
+//! shifts every later field and can yield a wrong keyword and value with no
+//! panic and no error.
 #![allow(clippy::doc_markdown)]
 
 use std::io::{self, Read};

--- a/crates/metadata/fits/src/lib.rs
+++ b/crates/metadata/fits/src/lib.rs
@@ -18,6 +18,11 @@
 //! keyword yields `None` rather than an error. A header the parser cannot
 //! handle at all — including one that panics inside `fits-header` — yields
 //! [`MetadataExtractError::Parse`]; [`FitsExtractor::extract`] never panics.
+//!
+//! A header that `fits-header` mis-parses without failing is NOT detectable
+//! here: the crate lossy-decodes each card before slicing it at fixed offsets,
+//! so one invalid byte shifts every later field and can yield a wrong keyword
+//! and value with no panic and no error.
 #![allow(clippy::doc_markdown)]
 
 use std::io::{self, Read};

--- a/crates/metadata/fits/src/lib.rs
+++ b/crates/metadata/fits/src/lib.rs
@@ -14,9 +14,10 @@
 //! `GAIN`, `XBINNING`, `YBINNING`, `NAXIS1`, `NAXIS2`, `INSTRUME`, `TELESCOP`,
 //! `DATE-OBS`.
 //!
-//! No cfitsio or heavy C dependencies — `fits-header` is pure Rust. Missing or
-//! garbage headers are handled gracefully; the extractor never panics or
-//! returns hard errors for corrupt files, preferring `None` values.
+//! No cfitsio or heavy C dependencies — `fits-header` is pure Rust. A missing
+//! keyword yields `None` rather than an error. A header the parser cannot
+//! handle at all — including one that panics inside `fits-header` — yields
+//! [`MetadataExtractError::Parse`]; [`FitsExtractor::extract`] never panics.
 #![allow(clippy::doc_markdown)]
 
 use std::io::{self, Read};
@@ -66,10 +67,25 @@ impl MetadataExtractor for FitsExtractor {
             msg: e.to_string(),
         })?;
 
+        // `fits-header` 0.4.2 lossy-decodes the block and then slices the
+        // resulting `String` at fixed byte offsets (`parse.rs:38`, `:47`,
+        // `:92`, `:98`). A non-ASCII byte widens to a 3-byte U+FFFD, so those
+        // offsets can land inside a char and panic. Containing that here
+        // depends on panics unwinding: the release profile in the workspace
+        // `Cargo.toml` deliberately keeps the default `panic = "unwind"`.
+        let parsed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            fits_header::Header::parse(&bytes)
+        }))
+        .map_err(|_| MetadataExtractError::Parse {
+            path: path.display().to_string(),
+            msg: "the FITS header parser panicked on malformed header bytes".to_owned(),
+        })?;
+
         // Header::parse never actually errs (parsing is lenient by design);
         // propagate defensively rather than unwrap.
-        let header = fits_header::Header::parse(&bytes).map_err(|e| {
-            MetadataExtractError::Parse { path: path.display().to_string(), msg: e.to_string() }
+        let header = parsed.map_err(|e| MetadataExtractError::Parse {
+            path: path.display().to_string(),
+            msg: e.to_string(),
         })?;
 
         Ok(Some(parse_header(&header)))
@@ -351,6 +367,22 @@ mod tests {
     fn empty_block_returns_empty_metadata() {
         let meta = parse(&[]);
         assert!(meta.image_typ.is_none());
+    }
+
+    /// Regression for astro-plan-3v3r.20.33 / 20.16: a `.fits` file whose first
+    /// block is non-ASCII drives `fits-header` 0.4.2 into a non-char-boundary
+    /// slice, which in production unwinds out of the inbox scan.
+    #[test]
+    fn malformed_header_bytes_are_an_error_not_a_panic() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("corrupt.fits");
+        std::fs::write(&path, [0xffu8; BLOCK_SIZE]).expect("write fixture");
+
+        let err = FitsExtractor.extract(&path).expect_err("malformed header must be an error");
+        assert!(
+            matches!(err, MetadataExtractError::Parse { .. }),
+            "expected a Parse error, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/metadata/xisf/src/lib.rs
+++ b/crates/metadata/xisf/src/lib.rs
@@ -50,7 +50,19 @@ impl MetadataExtractor for XisfExtractor {
 
         // Reads only the 16-byte preamble + declared XML header (capped at
         // 8 MiB internally); never touches pixel/attachment data.
-        let header = Header::read_from_file(path).map_err(|e| map_err(&e, path))?;
+        //
+        // `xisf-header` 0.4.3 length-checks before every slice, so no panic is
+        // known here; the guard keeps a future parser panic from reaching the
+        // inbox scan, matching the FITS adapter. It depends on panics
+        // unwinding: the release profile in the workspace `Cargo.toml`
+        // deliberately keeps the default `panic = "unwind"`.
+        let header =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| Header::read_from_file(path)))
+                .map_err(|_| MetadataExtractError::Parse {
+                    path: path.display().to_string(),
+                    msg: "the XISF header parser panicked on malformed header bytes".to_owned(),
+                })?
+                .map_err(|e| map_err(&e, path))?;
 
         Ok(Some(parse_header(&header)))
     }

--- a/crates/targeting/resolver/src/simbad/cache.rs
+++ b/crates/targeting/resolver/src/simbad/cache.rs
@@ -31,14 +31,53 @@ impl ResolveCache {
     /// (`crate::seed::WARM_CHUNK_SIZE`'s ~13-chunk bundled seed warm going
     /// from ~13 fsyncs to 1).
     ///
+    /// A file that is shorter than the layout recorded in its own redb header —
+    /// the shape an unclean shutdown or a torn write leaves behind — aborts the
+    /// open by panic rather than by `Err`, because redb 4.1.0 checks it with a
+    /// release-live `assert!` (`page_store/page_manager.rs:231`). This deletes
+    /// such a file and opens once more; the cache is a reproducible projection
+    /// of the bundled seed and the `canonical_target` rows, so nothing
+    /// user-authored is lost.
+    ///
     /// # Errors
     ///
-    /// Returns [`ResolveError::Network`] if the redb file cannot be opened or
-    /// its tables cannot be initialised.
+    /// Returns [`ResolveError::Network`] if the redb file cannot be opened, its
+    /// tables cannot be initialised, or a file that aborted the open cannot be
+    /// deleted.
     pub fn open(path: impl AsRef<std::path::Path>) -> Result<Self, ResolveError> {
-        simbad_resolver::Store::open_with(path, simbad_resolver::BatchDurability::Eventual)
-            .map(Self)
-            .map_err(|e| from_cache_error(&e))
+        let path = path.as_ref();
+        if let Some(result) = Self::open_store(path) {
+            return result;
+        }
+
+        if let Err(e) = std::fs::remove_file(path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                return Err(ResolveError::Network(format!(
+                    "the resolve cache file at {} aborted the open and could not be removed: {e}",
+                    path.display()
+                )));
+            }
+        }
+
+        Self::open_store(path).unwrap_or_else(|| {
+            Err(ResolveError::Network(format!(
+                "the resolve cache store aborted the open of a freshly created file at {}",
+                path.display()
+            )))
+        })
+    }
+
+    /// Open the backing store, returning `None` when the open aborted by panic
+    /// instead of returning. Containing that panic depends on panics unwinding:
+    /// the release profile in the workspace `Cargo.toml` deliberately keeps the
+    /// default `panic = "unwind"`.
+    fn open_store(path: &std::path::Path) -> Option<Result<Self, ResolveError>> {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            simbad_resolver::Store::open_with(path, simbad_resolver::BatchDurability::Eventual)
+                .map(Self)
+                .map_err(|e| from_cache_error(&e))
+        }))
+        .ok()
     }
 
     /// An ephemeral, in-memory resolve cache (nothing persisted) — for tests
@@ -78,5 +117,36 @@ impl ResolveCache {
         // `Self::cache()` above, which erases it to `impl Cache` — `flush`
         // is redb-specific, not part of the portable `Cache` trait).
         self.0.cache().flush().await.map_err(|e| from_cache_error(&e))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ResolveCache;
+
+    /// Regression for astro-plan-3v3r.10.42 / 10.29. The fixture must be a
+    /// VALID redb store truncated below its own recorded layout: random bytes
+    /// fail redb's header parse and return `Err` long before the release-live
+    /// `assert!` at `page_store/page_manager.rs:231` that this guard contains.
+    #[test]
+    fn a_truncated_cache_file_is_recreated_instead_of_aborting_the_open() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("simbad-cache.redb");
+
+        drop(ResolveCache::open(&path).expect("a fresh cache file must open"));
+        let full_len = std::fs::metadata(&path).expect("stat the store").len();
+        assert!(
+            full_len > 4096,
+            "fixture must be longer than the truncation point, got {full_len}"
+        );
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .expect("reopen for truncation")
+            .set_len(4096)
+            .expect("truncate the store below its recorded layout");
+
+        ResolveCache::open(&path).expect("a truncated cache file must reopen, not abort");
+        assert!(path.exists(), "the reopened cache must leave a usable file behind");
     }
 }


### PR DESCRIPTION
## Summary

- A `.fits`, `.fit`, or `.fts` file whose header bytes are not valid ASCII no longer crashes the app during an inbox scan; the file is reported as unreadable and the scan continues.
- A resolve-cache file left short by an unclean shutdown no longer crashes startup; the app deletes it and builds a fresh one.

Closes the reachable-crash group NOPANIC-1: astro-plan-3v3r.20.16, .20.33, .20.30, .10.42, .10.29.

Work bead: astro-plan-0rkow. Merge bead: astro-plan-56aq2. Do not mark ready; an independent review runs next.

## Per-bead reachability

| Bead | Reachable in production | Evidence |
| --- | --- | --- |
| .20.33, .20.16 | Yes, live crash | `FitsExtractor::extract` (`crates/metadata/fits/src/lib.rs:49-57`) gates on file extension only; `read_header_bytes` (`:101-124`) does no magic-number or UTF-8 check, so the first 2880-byte block of any `.fits`/`.fit`/`.fts` file reaches `fits_header::Header::parse` verbatim. `fits-header` 0.4.2 `parse.rs:37-38` lossy-decodes then slices `card_str[..8]`; a `0xff` byte becomes a 3-byte U+FFFD so boundaries land at 0, 3, 6, 9. Observed panic text at base: `end byte index 8 is not a char boundary; it is inside '\u{fffd}' (bytes 6..9 of string)`. Five paths reach the dispatch at `crates/app/targets/src/metadata_cache.rs:103`: `crates/app/inbox/src/scan.rs`, `classify.rs`, `confirm.rs`, `plan_listener.rs:510`, `crates/app/targets/src/ingest_sessions.rs:708`. |
| .20.30 (FITS half) | Yes | Same defect as .20.33; the module doc at `crates/metadata/fits/src/lib.rs:17-20` claimed a never-panic guarantee the crate did not hold. |
| .20.30 (XISF half) | No, defensive only | `xisf-header` 0.4.3 length-checks before slicing (`reader.rs:105-114`) and every `unwrap`/`expect` in that crate is in tests or doctests. No panic is known. The `catch_unwind` at `crates/metadata/xisf/src/lib.rs:59` is symmetry, not a bug fix, and no never-panic claim was added to the XISF module doc. |
| .10.42, .10.29 | Yes, live crash | `ResolveCache::open` (`crates/targeting/resolver/src/simbad/cache.rs`) had no arm for a file shorter than its own recorded layout, because redb 4.1.0 checks it with a release-live `assert!` (`tree_store/page_store/page_manager.rs:231`), not an `Err`; the `map_err` never saw it. Reached at startup: `apps/desktop/src-tauri/src/lib.rs:701` calls `open_or_in_memory` (`apps/desktop/src-tauri/src/resolve_cache.rs:70-79`) against a file in the user data dir. Trigger: unclean shutdown or partial write. Observed panic text at base: `assertion failed: storage.raw_file_len()? >= header.layout().len()`. |

`.10.29` needs no separate change; it is the same locus and defect as `.10.42`.

## Changes

- `crates/metadata/fits/src/lib.rs` — `Header::parse` runs under `catch_unwind(AssertUnwindSafe(..))`; a caught panic becomes `MetadataExtractError::Parse`. Module doc rewritten to state the guarantee that holds (an `Err`, not a `None`-everywhere pass).
- `crates/metadata/xisf/src/lib.rs` — same wrap around `Header::read_from_file`. Defensive.
- `crates/targeting/resolver/src/simbad/cache.rs` — `ResolveCache::open` opens the store under `catch_unwind` via a private `open_store`; a caught panic deletes the file and opens once more, then returns `Err`. No loop.
- `crates/metadata/fits/Cargo.toml` — `tempfile` dev-dependency for the new file-based test.

Containment depends on panics unwinding; the release profile in the workspace `Cargo.toml` keeps the default by omitting `panic = "abort"`, and each guard names that dependency in a comment. No global panic hook is installed and the default hook's stderr output is untouched.

## A2 test shape

Valid-store-then-truncate, not random bytes. The test opens a real store at a temp path, drops it, asserts the file is longer than 4096 bytes, then `set_len(4096)`. A random-bytes fixture would prove nothing: redb rejects it in `DatabaseHeader::from_bytes` and never reaches the assertion the guard contains. The test asserts that on the truncated file, which is the shape that panicked at base.

## Base-failing tests

Both were confirmed failing by reverting only the guard in place (the `catch_unwind` call replaced with the direct call, test unchanged), running the test, then restoring the guard from a saved copy.

| Test | Bead | At base | Observed failure at base |
| --- | --- | --- | --- |
| `metadata_fits` `tests::malformed_header_bytes_are_an_error_not_a_panic` | .20.33, .20.16, .20.30 | FAIL | `panicked at fits-header-0.4.2/src/parse.rs:38:31: end byte index 8 is not a char boundary; it is inside '\u{fffd}' (bytes 6..9 of string)`; `test result: FAILED. 0 passed; 1 failed`, exit 101 |
| `targeting_resolver` `simbad::cache::tests::a_truncated_cache_file_is_recreated_instead_of_aborting_the_open` | .10.42, .10.29 | FAIL | `panicked at redb-4.1.0/src/tree_store/page_store/page_manager.rs:231:9: assertion failed: storage.raw_file_len()? >= header.layout().len()`; `test result: FAILED. 0 passed; 1 failed`, exit 101 |

The XISF wrap has no test: there is no known panic to reproduce, so any test would assert only that a valid file still parses, which the existing 20 tests already do.

## `fits-header` slice sites

`fits-header` 0.4.2 has **five** byte-slice sites on the lossy `String`: `parse.rs:38`, `:47`, `:61`, `:92`, `:98`. One `catch_unwind` at the `Header::parse` call covers all five. Pinned at 0.4.2 in `Cargo.lock`.

The guard contains the crash, not the whole defect. The root cause is offset drift: lossy decoding widens each invalid byte to a 3-byte U+FFFD, so a fixed-offset slice after one reads the wrong field. When the shifted offset still lands on a char boundary the parse succeeds and returns wrong keyword and value bytes with no panic, which no caller-side `catch_unwind` can detect. Upstream `fits-header` 0.4.3, already published, is the upstream fix for that half; taking it is astro-plan-61v2y. Drift needs an invalid UTF-8 byte, since a valid multi-byte sequence round-trips at the same width, so an ASCII pre-check on the header block at this adapter's boundary would also reject the population that can drift. This PR adds no such check.

The durable fix is upstream and is out of scope here; filed as **astro-plan-61v2y** (`discovered-from: astro-plan-3v3r.20.33`).

## Enumeration of every site of the pattern

| Search | Hits | Result |
| --- | --- | --- |
| `rg -l 'fits_header::'` | 1 file | `crates/metadata/fits/src/lib.rs` only, as expected |
| `rg -l 'xisf_header'` | 1 file | `crates/metadata/xisf/src/lib.rs` only, as expected |
| `rg -n 'ResolveCache::open\|Store::open_with\|Store::in_memory'` | 1 file open | `Store::open_with` only at `crates/targeting/resolver/src/simbad/cache.rs`. Production `ResolveCache::open` callers: `apps/desktop/src-tauri/src/resolve_cache.rs:71` and `:109`, both covered by the one in-crate guard; no second guard added. Every other hit is `Store::in_memory` (no file) or a test. |
| `rg -n 'catch_unwind'` | 2 pre-existing | `apps/desktop/src-tauri/src/commands/lifecycle.rs:142` and `crates/app/core/src/plan_apply/tests.rs:1702`. Correction to the brief: the `lifecycle.rs:142` occurrence is inside a `#[cfg(test)] mod cache_warming_guard_tests`, so the workspace had **zero** non-test `catch_unwind` before this PR, not one. The style used here matches those two sites. |

`crates/metadata/video` is an extension-matching stub with no parser and needs no guard.

## Verification

| Command | Result |
| --- | --- |
| `cargo test -p metadata_fits -p metadata_xisf` | exit 0 |
| `cargo test -p targeting_resolver --lib simbad::cache` | exit 0 |
| `cargo clippy -p metadata_fits -p metadata_xisf -p targeting_resolver --all-targets` | exit 0, no warnings |
| `cargo fmt --all` | applied, no residual diff |

CI-verified only: nothing in `apps/desktop/src-tauri` was changed, so no Tauri-graph build was needed. The full `just check` was not run: it pulls the Tauri graph, and disk headroom on this host is about 13 GiB with two other Rust build slots in use. The known pre-existing `just check` failure (astro-plan-8vxx1, an appliable typo lint in `crates/app/inbox`) is outside the files touched here; scoped clippy over the three crates changed is clean.

## Deviations from the dispatch brief

1. **The `# Panics` doc at `apps/desktop/src-tauri/src/resolve_cache.rs:65-68` was left in place.** The brief asked for it to be removed or corrected as a false claim. It is not false. It documents the `expect` on the in-memory fallback at `:77`, which still panics; that is unchanged by this PR. Removing it would delete a true `# Panics` claim. No file under `apps/desktop/src-tauri` is touched by this PR as a result.
2. **A2 recovers from a caught panic only, not from a corrupt-file `Err`.** The brief asked for both. `simbad_resolver::CacheError` carries no corrupt-file discriminant — the redb failure arrives as `Backend(String)` — so an `Err` arm would have to match on redb's message text, which is brittle. An `Err` from `open` already degrades gracefully: `open_or_in_memory` (`resolve_cache.rs:71`) falls back to an in-memory cache. The panic was the crash, and it is contained.



## Review round 1 (astro-plan-wisp-6hx)

Verdict FIX, one item: the `fits-header` slice-site count was four and is five. `parse.rs:61` slices `next_str[10..]` over a whole 80-byte CONTINUE card whose lossy decode is gated only on bytes 0..8 by the `next_kw != "CONTINUE"` break at `:54-57`, so bytes 8 and 9 can widen and put index 10 inside a char. The `&next[..8]` at `:54` is a byte slice, not a site. Corrected in `349be5a2c` in the source comment at `crates/metadata/fits/src/lib.rs:70-72`, in the section above, and on astro-plan-61v2y. No code change: one `catch_unwind` covers all five either way. The commit message of `ebfa7f6a5` still says four and is left as-is; this PR squashes, so the body is the changelog entry.

CP1 (guard is the right fix), CP2 (tests), CP3 (dev-only dependency), CP5 (nothing unbuilt), and CP7 (base/CI) all passed and were not redone. The reviewer independently reproduced both base panics in a scratch crate pinned to the workspace versions and confirmed a caveat worth recording: **redb 4.2.0 returns `Err` where 4.1.0 asserts**, so anyone re-checking the A2 test must pin `redb =4.1.0` or they will wrongly conclude the test is vacuous. Both premise corrections declared in the deviations section below were independently verified correct, as was the `catch_unwind` correction in the enumeration table.


## Review round 2 (astro-plan-wisp-20l)

Verdict FIX, one item: the slice-site section framed the defect as a panic only, inviting the reading that the guard fully mitigates it. The paragraph on offset drift above is the reviewer's required text, appended verbatim. CP1 (count is five in all three places), CP3 (no redb pin needed) and CP4 (base merges cleanly, `git merge-tree --write-tree` exit 0, 15 checks passed) passed.

The reviewer's optional companion was taken: the module doc at `crates/metadata/fits/src/lib.rs:22-26` now states that a silently mis-parsed header is not detectable in this adapter (`6695c9c78`).

CP3 detail worth keeping: a redb bump cannot make the A2 test vacuous. `crates/targeting/resolver/src/simbad/cache.rs` returns `None` only on a caught panic, so under redb 4.2.0 the open yields `Some(Err(..))`, `ResolveCache::open` returns `Err`, and the test's `expect` fails loudly. A bump turns that test red, not silent. Under 4.2.0 a truncated file would instead degrade to the in-memory fallback and never be recreated, which is the gap deviation 2 below already declares.


## Review round 3 (astro-plan-wisp-pn2)

Verdict FIX, two items, both wording; no code changed. CP1 (framing honest, not overcorrected), CP3 (diff is doc-comment only), CP4 (base/CI: 13 SUCCESS, 0 failing) and CP5 (all five beads still open, none closed by me) passed.

1. The module doc said a silent mis-parse is "NOT detectable here", which claimed an impossibility where the truth is that this adapter does not check. Offset drift requires an invalid UTF-8 byte, so an `is_ascii` gate on the 2880-byte block would reject that whole population. Reworded at `crates/metadata/fits/src/lib.rs:22-26` to state the gap (`e7fee7376`). No gate added, per the reviewer's instruction to leave the mitigation to astro-plan-61v2y.
2. "the only fix for that half" is softened to "the upstream fix" in the paragraph above, with the alternative named.
