### PR TITLE
ci: fail the build when a test run selects zero tests instead of reporting success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,15 +549,27 @@ jobs:
             cargo nextest run --workspace --profile ci
           else
             echo "Running scoped tests for: $args"
-            # --no-tests=pass: a scoped crate set can legitimately contain
-            # zero runnable tests (e.g. an e2e_tests-only change — all its
-            # tests are #[ignore]d for the Layer-2 e2e.yml job), and nextest
-            # otherwise exits 4 ("no tests to run", run 28751553778).
+            # A scoped crate set can legitimately contain zero runnable tests
+            # (e.g. an e2e_tests-only change — all its tests are #[ignore]d for
+            # the Layer-2 e2e.yml job, run 28751553778), so nextest's default
+            # exit 4 is wrong here. A bare --no-tests=pass is wrong too: it also
+            # swallows a broken scripts/ci-affected-crates.sh output, and the job
+            # goes green having run nothing. Count the selection first, so the
+            # zero case is an announced exemption rather than a silent one.
+            # `nextest list` exits 0 on an empty selection, so the count is safe
+            # under `pipefail`.
             #
             # $args is a word list of `-p <crate>` flags and has to split, so the
             # SC2086 quote would collapse it into one bad argument.
             # shellcheck disable=SC2086
-            cargo nextest run --profile ci --no-tests=pass $args
+            selected=$(cargo nextest list --profile ci --message-format oneline $args | wc -l | tr -d '[:space:]')
+            echo "Scoped selection: ${selected} test(s)."
+            if [ "$selected" -eq 0 ]; then
+              echo "::notice::Exemption: the scoped crate set contains zero runnable tests; nextest is not invoked."
+            else
+              # shellcheck disable=SC2086
+              cargo nextest run --profile ci $args
+            fi
           fi
 
       # nextest does not run doctests; keep them in a dedicated step. Doctest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,8 +40,11 @@
 #   Layer-1 `cargo test --workspace` job (ci.yml) — which has no
 #   tauri-webdriver CLI, no e2e-feature app build, and no served frontend —
 #   skips them; this workflow opts back in with `--run-ignored all`.
-#   `--no-tests=warn` is kept only as a defensive fallback; it should never
-#   actually trigger since every journey runs on both Linux and Windows.
+#   Every nextest invocation here spells `--no-tests=fail` explicitly:
+#   `taiki-e/install-action@nextest` installs the latest release, so nextest's
+#   own default is not pinned by this workflow. An empty selection means a
+#   filter, shard partition, or archive is broken, never that there is nothing
+#   to run.
 # - The Linux + Windows matrix proves the runner AND the journeys work on the
 #   supported platforms.
 # - This workflow runs independently of ci.yml (Layer-1 integration). Ordering /
@@ -818,8 +821,9 @@ jobs:
         # --filter-expr selects exactly the smoke subset by test name. The
         # expression is an OR of exact name matches — no glob, no substring —
         # so a new journey with a similar name does not silently join the smoke
-        # run. `--no-tests=warn` is a defensive fallback (the filter should
-        # always match at least one test).
+        # run. This job publishes a branch-protection-required check and has no
+        # shard-coverage check behind it, so `--no-tests=fail` is the only thing
+        # standing between a renamed journey and a green check that ran nothing.
         run: >-
           xvfb-run -s "-screen 0 1600x1200x24" -a
           cargo nextest run
@@ -827,7 +831,7 @@ jobs:
           --workspace-remap .
           --profile e2e
           --run-ignored all
-          --no-tests=warn
+          --no-tests=fail
           --filter-expr 'test(all_top_level_screens_load) | test(inbox_ui_mixed_folder_splits_into_single_type_items) | test(targets_ui_add_target_no_duplicate_on_reconfirm)'
 
   # Gate for the smoke job, and the ONLY publisher of
@@ -999,7 +1003,7 @@ jobs:
           WEBKIT_DISABLE_DMABUF_RENDERER: "1"
           WEBKIT_DISABLE_COMPOSITING_MODE: "1"
           PV_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
-        run: xvfb-run -s "-screen 0 1600x1200x24" -a cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition hash:${{ matrix.shard }}/4
+        run: xvfb-run -s "-screen 0 1600x1200x24" -a cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=fail --partition hash:${{ matrix.shard }}/4
 
   # Copy of real-ui-e2e-ubuntu for Windows (no Linux deps/xvfb/chmod).
   #
