### PR TITLE
fix: boot recovery no longer treats a broken shortcut as a finished file move

### DIFF
--- a/crates/app/inbox/src/scan.rs
+++ b/crates/app/inbox/src/scan.rs
@@ -18,6 +18,7 @@
 //! used for content signatures.
 #![allow(clippy::doc_markdown)]
 
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use app_core_targets::metadata_cache::cached_extract;
@@ -320,7 +321,9 @@ struct LeafDir {
 ///
 /// # Errors
 ///
-/// Returns an error string if `root` is not a directory or cannot be read.
+/// Returns an error string if `root` is not a directory the walker will
+/// descend under `options.follow_symlinks` — including a symlinked or junction
+/// root while following is disabled — or cannot be read.
 /// Unreadable *sub*-directories are non-fatal: they are collected in
 /// [`ScanOutput::warnings`] and the scan continues with whatever it can reach.
 ///
@@ -330,14 +333,14 @@ struct LeafDir {
 /// (e.g. a logic error in `process_leaf`). Per-file I/O failures
 /// (unreadable files, parse errors) are silently skipped and do not panic.
 pub fn scan_root(root: &Path, options: &ScanOptions) -> Result<ScanOutput, String> {
-    if !root.is_dir() {
-        return Err(format!("scan root is not a directory: {}", root.display()));
-    }
+    fs_pathsafe::probe_root(root, options.follow_symlinks)
+        .map_err(|reason| format!("scan root is unusable: {reason} ({})", root.display()))?;
 
     // Phase 1: collect leaf dirs via fast directory walk (no per-file I/O).
     let mut leaf_dirs: Vec<LeafDir> = Vec::new();
     let mut warnings: Vec<ScanWarning> = Vec::new();
-    collect_leaf_dirs(root, options, &mut leaf_dirs, &mut warnings)?;
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    collect_leaf_dirs(root, options, &mut leaf_dirs, &mut warnings, &mut visited)?;
 
     if leaf_dirs.is_empty() {
         return Ok(ScanOutput { items: vec![], warnings });
@@ -450,12 +453,25 @@ fn process_leaf(root: &Path, leaf: &LeafDir) -> ScannedInboxItem {
 /// When called on the scan root (top-level), a read failure propagates as
 /// `Err` — there is nothing to return. When called recursively on a subdir,
 /// the same failure is pushed into `warnings` and the walk continues.
+///
+/// `visited` holds the canonical path of every directory already entered and is
+/// consulted only when `options.follow_symlinks` is set. Without it a link back
+/// to an ancestor re-enters the same real directory once per link component the
+/// OS allows, duplicating every frame inside it; the same key shape as
+/// `fs_pathsafe::real_files_under_reporting`.
 fn collect_leaf_dirs(
     dir: &Path,
     options: &ScanOptions,
     leaf_dirs: &mut Vec<LeafDir>,
     warnings: &mut Vec<ScanWarning>,
+    visited: &mut HashSet<PathBuf>,
 ) -> Result<(), String> {
+    if options.follow_symlinks
+        && !visited.insert(std::fs::canonicalize(dir).unwrap_or_else(|_| dir.to_path_buf()))
+    {
+        return Ok(());
+    }
+
     let read_dir = std::fs::read_dir(dir)
         .map_err(|e| format!("cannot read directory {}: {e}", dir.display()))?;
 
@@ -514,7 +530,7 @@ fn collect_leaf_dirs(
     // A read failure on a subdir is non-fatal: record it in warnings and
     // continue so partial results reach the caller instead of nothing.
     for subdir in subdirs {
-        if let Err(reason) = collect_leaf_dirs(&subdir, options, leaf_dirs, warnings) {
+        if let Err(reason) = collect_leaf_dirs(&subdir, options, leaf_dirs, warnings, visited) {
             warnings.push(ScanWarning { path: subdir, reason });
         }
     }
@@ -966,6 +982,70 @@ mod tests {
         let options = ScanOptions { follow_symlinks: true, workers: None };
         let items = scan_root(&scan_root_dir, &options).unwrap().items;
         assert_eq!(items.len(), 1, "junction is traversed when explicitly enabled");
+    }
+
+    /// Directory link usable on both lanes: a symlink on Unix, a junction on
+    /// Windows, where `is_symlink()` does not report the reparse point.
+    fn link_dir(link: &Path, target: &Path) {
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(target, link).unwrap();
+        #[cfg(windows)]
+        make_junction(link, target);
+    }
+
+    /// A link back to an ancestor is re-entered without a visited set, so the
+    /// one real directory is inventoried once per re-entry — 16 items where one
+    /// is expected. The walk still ends, because each re-entry adds a link
+    /// component and the OS caps symlink resolution (`ELOOP`), so the bound
+    /// comes from the platform rather than from the walker.
+    #[test]
+    fn opt_in_traversal_terminates_on_a_directory_cycle() {
+        let tmp = tmpdir();
+        let root = tmp.path().join("library");
+        let frames = root.join("frames");
+        fs::create_dir_all(&frames).unwrap();
+        write_file(&frames, "light_001.fits", b"light");
+        link_dir(&frames.join("back_to_root"), &root);
+
+        let options = ScanOptions { follow_symlinks: true, workers: None };
+        let items = scan_root(&root, &options).unwrap().items;
+        assert_eq!(items.len(), 1, "the one real frame is inventoried exactly once");
+    }
+
+    /// Constitution §I: the root itself is a link, and `is_dir()` follows it, so
+    /// the default scan walked into it. The gate applies to the root on the same
+    /// terms as to any entry below it.
+    #[test]
+    fn symlinked_scan_root_rejected_by_default() {
+        let tmp = tmpdir();
+        let real_root = tmp.path().join("real_root");
+        fs::create_dir_all(&real_root).unwrap();
+        write_file(&real_root, "hidden.fits", b"hidden");
+
+        let linked_root = tmp.path().join("linked_root");
+        link_dir(&linked_root, &real_root);
+
+        let error = scan_root(&linked_root, &ScanOptions::default())
+            .expect_err("a symlinked root must be refused while following is disabled");
+        assert!(
+            error.contains("scan root is unusable"),
+            "error must name the root as unusable, got: {error}"
+        );
+    }
+
+    #[test]
+    fn symlinked_scan_root_accepted_when_follow_symlinks_enabled() {
+        let tmp = tmpdir();
+        let real_root = tmp.path().join("real_root");
+        fs::create_dir_all(&real_root).unwrap();
+        write_file(&real_root, "visible.fits", b"visible");
+
+        let linked_root = tmp.path().join("linked_root");
+        link_dir(&linked_root, &real_root);
+
+        let options = ScanOptions { follow_symlinks: true, workers: None };
+        let items = scan_root(&linked_root, &options).unwrap().items;
+        assert_eq!(items.len(), 1, "a symlinked root is walkable when explicitly enabled");
     }
 
     /// Multi-leaf sort-order is deterministic regardless of OS readdir ordering

--- a/crates/fs/executor/src/reconcile.rs
+++ b/crates/fs/executor/src/reconcile.rs
@@ -52,6 +52,11 @@ pub enum ReconcileVerdict {
 /// The truth tables are the inverse of each operation's post-condition:
 /// a relocate leaves the source gone and the destination present; a remove
 /// leaves the source gone; a create leaves the destination present.
+///
+/// Presence means *an entry occupies the path*, not *the path resolves to a
+/// reachable target*: a dangling symlink is present. `Path::exists()` follows
+/// links and would report such an entry absent, healing a mutation that never
+/// completed.
 #[must_use]
 pub fn classify(
     shape: MutationShape,
@@ -62,7 +67,7 @@ pub fn classify(
         MutationShape::None => ReconcileVerdict::Completed,
         MutationShape::Relocate => match (source, destination) {
             (Some(src), Some(dst)) => {
-                match (src.exists(), dst.exists()) {
+                match (entry_present(src), entry_present(dst)) {
                     (false, true) => ReconcileVerdict::Completed,
                     (true, false) => ReconcileVerdict::NotStarted,
                     // Both present: a cross-volume copy that completed but whose
@@ -75,16 +80,25 @@ pub fn classify(
             _ => ReconcileVerdict::Ambiguous,
         },
         MutationShape::Remove => match source {
-            Some(src) if !src.exists() => ReconcileVerdict::Completed,
+            Some(src) if !entry_present(src) => ReconcileVerdict::Completed,
             Some(_) => ReconcileVerdict::NotStarted,
             None => ReconcileVerdict::Ambiguous,
         },
         MutationShape::Create => match destination {
-            Some(dst) if dst.exists() => ReconcileVerdict::Completed,
+            Some(dst) if entry_present(dst) => ReconcileVerdict::Completed,
             Some(_) => ReconcileVerdict::NotStarted,
             None => ReconcileVerdict::Ambiguous,
         },
     }
+}
+
+/// Whether an entry occupies `path`, without resolving it.
+///
+/// Matches `fs_pathsafe`'s reparse-aware probes and the link operation's
+/// pre-check: a dangling symlink or junction is an entry, so overwriting or
+/// re-running the mutation would still collide with it.
+fn entry_present(path: &Utf8Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok()
 }
 
 #[cfg(test)]
@@ -104,6 +118,64 @@ mod tests {
 
     fn absent(dir: &std::path::Path, name: &str) -> Utf8PathBuf {
         Utf8PathBuf::from_path_buf(dir.join(name)).unwrap()
+    }
+
+    /// An entry that occupies its path while resolving to nothing: the state
+    /// `Path::exists()` reports as absent.
+    ///
+    /// On Windows the reparse point is a junction created against a real
+    /// directory that is then removed — `mklink /J` needs no privilege, while
+    /// `symlink_file` does, and a junction cannot be created against a missing
+    /// target.
+    fn dangling_link(dir: &std::path::Path, name: &str) -> Utf8PathBuf {
+        let link = dir.join(name);
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(dir.join("no_such_target"), &link).unwrap();
+
+        #[cfg(windows)]
+        {
+            let target = dir.join(format!("{name}_target"));
+            std::fs::create_dir(&target).unwrap();
+            let status = std::process::Command::new("cmd")
+                .args(["/C", "mklink", "/J", link.to_str().unwrap(), target.to_str().unwrap()])
+                .status()
+                .expect("mklink invocation failed");
+            assert!(status.success(), "mklink /J failed to create the test junction");
+            std::fs::remove_dir(&target).unwrap();
+        }
+
+        assert!(!link.exists(), "fixture must be dangling: exists() has to answer false");
+        assert!(
+            std::fs::symlink_metadata(&link).is_ok(),
+            "fixture must still occupy its path as an entry"
+        );
+        Utf8PathBuf::from_path_buf(link).unwrap()
+    }
+
+    #[test]
+    fn relocate_ambiguous_when_source_holds_a_dangling_link() {
+        let d = tmp();
+        let src = dangling_link(d.path(), "src");
+        let dst = touch(d.path(), "dst");
+        assert_eq!(
+            classify(MutationShape::Relocate, Some(&src), Some(&dst)),
+            ReconcileVerdict::Ambiguous
+        );
+    }
+
+    #[test]
+    fn remove_not_started_when_source_holds_a_dangling_link() {
+        let d = tmp();
+        let src = dangling_link(d.path(), "src");
+        assert_eq!(classify(MutationShape::Remove, Some(&src), None), ReconcileVerdict::NotStarted);
+    }
+
+    #[test]
+    fn create_completed_when_destination_is_a_dangling_link() {
+        let d = tmp();
+        let dst = dangling_link(d.path(), "dst");
+        assert_eq!(classify(MutationShape::Create, None, Some(&dst)), ReconcileVerdict::Completed);
     }
 
     #[test]


### PR DESCRIPTION
Tracks-Bead: astro-plan-fv0ki
Merge-Bead: astro-plan-rkm6a

Work bead: `astro-plan-fv0ki` (LINK-1). Merge bead: `astro-plan-rkm6a`.
Findings: `astro-plan-3v3r.1.15` (P1), `astro-plan-3v3r.6.19` (P2).

Draft. An independent review is mandatory before this is marked ready.

## What changes

| Site | Before | After |
| --- | --- | --- |
| `crates/fs/executor/src/reconcile.rs` — all three `classify` presence arms | `Path::exists()` | `symlink_metadata().is_ok()` via one local `entry_present` |
| `crates/app/inbox/src/scan.rs:335` root gate | `root.is_dir()` | `fs_pathsafe::probe_root(root, options.follow_symlinks)` |
| `crates/app/inbox/src/scan.rs` `collect_leaf_dirs` | no visited set | canonical-path `HashSet`, consulted only when `follow_symlinks` is set |

## Reachability in production

Both defects are reachable in the shipped app. Reachability was established by
reading the call chain, not by running the app.

**`astro-plan-3v3r.1.15` — boot reconciliation.** `classify` is imported at
`crates/app/core/src/plan_apply/reconcile.rs:31`, called at `:115`, and a
`Completed` verdict is written to `succeeded` at `:117-130`. The production
entry point is the app-boot unclean-shutdown sweep at
`apps/desktop/src-tauri/src/lib.rs:684`. The trigger is an entry that exists on
disk while `exists()` answers false, which is a dangling symlink. The app
materializes symlinks itself (`crates/fs/executor/src/ops/link_op.rs`,
`fs_pathsafe::create_symlink` at `crates/fs/pathsafe/src/lib.rs:262`), and a
source-view link dangles as soon as its target drive is offline.

The finding names only the `Relocate` arm at `:65`. The `Remove` arm at `:78` is
the more live case: an interrupted delete whose source path holds a dangling
link reads `!exists() == true`, is judged `Completed`, and is auto-healed to
`succeeded` while the entry is still on disk. All three arms are fixed.

**`astro-plan-3v3r.6.19` — inbox scan cycle.** Reachable only with
`follow_symlinks` enabled, a user setting. The default entry gate at `:489`
holds and two committed tests pin it
(`symlinked_subdir_not_traversed_by_default`, and its opt-in counterpart). This
is a user-opted-in bug, not a default-path bug.

**The `:335` root gate is separate from `.6.19` and does affect the default
path.** With `follow_symlinks = false` and a symlinked scan root, `is_dir()`
followed the link and the scan walked into it.

## Correction to the brief's severity claim for `.6.19`

The brief states the missing visited set makes the recursion unbounded, i.e. a
stack overflow. That is not what the reverted-fix run shows. With the visited
set removed, `opt_in_traversal_terminates_on_a_directory_cycle` returned **16
items where 1 is expected** and the walk terminated. Each re-entry appends one
more link component to the path, and the OS caps symlink resolution (`ELOOP`),
so the bound comes from the platform rather than from the walker. The observed
defect is duplicate inventory rows — exactly what the bead describes, not worse.
The test docstring records this.

## Per-test evidence

Each production change was reverted individually, with the test kept, and the
named result observed. No blanket claim.

| Test | Bead | Revert applied | Observed at base |
| --- | --- | --- | --- |
| `reconcile::tests::relocate_ambiguous_when_source_holds_a_dangling_link` | `.1.15` | `entry_present` → `path.exists()` | FAIL — `Completed`, expected `Ambiguous` |
| `reconcile::tests::remove_not_started_when_source_holds_a_dangling_link` | `.1.15` | same | FAIL — `Completed`, expected `NotStarted` |
| `reconcile::tests::create_completed_when_destination_is_a_dangling_link` | `.1.15` | same | FAIL — `NotStarted`, expected `Completed` |
| `scan::tests::symlinked_scan_root_rejected_by_default` | root gate (`:335`) | `probe_root` → `!root.is_dir()` | FAIL — returned `Ok` with 1 inbox item behind the symlinked root |
| `scan::tests::opt_in_traversal_terminates_on_a_directory_cycle` | `.6.19` | visited-set early return removed | FAIL — 16 items, expected 1 |
| `scan::tests::symlinked_scan_root_accepted_when_follow_symlinks_enabled` | — | `probe_root` → `!root.is_dir()` | PASS at base. This test guards against over-gating; it reproduces no defect and is labelled as such rather than counted as evidence. |

Every assertion is on a non-empty expected value (an enum variant or an item
count of 1), so none can pass vacuously.

Both lanes are covered without `cfg(unix)`-only guards. `scan.rs` gains one
`link_dir` helper that is `std::os::unix::fs::symlink` on Unix and the existing
`make_junction` (`mklink /J`) on Windows, so each new traversal test runs on
both. `reconcile.rs` gains `dangling_link`, which on Windows builds a junction
against a real directory and then removes the directory — `mklink /J` needs no
privilege, `symlink_file` does, and a junction cannot be created against a
missing target. The helper asserts its own fixture: `exists()` false and
`symlink_metadata` ok.

## Enumerations

**`exists()` in `crates/fs/executor/src/reconcile.rs` — three arms, all
changed:** `:65` `Relocate` (both endpoints), `:78` `Remove`, `:83` `Create`.
`git grep` shows no remaining `exists()` in that file.

**Production `read_dir` census** re-run as
`git grep -n read_dir origin/main -- crates apps tools`, test modules excluded.
The brief's seven sites are confirmed unchanged: `apps/desktop/src-tauri/src/lib.rs:575`
(flat backup prune), `apps/desktop/src-tauri/src/main.rs:19` (flat log dir),
`apps/desktop/src-tauri/src/watcher.rs:191` (delegates to `fs_pathsafe`),
`crates/app/inbox/src/classify.rs:1616` (non-recursive, link-gated at `:1621`),
`crates/app/inbox/src/scan.rs:459` (the defect), `crates/workflow/profiles/src/discover.rs:165`
(flat executable probe), `crates/workflow/artifacts/src/reconciler.rs:99`
(injected fn, no walk).

Three further production sites appear that the brief's list omits, all inside
`fs_pathsafe` itself: `crates/fs/pathsafe/src/lib.rs:143` (`probe_root`), `:172`
(`real_dirs_under`), `:232` (`real_files_under_reporting`). These are the gated
walkers the census treats as the safe destination, so the list is complete
rather than wrong. No addition outside them. `collect_leaf_dirs` was the only
hand-rolled recursive production walker left, and it now carries the same
visited-set shape as `fs_pathsafe`.

## Out of scope, not fixed

- `astro-plan-3v3r.20.27` is FALSE at `origin/main`. `fs_pathsafe::real_files_under`
  delegates to `real_files_under_reporting`, which is iterative and already
  deduplicates by canonical path. `fs_pathsafe` terminates; this PR makes no
  claim otherwise and does not touch the crate beyond calling `probe_root`.
- `astro-plan-3v3r.8.28`'s premise is FALSE at `origin/main`
  (`apps/desktop/src-tauri/src/watcher.rs:191-197` delegates to `fs_pathsafe`).
  Its residual — no depth or entry cap, a memory bound rather than a termination
  bug — is filed as `astro-plan-q52k8` and not fixed here.
- No schema change. No migration.
- No comparator or sort touched, so no ordering change.

## Verification

Run with a dedicated `CARGO_TARGET_DIR`.

| Command | Result |
| --- | --- |
| `cargo test -p fs_executor -p app_core_inbox` | 386 passed, 1 ignored, 7 suites |
| `cargo clippy -p fs_executor -p app_core_inbox --all-targets` | clean |
| `cargo clippy --workspace --all-targets -- -D warnings` (via `just lint`) | clean; zero findings in the two changed files |
| `cargo fmt --all --check` (via `just lint`) | clean |
| `just check` | exits 1 at `lint`, solely on the pre-existing `appliable` → `applicable` typo in `crates/app/inbox/src/confirm.rs` (5 occurrences, all inside `mod tests`), tracked as `astro-plan-8vxx1`. Not introduced here. |
| `just typecheck check-generated lifecycle-strings` | pass |
| `just db-boundary dead-callers hot-read test-targets` | pass |

`just check` stops at its first dependency, so the recipes after `lint` never
run under it. They were run directly, listed above, to confirm nothing hides
behind `astro-plan-8vxx1`. The one workspace-wide `just test` attempt aborted on
a nextest `double-spawn` error after the dedicated target directory was deleted
mid-run under disk pressure (9.9 GiB free); the two changed crates were re-run
green afterwards and CI covers the rest of the workspace.