@@ -1160,6 +1164,13 @@ jobs:
             --run-ignored all --message-format oneline \
             -E "${SHARD1} | ${SHARD2} | ${SHARD3}" | wc -l)
           echo "Total tests: ${TOTAL}, covered by shard union: ${UNION}"
+          # An empty or truncated archive makes both counts 0, which satisfies
+          # the equality below — the coverage check would pass having measured
+          # nothing. Assert a positive total before comparing.
+          if [ "${TOTAL}" -eq 0 ]; then
+            echo "::error::Archive lists zero tests. The e2e archive is empty or truncated; shard coverage cannot be verified."
+            exit 1
+          fi
           if [ "${TOTAL}" != "${UNION}" ]; then
             echo "::error::Shard coverage gap: ${TOTAL} tests in archive but only ${UNION} covered by the three shard filters. Add the missing test(s) to an -E expression."
             exit 1
@@ -1177,7 +1188,7 @@ jobs:
           --workspace-remap .
           --profile e2e
           --run-ignored all
-          --no-tests=warn
+          --no-tests=fail
           -E 'test(=slow_targets_ui_dock_pin_and_width_survive_a_real_restart) | test(=inbox_ui_missing_path_attribute_banner_blocks_confirm) | test(=inbox_ui_mixed_folder_splits_into_single_type_items) | test(=inbox_ui_unsplit_unclassified_folder_badge_is_not_classified) | test(=settings_ui_theme_applies_live_and_persists_to_settings_db)'
 
       # Shard 2 (~103s): slow_archive (25.5s) + 11 mid-range tests.
@@ -1192,7 +1203,7 @@ jobs:
           --workspace-remap .
           --profile e2e
           --run-ignored all
-          --no-tests=warn
+          --no-tests=fail
           -E 'test(=slow_archive_lifecycle_apply_trash_permanent_delete) | test(=targets_planner_real_astronomy_after_site_creation) | test(=targets_ui_identity_columns_stay_pinned_while_table_scrolls) | binary(calibration_ui_journeys) | binary(lifecycle_ui_journeys) | binary(source_view_journeys) | test(=ingestion_sessions_search) | binary(sessions_journeys) | test(=plan_review_empty_archive_plan_refuses_apply) | test(=plan_review_apply_with_audit) | test(=lifecycle_integrity)'
 
       # Shard 3 (~104s): no slow_ test, 13 mid-range tests.
@@ -1207,7 +1218,7 @@ jobs:
           --workspace-remap .
           --profile e2e
           --run-ignored all
-          --no-tests=warn
+          --no-tests=fail
           -E 'test(=inbox_ui_confirm_does_not_move_then_apply_moves_to_shown_destination) | binary(smoke) | test(=targets_ui_add_target_no_duplicate_on_reconfirm) | binary(inventory_journeys) | test(=cleanup_plan_review) | test(=inbox_ui_catalogue_in_place_zero_moves_byte_identical) | test(=plan_review_destructive_confirm_gate_and_apply) | test(=targets_ui_astronomy_columns_disclose_placeholder_without_site) | binary(onboarding_journey) | binary(cleanup_protection_gate_journey) | test(=first_run_resolve_create_project) | test(=inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm) | test(=settings_ui_ingestion_toggle_autosaves_no_global_save_button)'
 
   # Copy of real-ui-e2e-ubuntu for the dispatch-only macOS chain (issue #489):
@@ -1302,7 +1313,7 @@ jobs:
         shell: bash
         env:
           PV_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
-        run: cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition hash:${{ matrix.shard }}/2
+        run: cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=fail --partition hash:${{ matrix.shard }}/2
 
   # ---------------------------------------------------------------------------
   # Per-OS gates preserving the pre-DAG check names ("Real-UI E2E — <os>").

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -50,6 +50,5 @@ export default defineConfig({
     // Exclude Playwright e2e specs and any node_modules.
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
     exclude: ["node_modules/**", "dist/**", "../../tests/e2e/**"],
-    passWithNoTests: true,
   },
 });

--- a/specs/tiny/zero-test-selection-fails-ci.md
+++ b/specs/tiny/zero-test-selection-fails-ci.md
@@ -1,0 +1,110 @@
+# TinySpec: A test invocation that selects zero tests fails its CI job
+
+**Branch**: fix/gate1-ci-zero-test-selection
+**Date**: 2026-08-23
+**Status**: draft
+**Complexity**: small
+
+## What
+
+Seven CI test invocations exit 0 when their selection matches zero tests, so the
+job reports success having executed nothing. Six are `cargo nextest`
+invocations in `.github/workflows/e2e.yml` carrying `--no-tests=warn`; one is
+the scoped-crate `cargo nextest` invocation in `.github/workflows/ci.yml`
+carrying `--no-tests=pass`. The frontend lane has the same defect one layer
+down: `apps/desktop/vitest.config.ts` sets `passWithNoTests: true`, and the
+shard-coverage integrity check in `e2e.yml` compares two counts that are equal
+when both are zero.
+
+This is a CI-signal defect. No runtime path in the shipped application is
+affected.
+
+## The rule (decision)
+
+**Every CI test invocation either fails when its selection is empty, or asserts
+a positive selected count. `--no-tests=pass` survives only on a path that
+announces the exemption by name.**
+
+### Rust test invocations spell `--no-tests=fail`
+
+All six `e2e.yml` invocations carry an explicit `--no-tests=fail`, including the
+dispatch-only macOS shard. `fail` is written out rather than left to nextest's
+`auto` default because `taiki-e/install-action@nextest` installs the latest
+release, so the default is not pinned by the workflow.
+
+### The scoped `ci.yml` invocation asserts a count before it may pass
+
+A scoped crate set can legitimately select zero runnable tests (an
+`e2e_tests`-only change, whose tests are `#[ignore]`d for `e2e.yml`). The step
+therefore lists the scoped selection first, prints the count, and takes the
+zero-count path only as a named, log-announced exemption. The general path
+carries no `--no-tests=pass`.
+
+### Vitest fails on an empty selection
+
+`passWithNoTests` is absent from `apps/desktop/vitest.config.ts`, so an empty
+selection exits non-zero. The `vitest related` fallback in `ci.yml` keys on the
+`No test files found` message, not on the exit code, so it continues to fall
+back to the full suite rather than propagating the failure.
+
+### The shard-coverage check asserts a positive total
+
+`TOTAL` must be greater than zero before `TOTAL` and `UNION` are compared, so an
+empty or truncated archive fails the check instead of satisfying it by equality.
+
+## Per-finding verdict at head `efaaf57a0d800a91efab5437d6d4eac32cc78ad5`
+
+| Bead | Site at head | Reachable | Verdict |
+| --- | --- | --- | --- |
+| `astro-plan-3v3r.17.20` | `.github/workflows/e2e.yml:830` (`smoke-ubuntu`) | YES — renaming any of the three journeys in the `--filter-expr` matches zero tests; `--no-tests=warn` exits 0 and the branch-protection-required check `Real-UI smoke (L3) — ubuntu-latest` reports success. The smoke job has no shard-coverage check. | FIXED |
+| `astro-plan-3v3r.17.20` | `.github/workflows/e2e.yml:1002, 1180, 1195, 1210, 1305` | YES — a stale or truncated `e2e-archive.tar.zst` makes every `--partition` shard select zero tests; all exit 0 and the aggregate gate turns green. | FIXED |
+| `astro-plan-3v3r.17.20` | `.github/workflows/ci.yml:560` (`integration`, scoped branch) | YES — a `scripts/ci-affected-crates.sh` output naming only crates without runnable tests selects zero tests and exits 0. | FIXED — count assertion, exemption announced |
+| `astro-plan-3v3r.15.8` | duplicate of `.17.20`, same seven sites | YES | FIXED by the same change |
+| M1 (no bead; found in this unit) | `apps/desktop/vitest.config.ts:53` | YES — if the `include` glob `src/**/*.{test,spec}.{ts,tsx}` stops matching (specs move out of `src/`, or the naming convention changes) the full suite runs zero specs and exits 0, defeating the `ci.yml` `No test files found` fallback. | FIXED |
+| M2 (no bead; found in this unit) | `.github/workflows/e2e.yml:1155-1167` | YES — both counts are 0 on an empty archive, they compare equal, and the integrity check passes. | FIXED |
+| M3 | `.github/workflows/ci.yml:614` `pnpm ... -r --if-present test` | Latent, not live — the only matched package is `packages/contracts`, whose `test` script is an `&&` chain of named node scripts and fails loudly. | DEFERRED to `astro-plan-f6qg1`; removing `--if-present` would redden a newly added script-less package |
+
+Census-closing non-defects at the same head:
+
+- `ci.yml:550` `cargo nextest run --workspace --profile ci` (full-suite branch) — unfiltered; nextest's default exits 4 on zero tests.
+- `ci.yml:567` `cargo test --workspace --doc` — unfiltered; zero doctests is not a selection bug.
+- `apps/desktop` Playwright — `apps/desktop/playwright.config.ts` sets no `passWithNoTests`, so Playwright exits 1 when it finds no tests.
+- `release-gate.yml:176` `cargo test --workspace` — unfiltered and `continue-on-error: true` by design.
+
+## Context
+
+| File | Role |
+| --- | --- |
+| `.github/workflows/e2e.yml` | Modify — six `--no-tests` values, the two comments defending `warn`, the shard-coverage check |
+| `.github/workflows/ci.yml` | Modify — scoped-crate step: list-and-count before running |
+| `apps/desktop/vitest.config.ts` | Modify — delete `passWithNoTests` |
+
+## Requirements
+
+1. No `--no-tests=warn` remains in `.github/workflows/`.
+2. Each of the six `e2e.yml` nextest invocations carries `--no-tests=fail`.
+3. Comments describing `--no-tests=warn` as a defensive fallback are removed.
+4. The `ci.yml` scoped step prints the selected test count and exits non-zero on a zero count unless it announces the exemption by name in the log.
+5. `apps/desktop/vitest.config.ts` sets no `passWithNoTests`; `pnpm exec vitest run <no-match>` exits non-zero.
+6. The `ci.yml` `vitest related` fallback still runs the full suite when no dependent spec exists, keyed on the `No test files found` message rather than the exit code.
+7. The shard-coverage check exits non-zero when `TOTAL` is 0, with a distinct `::error::` message.
+8. Every edited step remains shell-portable and keeps its `shell: bash`.
+
+## Tasks
+
+- [x] Replace `--no-tests=warn` with `--no-tests=fail` at the six `e2e.yml` sites
+- [x] Remove the two comments defending `--no-tests=warn`
+- [x] Add the list-and-count guard to the `ci.yml` scoped-crate step
+- [x] Delete `passWithNoTests` from `apps/desktop/vitest.config.ts`
+- [x] Add the `TOTAL -gt 0` assertion to the shard-coverage check
+- [x] Record the zero-selection exit code at each changed site, before and after
+- [x] File a bead for M3 (`astro-plan-f6qg1`)
+
+## Done When
+
+- [ ] `git grep -c 'no-tests=warn' .github/workflows/` returns no matches
+- [ ] `git grep -c passWithNoTests apps packages` returns no matches
+- [ ] `cargo nextest run -p safe-filename -E 'test(=zzz_no_such_test)' --no-tests=fail` exits 4
+- [ ] `pnpm exec vitest run zzz-no-such-spec` in `apps/desktop` exits non-zero
+- [ ] The shard-coverage body run with `TOTAL=0 UNION=0` exits 1
+- [ ] `actionlint` accepts both edited workflows


### PR DESCRIPTION
## What

Seven CI test invocations exited 0 when their selection matched zero tests, so the job reported success having executed nothing. Every downstream gate then read green as "the suite passed" when the correct reading was "the suite never ran".

**This is a CI-signal defect. No runtime path in the shipped application is affected.** The defect **was reachable** — see below.

TinySpec: [`specs/tiny/zero-test-selection-fails-ci.md`](specs/tiny/zero-test-selection-fails-ci.md). Rule: *every CI test invocation either fails when its selection is empty, or asserts a positive selected count; `--no-tests=pass` survives only on a path that announces the exemption by name.*

## Reachability

1. **Smoke job.** Rename any of the three journeys in `smoke-ubuntu`'s `--filter-expr` (`all_top_level_screens_load`, `inbox_ui_mixed_folder_splits_into_single_type_items`, `targets_ui_add_target_no_duplicate_on_reconfirm`). The expression is an OR of exact name matches, so it then matched zero tests, `--no-tests=warn` exited 0, and the branch-protection-required check `Real-UI smoke (L3) — ubuntu-latest` reported success on every PR having executed no journey. Unlike the Windows shards, that job has **no** shard-coverage check behind it.
2. **Shard archive.** A stale or truncated `e2e-archive.tar.zst` made all four `--partition hash:N/4` ubuntu shards select zero tests. All four exited 0 and `e2e-gate-ubuntu` — whose header comment claims green "means the shards genuinely executed and passed" — turned green.

## Census at base `efaaf57a0d800a91efab5437d6d4eac32cc78ad5`

Line numbers below are at the base sha, verified with `git grep` (`.gitignore` hides `ci.yml` from `rg` and from repomix, so an `rg`-based census misses it silently).

| # | Site at base | Shape | Fix |
| --- | --- | --- | --- |
| 1 | `.github/workflows/e2e.yml:830` — `smoke-ubuntu`, "Run L3 smoke (3 journeys via filter-expr)" | `--no-tests=warn` + `--filter-expr`, no coverage check | `--no-tests=fail` |
| 2 | `.github/workflows/e2e.yml:1002` — `real-ui-e2e-ubuntu`, "Run E2E (xvfb)" | `--no-tests=warn` + `--partition hash:N/4` | `--no-tests=fail` |
| 3 | `.github/workflows/e2e.yml:1180` — `real-ui-e2e-windows`, "Run E2E (shard 1/3)" | `--no-tests=warn` + pure `-E` | `--no-tests=fail` |
| 4 | `.github/workflows/e2e.yml:1195` — "Run E2E (shard 2/3)" | same | `--no-tests=fail` |
| 5 | `.github/workflows/e2e.yml:1210` — "Run E2E (shard 3/3)" | same | `--no-tests=fail` |
| 6 | `.github/workflows/e2e.yml:1305` — `real-ui-e2e-macos`, "Run E2E" | `--no-tests=warn` + `hash:N/2`, dispatch-only | `--no-tests=fail` |
| 7 | `.github/workflows/ci.yml:560` — `integration`, "Rust tests (L1+L2 …)", scoped branch | `--no-tests=pass` | list-and-count guard, announced exemption |

**Correcting the plan:** the plan states `ci.yml:552,560 --no-tests=pass`, implying two ci.yml sites. There is exactly **one** `--no-tests=pass` invocation in ci.yml (`:560`); `:552` is its explanatory comment. 6 + 1 = the 7 sites named.

`--no-tests=fail` is written out at all six rather than left to nextest's `auto` default, because `taiki-e/install-action@nextest` installs the latest release, so the default is not pinned by the workflow. Verified against the accepted value set of the installed nextest (0.9.132): `auto | pass | warn | fail`.

Site 7 is **not** simply flipped. Its comment documents a legitimate zero-test scoped set (an `e2e_tests`-only change, all tests `#[ignore]`d for e2e.yml, run 28751553778). The step now lists the scoped selection, prints the count, and takes the zero path only as a log-announced named exemption; the general path carries no `--no-tests=pass`. `cargo nextest list` exits 0 on an empty selection, so the count survives the runner's `pipefail`.

The two comments defending `--no-tests=warn` as a "defensive fallback" (base `e2e.yml:43` and `:824`) were **removed alongside the flag** and replaced with the reason `fail` is spelled explicitly.

### Sites the plan missed

Found by searching every test-invocation verb in the repo (`nextest run`, `nextest list`, `cargo test`, `vitest run`, `vitest related`, `playwright test`, `pnpm -r … test`) rather than the `--no-tests` flag.

**M1 — `apps/desktop/vitest.config.ts:53` `passWithNoTests: true`. Fixed by deletion.** ci.yml already carries the correct guard for this class: when `vitest related` prints `No test files found` the step falls back to the full suite rather than "reporting a vacuous pass" (its own words). The config flag defeated that: had the `include` glob `src/**/*.{test,spec}.{ts,tsx}` stopped matching, the *full* suite would have run zero of its 270 specs and exited 0. Confirmed the fallback still works — without the flag vitest prints `No test files found, exiting with code 1`, and the step greps the message **before** checking the exit code.

**M2 — `.github/workflows/e2e.yml` "Verify shard coverage" (base `:1155-1167`). Fixed.** It compared `TOTAL` against `UNION` from two `cargo nextest list | wc -l` calls; on an empty or truncated archive both were `0`, compared equal, and the integrity check passed — the vacuous-pass pattern inside the guard meant to prevent a coverage gap. Now asserts `TOTAL -gt 0` with a distinct `::error::` message before comparing.

**M3 — `.github/workflows/ci.yml:614` `pnpm --filter='!./apps/desktop' --filter='!.' -r --if-present test`. Deferred, not changed.** `--if-present` silently no-ops for any matched package lacking a `test` script. Today the only matched package is `packages/contracts`, whose `test` is an explicit `&&` chain of named node scripts and so fails loudly, making this latent rather than live. Dropping the flag would turn a newly added script-less package red — a false failure. Filed as **`astro-plan-f6qg1`**.

### Census-closing non-defects, all re-confirmed at the base sha

- `ci.yml:549` `cargo nextest run --workspace --profile ci` (full-suite branch) — unfiltered, and nextest's default exits 4 on zero tests. Fails closed.
- `ci.yml:567` `cargo test --workspace --doc` — unfiltered; zero doctests is not a selection bug.
- `pnpm --filter @astro-plan/desktop test:e2e` — `apps/desktop/playwright.config.ts` has **no** `passWithNoTests`, so Playwright exits 1 when it finds no tests.
- `release-gate.yml:176` `cargo test --workspace` — unfiltered and `continue-on-error: true`, a soft check by design.

## Per-site evidence: every demonstration confirmed failing at base

No Rust test is added by this change, so the obligation is discharged as recorded exit codes per site, each confirmed at base and after. `safe-filename` is the leaf crate used for the nextest halves (note: crate name is `safe-filename`, not `safe_filename`; `-p safe_filename` exits 101 as an unmatched package spec). No workspace build was started.

| Site | Demonstration | At base | After fix |
| --- | --- | --- | --- |
| 1-6 (`e2e.yml`) | `cargo nextest run -p safe-filename -E 'test(=zzz_no_such_test)' --no-tests=warn` vs `--no-tests=fail` | **exit 0** (`0 tests run: 0 passed, 34 skipped`) | **exit 4** (`error: no tests to run`) |
| 7 (`ci.yml`) | same with `--no-tests=pass` | **exit 0**, silent | count guard prints `Scoped selection: 0 test(s).` + `::notice::Exemption:…`, exit 0 **announced**; a positive selection prints `Scoped selection: 34 test(s).` and runs nextest with no `--no-tests` override, so its default fails closed |
| M1 (`vitest.config.ts`) | `pnpm exec vitest run zzz-no-such-spec` in `apps/desktop` | **exit 0** | **exit 1** |
| M2 (shard coverage) | the step's shell body under `bash -eo pipefail` with `TOTAL=0 UNION=0` | **exit 0** | **exit 1** with the new `::error::` |

Reference exit codes for the installed nextest 0.9.132 on the zero-selection case: `warn` → 0, `pass` → 0, `fail` → 4, default `auto` → 4.

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml` → exit 0
- `python3 yaml.safe_load` on both workflows → parses
- `git grep -c 'no-tests=warn' -- .github/workflows/` → no matches
- `git grep -c passWithNoTests -- apps packages` → no matches
- `origin/main` merged at `0f8cff68c` and the merge read: clean, touching only `crates/app/inbox/src/scan.rs` and `crates/fs/executor/src/reconcile.rs` — disjoint from this change. Invariant greps and actionlint re-run after the merge.
- Windows shard steps keep their `shell: bash`; no edit introduces a non-portable construct.

PR #1718 (the serialization concern in the plan) is **merged** and touched `e2e-alert.yml`, not `ci.yml` or `e2e.yml`. No overlap.

## Beads

- Work bead: `astro-plan-l7r1n`
- Merge bead: `astro-plan-rvmwx`
- Findings addressed: `astro-plan-3v3r.17.20`; `astro-plan-3v3r.15.8` is a **duplicate** of it, same seven sites
- Filed: `astro-plan-f6qg1` (M3)

**No bead was closed by this author.** Beads close on merge.
