### PR TITLE
fix: stop metadata values from adding folder levels to planned destinations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5355,6 +5355,7 @@ dependencies = [
  "rstest",
  "thiserror 2.0.19",
  "unicode-normalization",
+ "unicode-script",
  "unicode-security",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ quick-xml = "0.41"
 sha2 = "0.10"
 tempfile = "3"
 unicode-normalization = "0.1"
+unicode-script = "0.5"
 unicode-security = "0.1"
 # Ratified stack (spec 002 2026-05-23 — wired with network access):
 #   sqlx 0.9 renamed runtime-tokio-rustls -> runtime-tokio + tls-rustls (two separate features).

--- a/crates/app/core/src/patterns.rs
+++ b/crates/app/core/src/patterns.rs
@@ -230,6 +230,13 @@ fn map_resolve_error(e: ResolveError) -> ContractError {
             "resolvedLength": resolved_length,
             "segmentLengthBytes": segment_length_bytes
         })),
+        ResolveError::EmptySegment { value } => ContractError::new(
+            ErrorCode::PatternInvalid,
+            format!("Pattern segment is empty after sanitization: {value}"),
+            ErrorSeverity::Blocking,
+            false,
+        )
+        .with_details(serde_json::json!({ "offendingValue": value })),
     }
 }
 

--- a/crates/app/projects/src/source_view_generate/mod.rs
+++ b/crates/app/projects/src/source_view_generate/mod.rs
@@ -74,10 +74,11 @@ fn layout_resolve_err(
     let code = match e {
         ResolveError::PathTraversal { .. } => ErrorCode::PathTraversal,
         ResolveError::ReservedName { .. } => ErrorCode::PathReservedName,
-        ResolveError::Empty | ResolveError::UnknownToken { .. } => ErrorCode::PathInvalid,
-        ResolveError::UnicodeConfusable { .. } | ResolveError::PathTooLong { .. } => {
-            ErrorCode::PathInvalid
-        }
+        ResolveError::Empty
+        | ResolveError::UnknownToken { .. }
+        | ResolveError::UnicodeConfusable { .. }
+        | ResolveError::PathTooLong { .. }
+        | ResolveError::EmptySegment { .. } => ErrorCode::PathInvalid,
     };
     contracts_core::ContractError::new(
         code,

--- a/crates/patterns/src/resolver.rs
+++ b/crates/patterns/src/resolver.rs
@@ -20,7 +20,7 @@
 
 use std::collections::HashMap;
 
-use safe_filename::{sanitize_token_value, SanitizeError};
+use safe_filename::{sanitize_token_value, step4_reserved_name_check, SanitizeError};
 
 use crate::registry::{TokenRegistry, TokenTransform};
 use crate::validator::{validate, ValidationWarning};
@@ -98,6 +98,10 @@ pub enum ResolveError {
     /// (data-model.md `pattern.invalid`).
     #[error("path length violated: resolved_length={resolved_length}, segment_length_bytes={segment_length_bytes}")]
     PathTooLong { resolved_length: usize, segment_length_bytes: usize },
+    /// A literal pattern segment sanitized to nothing, so the pattern names a
+    /// path level that cannot be rendered (data-model.md `pattern.invalid`).
+    #[error("pattern segment is empty after sanitization: {value}")]
+    EmptySegment { value: String },
 }
 
 // ── resolve ───────────────────────────────────────────────────────────────
@@ -133,39 +137,12 @@ pub fn resolve(
     for part in pattern {
         match part.kind.as_str() {
             "token" => {
-                let def = registry
-                    .get(&part.value)
-                    .ok_or_else(|| ResolveError::UnknownToken { token: part.value.clone() })?;
-
-                // Look up the source field in the metadata bundle.
-                let raw_opt = metadata.get(def.source_field).filter(|s| !s.is_empty());
-
-                let (raw, is_fallback) =
-                    if let Some(v) = raw_opt { (v.as_str(), false) } else { (def.fallback, true) };
-
-                if is_fallback {
-                    missing_tokens.push(part.value.clone());
-                }
-
-                // Apply transform before sanitize (some transforms can produce
-                // different chars; sanitize runs after).
-                let transformed = apply_transform(raw, def.transform);
-
-                // Sanitize.
-                let sanitized =
-                    sanitize_token_value(&part.value, &transformed).map_err(map_sanitize_error)?;
-
-                // If sanitize ate the entire value, use the fallback.
-                let final_value = if sanitized.is_empty() {
-                    if !is_fallback {
-                        missing_tokens.push(part.value.clone());
-                    }
-                    def.fallback.to_owned()
-                } else {
-                    sanitized
-                };
-
-                parts.push(final_value);
+                parts.push(resolve_one_token(
+                    &part.value,
+                    metadata,
+                    registry,
+                    &mut missing_tokens,
+                )?);
             }
             "separator" => {
                 // Separators are already validated; emit as-is.
@@ -217,7 +194,8 @@ pub fn resolve_v1(
 ///   is pushed onto `missing_tokens`.
 /// - Literal text is sanitized for filesystem safety (same pipeline as token
 ///   values) and emitted verbatim; literals are **never** added to
-///   `missing_tokens`.
+///   `missing_tokens`. A literal the sanitizer empties is a hard error, since a
+///   literal has no fallback and a dropped segment loses a named path level.
 ///
 /// `relative_path` follows the same convention as [`resolve`]: forward-slash
 /// joined, no leading slash, and no empty trailing segment (a trailing `/` in
@@ -258,12 +236,7 @@ fn resolve_pattern_str_with(
             // joined path has no empty components (matches resolve()).
             continue;
         }
-        let resolved = resolve_segment(raw_segment, bundle, registry, &mut missing_tokens)?;
-        // A segment that sanitizes to empty (e.g. a literal of only dots) is
-        // dropped rather than producing an empty path component.
-        if !resolved.is_empty() {
-            segments.push(resolved);
-        }
+        segments.push(resolve_segment(raw_segment, bundle, registry, &mut missing_tokens)?);
     }
 
     let relative_path = segments.join("/");
@@ -273,14 +246,15 @@ fn resolve_pattern_str_with(
     Ok(ResolveResult { relative_path, missing_tokens, warnings: Vec::new() })
 }
 
-/// Traversal guard and length caps applied to an assembled relative path.
+/// Traversal, reserved-name, and length checks applied to an assembled relative
+/// path.
 ///
-/// Per-piece sanitization cannot see traversal that only appears once the
-/// pieces are joined: a segment of `{filter}.` whose token value sanitizes to
-/// `.` assembles to `..`. Both resolvers therefore re-check the assembled
-/// string, and they must apply the same policy -- a resolver that skips this
-/// hands its caller a destination that escapes the root it was resolved
-/// against.
+/// Per-piece sanitization cannot see what only appears once the pieces are
+/// joined: a segment built as literal `CO` plus a token resolving to `N` is the
+/// device name `CON`, and no per-piece step-4 call sees it. Both resolvers
+/// therefore re-check the assembled string, and they must apply the same policy
+/// -- a resolver that skips this hands its caller a destination that escapes the
+/// root it was resolved against.
 fn check_assembled_path(relative_path: &str, config: &ResolverConfig) -> Result<(), ResolveError> {
     for segment in relative_path.split('/') {
         if segment == ".." || segment == "." {
@@ -289,6 +263,7 @@ fn check_assembled_path(relative_path: &str, config: &ResolverConfig) -> Result<
         if segment.is_empty() {
             continue; // Leading/trailing slash produces empty segments — skip.
         }
+        step4_reserved_name_check(segment).map_err(map_sanitize_error)?;
         let byte_len = segment.len();
         if byte_len > config.max_segment_bytes() {
             return Err(ResolveError::PathTooLong {
@@ -312,7 +287,8 @@ fn check_assembled_path(relative_path: &str, config: &ResolverConfig) -> Result<
 /// Resolve one `/`-delimited segment that may interleave `{token}` placeholders
 /// with literal text. Tokens append their resolved value; literal runs are
 /// sanitized and appended verbatim. The result is the concatenation of the
-/// pieces (a segment never contains an internal `/`).
+/// pieces, and never contains an internal `/` — step 2 of the sanitize pipeline
+/// substitutes one, so no resolved value can introduce a path level.
 fn resolve_segment(
     segment: &str,
     bundle: &MetadataBundle,
@@ -382,20 +358,26 @@ fn resolve_one_token(
     }
 
     let transformed = apply_transform(raw, def.transform);
-    let sanitized = sanitize_token_value(token_name, &transformed).map_err(map_sanitize_error)?;
-
-    if sanitized.is_empty() {
-        if !is_fallback {
-            missing_tokens.push(token_name.to_owned());
+    match sanitize_token_value(token_name, &transformed) {
+        Ok(sanitized) => Ok(sanitized),
+        // A value the sanitizer consumed entirely takes the registry fallback,
+        // so plan generation reports a missing token rather than failing.
+        Err(SanitizeError::EmptyAfterSanitize { .. }) => {
+            if !is_fallback {
+                missing_tokens.push(token_name.to_owned());
+            }
+            Ok(def.fallback.to_owned())
         }
-        Ok(def.fallback.to_owned())
-    } else {
-        Ok(sanitized)
+        Err(e) => Err(map_sanitize_error(e)),
     }
 }
 
 /// Sanitize a literal pattern run through the same filesystem-safety pipeline
 /// used for token values (traversal/reserved-name/confusable rejection).
+///
+/// A literal has no registry fallback, so an emptied literal is a hard error:
+/// the alternative is a pattern segment that silently disappears from the
+/// rendered path.
 fn sanitize_literal(literal: &str) -> Result<String, ResolveError> {
     sanitize_token_value("literal", literal).map_err(map_sanitize_error)
 }
@@ -434,6 +416,7 @@ fn map_sanitize_error(e: SanitizeError) -> ResolveError {
         SanitizeError::UnicodeConfusable { token, value } => {
             ResolveError::UnicodeConfusable { token, value }
         }
+        SanitizeError::EmptyAfterSanitize { value, .. } => ResolveError::EmptySegment { value },
     }
 }
 
@@ -807,16 +790,16 @@ mod tests {
         assert!(matches!(err, ResolveError::UnicodeConfusable { .. }));
     }
 
+    /// astro-plan-3v3r.1.23: a literal segment made entirely of dots is not
+    /// `.`/`..` (so it passes the traversal check) but step 2's dot-trim
+    /// collapses it to empty. A literal has no fallback, so the pattern names a
+    /// path level that cannot be rendered and the resolve is refused rather than
+    /// silently dropping the level.
     #[test]
-    fn pattern_str_literal_all_dots_segment_dropped() {
-        // A literal segment made entirely of dots is not `.`/`..` (so it
-        // passes the traversal check) but step2's dot-trim collapses it to
-        // empty — it is dropped rather than producing an empty path
-        // component, mirroring the "sanitizes to empty" fallback rule used
-        // for tokens.
+    fn pattern_str_literal_all_dots_segment_rejected() {
         let bundle = meta(&[("exposure", "300s")]);
-        let r = resolve_pattern_str("masters/.../{exposure}/", &bundle).unwrap();
-        assert_eq!(r.relative_path, "masters/300s");
+        let err = resolve_pattern_str("masters/.../{exposure}/", &bundle).unwrap_err();
+        assert!(matches!(err, ResolveError::EmptySegment { .. }));
     }
 
     #[test]
@@ -829,26 +812,93 @@ mod tests {
         assert!(matches!(err, ResolveError::PathTraversal { .. }));
     }
 
-    /// astro-plan-3v3r.9.10: `sanitize_token_value` leaves `/` alone by design
-    /// (`safe-filename` defers separators to the resolver), so a token value
-    /// carrying `../` only fails on the assembled-path check that `resolve`
-    /// always had and `resolve_pattern_str` skipped.
+    /// astro-plan-3v3r.9.10 + .20.24: a token value carrying `../` used to reach
+    /// the assembled-path traversal check, because `safe-filename` deferred
+    /// separators to the resolver. Step 2 now substitutes `/`, so the value
+    /// cannot express a traversal or a second path level at all — it stays one
+    /// segment. `check_assembled_path` is kept as the guard for the length caps
+    /// and for any future composition that reintroduces a separator.
     #[test]
-    fn pattern_str_token_value_traversal_rejected() {
+    fn pattern_str_token_value_cannot_add_a_level_or_traverse() {
         let bundle = meta(&[("filter", "Ha/../../etc")]);
-        let err = resolve_pattern_str("flats/{filter}/", &bundle).unwrap_err();
-        assert!(matches!(err, ResolveError::PathTraversal { .. }));
+        let r = resolve_pattern_str("flats/{filter}/", &bundle).unwrap();
+        assert_eq!(r.relative_path, "flats/Ha_.._.._etc");
+        assert_eq!(r.relative_path.split('/').count(), 2);
     }
 
-    /// The same value through `resolve`, pinning that both resolvers now answer
-    /// alike -- the defect was the divergence.
+    /// The same value through `resolve`, pinning that both resolvers answer
+    /// alike -- the original defect was the divergence.
     #[test]
-    fn assembled_traversal_rejected_alike_by_both_resolvers() {
+    fn token_value_separators_neutralized_alike_by_both_resolvers() {
         let bundle = meta(&[("filter", "Ha/../../etc")]);
-        let via_parts = resolve_v1(&[tok("f", "filter")], &bundle).unwrap_err();
-        let via_pattern_str = resolve_pattern_str("{filter}", &bundle).unwrap_err();
-        assert!(matches!(via_parts, ResolveError::PathTraversal { .. }));
-        assert!(matches!(via_pattern_str, ResolveError::PathTraversal { .. }));
+        let via_parts = resolve_v1(&[tok("f", "filter")], &bundle).unwrap();
+        let via_pattern_str = resolve_pattern_str("{filter}", &bundle).unwrap();
+        assert_eq!(via_parts.relative_path, "Ha_.._.._etc");
+        assert_eq!(via_pattern_str.relative_path, via_parts.relative_path);
+    }
+
+    /// astro-plan-3v3r.20.24 at the caller's level: the shipped pattern shape
+    /// with a dual-narrowband `FILTER` header must render the pattern's own
+    /// number of levels, not one more.
+    #[test]
+    fn pattern_str_slash_in_metadata_does_not_add_a_level() {
+        let bundle = meta(&[("target", "M42"), ("filter", "Ha/OIII"), ("date", "2026-08-23")]);
+        let r = resolve_pattern_str("{target}/{filter}/{date}/", &bundle).unwrap();
+        assert_eq!(r.relative_path, "M42/Ha_OIII/2026-08-23");
+        assert_eq!(r.relative_path.split('/').count(), 3);
+    }
+
+    /// astro-plan-3v3r.20.24, the injectivity half: two different metadata
+    /// tuples used to render the same path, because the `/` inside a value was
+    /// indistinguishable from the pattern's own separator.
+    #[test]
+    fn pattern_str_distinct_metadata_tuples_render_distinct_paths() {
+        let pattern = "{target}/{filter}/";
+        let split_in_target = meta(&[("target", "M42/Trapezium"), ("filter", "Ha")]);
+        let split_in_filter = meta(&[("target", "M42"), ("filter", "Trapezium/Ha")]);
+        let a = resolve_pattern_str(pattern, &split_in_target).unwrap();
+        let b = resolve_pattern_str(pattern, &split_in_filter).unwrap();
+        assert_eq!(a.relative_path, "M42_Trapezium/Ha");
+        assert_eq!(b.relative_path, "M42/Trapezium_Ha");
+        assert_ne!(a.relative_path, b.relative_path);
+    }
+
+    /// astro-plan-3v3r.1.22 at the composition level: step 4 runs on each piece,
+    /// so a device name assembled from a literal plus a token was seen by no
+    /// per-piece check. `check_assembled_path` closes it.
+    #[test]
+    fn pattern_str_reserved_name_assembled_from_literal_and_token_rejected() {
+        let bundle = meta(&[("filter", "N")]);
+        let err = resolve_pattern_str("masters/CO{filter}/", &bundle).unwrap_err();
+        assert!(matches!(err, ResolveError::ReservedName { .. }));
+    }
+
+    /// astro-plan-3v3r.1.23, token lane: an emptied token value keeps the
+    /// registry fallback and is reported, so plan generation does not fail.
+    #[test]
+    fn pattern_str_token_emptied_by_sanitize_falls_back_and_reports() {
+        let bundle = meta(&[("target", "..."), ("filter", "Ha")]);
+        let r = resolve_pattern_str("{target}/{filter}/", &bundle).unwrap();
+        assert_eq!(r.relative_path, "unclassified/Ha");
+        assert!(r.missing_tokens.contains(&"target".to_owned()));
+    }
+
+    /// astro-plan-3v3r.8.39 at the caller's level: the pattern preview and
+    /// source-view lanes both go through here, and both refused this name.
+    #[test]
+    fn pattern_str_accepts_greek_bayer_target_name() {
+        let bundle = meta(&[("target", "α Centauri"), ("filter", "Ha")]);
+        let r = resolve_pattern_str("{target}/{filter}/", &bundle).unwrap();
+        assert_eq!(r.relative_path, "α Centauri/Ha");
+    }
+
+    /// The spoof direction at the caller's level, so the relaxation cannot be
+    /// widened later without a failing test.
+    #[test]
+    fn pattern_str_still_rejects_cyrillic_homoglyph_target_name() {
+        let bundle = meta(&[("target", "M\u{0430}sters"), ("filter", "Ha")]);
+        let err = resolve_pattern_str("{target}/{filter}/", &bundle).unwrap_err();
+        assert!(matches!(err, ResolveError::UnicodeConfusable { .. }));
     }
 
     #[test]

--- a/crates/safe-filename/Cargo.toml
+++ b/crates/safe-filename/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 [dependencies]
 thiserror.workspace = true
 unicode-normalization.workspace = true
+unicode-script.workspace = true
 unicode-security.workspace = true
 
 [dev-dependencies]

--- a/crates/safe-filename/src/lib.rs
+++ b/crates/safe-filename/src/lib.rs
@@ -13,12 +13,16 @@
 //!
 //! Steps (applied in order):
 //! 1. NFC normalization + strip C0/C1 controls, format chars, bidi overrides.
-//! 2. OS character substitution: Windows reserved chars → `_`, trim
+//! 2. OS character substitution: Windows reserved chars and `/` → `_`, trim
 //!    leading/trailing whitespace and dots.
 //! 3. Path-traversal rejection: `.` or `..`.
 //! 4. Windows reserved device-name rejection (CON, PRN, AUX, NUL, COM1–9,
-//!    LPT1–9), case-insensitive, on all platforms.
-//! 5. Unicode confusables detection via `unicode-security` (mixed-script).
+//!    LPT1–9) on the pre-first-dot stem, case-insensitive, on all platforms.
+//! 5. Unicode confusables detection via `unicode-security` (mixed-script),
+//!    relaxed to admit a mixed Latin/Greek value.
+//!
+//! A successful [`sanitize_token_value`] returns exactly one usable path
+//! segment: the result never contains a separator and is never empty.
 //!
 //! Each step is exposed individually so a caller can run them in sequence and
 //! surface the first hard error, or call [`sanitize_token_value`] for the full
@@ -27,6 +31,7 @@
 //! sanitizer in a filesystem path-pattern resolver).
 
 use unicode_normalization::UnicodeNormalization;
+use unicode_script::{Script, UnicodeScript};
 use unicode_security::MixedScript;
 
 // ── Sanitize errors ────────────────────────────────────────────────────────
@@ -43,6 +48,10 @@ pub enum SanitizeError {
     /// Token value contains Unicode confusables or disallowed characters.
     #[error("Unicode confusables or disallowed chars in token {token}: {value}")]
     UnicodeConfusable { token: String, value: String },
+    /// Steps 1 and 2 together consumed the whole value, leaving nothing usable
+    /// as a path segment.
+    #[error("token {token} is empty after sanitization: {value}")]
+    EmptyAfterSanitize { token: String, value: String },
 }
 
 // ── Step 1: NFC + strip disallowed code-points ─────────────────────────────
@@ -93,15 +102,16 @@ pub fn step1_normalize_and_strip(input: &str) -> String {
 /// `/` and `\` are path delimiters; `?`, `*`, `"`, `<`, `>`, `|`, `:` are
 /// Windows-reserved. They are mapped to `_`.
 fn is_windows_reserved_char(c: char) -> bool {
-    matches!(c, '\\' | ':' | '?' | '*' | '"' | '<' | '>' | '|')
+    matches!(c, '/' | '\\' | ':' | '?' | '*' | '"' | '<' | '>' | '|')
 }
 
 /// Step 2: Replace Windows-reserved characters with `_`, then trim leading/
 /// trailing whitespace and dots.
 ///
-/// The `/` separator is **not** substituted here — segment splitting is done
-/// by the resolver before calling sanitize. Individual token values should
-/// never contain `/`; if they do the resolver will catch path-traversal issues.
+/// `/` is substituted here, which is what makes a sanitized value exactly one
+/// path segment rather than however many its content implies. Callers that
+/// split a multi-segment pattern do so *before* sanitizing each piece, so a
+/// literal directory level in a pattern is unaffected.
 #[must_use]
 pub fn step2_substitute_reserved_chars(input: &str) -> String {
     let substituted: String =
@@ -137,13 +147,18 @@ static WINDOWS_RESERVED_NAMES: &[&str] = &[
     "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
 ];
 
-/// Step 4: Return an error if the segment (after prior sanitization) matches
-/// a Windows reserved device name, case-insensitively.
+/// Step 4: Return an error if the segment (after prior sanitization) names a
+/// Windows reserved device, case-insensitively.
+///
+/// Windows resolves a device name from the text before the **first** dot, so
+/// `CON.fits` and `NUL.xisf` name devices just as `CON` does. The comparison is
+/// therefore on that stem, not on the whole segment.
 ///
 /// # Errors
 /// Returns [`SanitizeError::ReservedName`] when the segment is a reserved name.
 pub fn step4_reserved_name_check(segment: &str) -> Result<(), SanitizeError> {
-    let upper = segment.to_uppercase();
+    let stem = segment.split('.').next().unwrap_or(segment);
+    let upper = stem.to_uppercase();
     if WINDOWS_RESERVED_NAMES.contains(&upper.as_str()) {
         return Err(SanitizeError::ReservedName { segment: segment.to_owned() });
     }
@@ -152,17 +167,29 @@ pub fn step4_reserved_name_check(segment: &str) -> Result<(), SanitizeError> {
 
 // ── Step 5: Unicode confusables check ──────────────────────────────────────
 
+/// Scripts a value may mix freely: Latin and Greek, plus the script-neutral
+/// `Common` and `Inherited` (digits, punctuation, combining marks).
+///
+/// Bayer designations attach a Greek letter to a Latin constellation name, so
+/// `α Centauri` is a legitimate catalogue name that a plain mixed-script
+/// rejection refuses. Admitting this one pair also admits a Latin/Greek
+/// homoglyph (Greek ο against Latin o); no other script pair is admitted.
+fn is_astronomy_script(c: char) -> bool {
+    matches!(c.script(), Script::Latin | Script::Greek | Script::Common | Script::Inherited)
+}
+
 /// Step 5: Check the sanitized value for Unicode confusables using the
-/// `unicode-security` crate's mixed-script confusable detection.
+/// `unicode-security` crate's mixed-script confusable detection, relaxed to
+/// admit a value mixing only Latin and Greek.
 ///
 /// # Errors
-/// Returns [`SanitizeError::UnicodeConfusable`] when the value is detected as
-/// a confusable by the `unicode-security` mixed-script profile.
+/// Returns [`SanitizeError::UnicodeConfusable`] when the value mixes scripts
+/// beyond the Latin/Greek pair.
 pub fn step5_confusables_check(token_name: &str, value: &str) -> Result<(), SanitizeError> {
     // The unicode-security crate checks whether a string is "safe" from the
     // mixed-script confusables perspective (Unicode TR #39 §4).
     // `MixedScript::is_single_script` is implemented on `&str`.
-    if !value.is_ascii() && !value.is_single_script() {
+    if !value.is_ascii() && !value.is_single_script() && !value.chars().all(is_astronomy_script) {
         return Err(SanitizeError::UnicodeConfusable {
             token: token_name.to_owned(),
             value: value.to_owned(),
@@ -175,17 +202,26 @@ pub fn step5_confusables_check(token_name: &str, value: &str) -> Result<(), Sani
 
 /// Run the full sanitize pipeline on a token value.
 ///
-/// Returns the cleaned value on success. Returns the first hard error
-/// (`PathTraversal`, `ReservedName`, or `UnicodeConfusable`) encountered.
+/// Returns exactly one usable path segment on success: never empty, never
+/// containing a separator. Returns the first hard error encountered.
 ///
 /// # Errors
-/// Returns a [`SanitizeError`] if any step rejects the value.
+/// Returns a [`SanitizeError`] if any step rejects the value, including
+/// [`SanitizeError::EmptyAfterSanitize`] when the steps consume it entirely.
+/// Reporting that as an error rather than `Ok("")` is what keeps the emptiness
+/// check off every caller.
 pub fn sanitize_token_value(token_name: &str, raw: &str) -> Result<String, SanitizeError> {
     let s = step1_normalize_and_strip(raw);
     // Step 3 (traversal check) must run BEFORE step 2 so that `.` / `..` are
     // caught before step 2's dot-trimming collapses them to an empty string.
     step3_traversal_check(&s)?;
     let s = step2_substitute_reserved_chars(&s);
+    if s.is_empty() {
+        return Err(SanitizeError::EmptyAfterSanitize {
+            token: token_name.to_owned(),
+            value: raw.to_owned(),
+        });
+    }
     step4_reserved_name_check(&s)?;
     step5_confusables_check(token_name, &s)?;
     Ok(s)
@@ -237,9 +273,22 @@ mod tests {
     #[case("glob*", "glob_")] // asterisk → _
     #[case(".hidden.", "hidden")] // leading/trailing dots trimmed
     #[case("trailing ", "trailing")] // trailing space trimmed
-    #[case("NGC-7000_Ha", "NGC-7000_Ha")] // inner hyphen/underscore preserved
+    #[case("NGC-7000_Ha", "NGC-7000_Ha")]
+    // inner hyphen/underscore preserved
+    // astro-plan-3v3r.20.24: `/` is substituted, so a value cannot add a level.
+    #[case("Ha/OIII", "Ha_OIII")] // dual-narrowband FILTER header
+    #[case("M42/Trapezium", "M42_Trapezium")] // OBJECT header with a slash
+    #[case("a/b/c", "a_b_c")] // every separator, not just the first
     fn step2_substitute_reserved_chars_cases(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(step2_substitute_reserved_chars(input), expected);
+    }
+
+    /// astro-plan-3v3r.20.24: the pipeline's output is exactly one segment.
+    #[test]
+    fn sanitize_token_value_never_yields_a_separator() {
+        let out = sanitize_token_value("filter", "Ha/OIII").unwrap();
+        assert_eq!(out, "Ha_OIII");
+        assert!(!out.contains('/'));
     }
 
     // ── Step 3: traversal check ────────────────────────────────────────────
@@ -268,7 +317,16 @@ mod tests {
     #[case("COM9", true)] // numbered device
     #[case("lpt1", true)] // lowercase numbered device
     #[case("CONtrast", false)] // CON prefix is not reserved
-    #[case("NGC7000", false)] // normal name
+    #[case("NGC7000", false)]
+    // normal name
+    // astro-plan-3v3r.1.22: Windows resolves a device name from the text before
+    // the FIRST dot, so an extension does not make the segment a filename.
+    #[case("CON.fits", true)] // device name with an extension
+    #[case("nul.xisf", true)] // lowercase, with an extension
+    #[case("COM1.json", true)] // numbered device with an extension
+    #[case("CON.foo.json", true)] // `file_stem` would keep `CON.foo` and pass
+    #[case("CONtrast.fits", false)] // a real filename whose stem is not a device
+    #[case("NGC7000.fits", false)] // ordinary astronomy filename
     fn step4_reserved_name_check_cases(#[case] segment: &str, #[case] expect_err: bool) {
         let result = step4_reserved_name_check(segment);
         if expect_err {
@@ -283,9 +341,28 @@ mod tests {
     /// Table-driven step-5 cases: pure ASCII and single-script non-ASCII pass.
     #[rstest]
     #[case("NGC7000")] // pure ASCII
-    #[case("Andromède")] // single-script Latin (accented)
+    #[case("Andromède")]
+    // single-script Latin (accented)
+    // astro-plan-3v3r.8.39: a Bayer designation attaches a Greek letter to a
+    // Latin constellation name; refusing it refuses a real catalogue name.
+    #[case("α Centauri")] // Greek U+03B1 + Latin — the recorded harness vector
+    #[case("β Cygni")] // second Bayer name, Greek + Latin
+    #[case("μ Cephei")] // Greek + Latin
     fn step5_confusables_check_allows(#[case] value: &str) {
         assert!(step5_confusables_check("target", value).is_ok());
+    }
+
+    /// astro-plan-3v3r.8.39, the other direction: relaxing the rule to the
+    /// Latin/Greek pair must not admit a homoglyph spoof from another script.
+    #[rstest]
+    #[case("mаsters")] // Cyrillic а (U+0430) inside an otherwise Latin word
+    #[case("Аndromeda")] // Cyrillic А (U+0410) leading a Latin word
+    #[case("M42\u{0430}")] // Cyrillic а appended to an ASCII designation
+    fn step5_confusables_check_rejects_cross_script_homoglyphs(#[case] value: &str) {
+        assert!(matches!(
+            step5_confusables_check("target", value),
+            Err(SanitizeError::UnicodeConfusable { .. })
+        ));
     }
 
     // ── Full pipeline ──────────────────────────────────────────────────────
@@ -313,6 +390,35 @@ mod tests {
     fn full_pipeline_reserved_name_rejected() {
         let err = sanitize_token_value("target", "CON").unwrap_err();
         assert!(matches!(err, SanitizeError::ReservedName { .. }));
+    }
+
+    /// astro-plan-3v3r.1.23: the pipeline reports "nothing left" as an error, so
+    /// the emptiness check does not fall to every caller.
+    #[rstest]
+    #[case("...")] // dot-only
+    #[case("  ..  ")] // padded traversal
+    #[case("   ")] // whitespace-only
+    #[case(". . .")] // dots and spaces, trimmed from both ends
+    #[case("\u{200B}")] // a value that is only a stripped format character
+    fn full_pipeline_empty_after_sanitize_is_an_error(#[case] raw: &str) {
+        assert!(matches!(
+            sanitize_token_value("target", raw),
+            Err(SanitizeError::EmptyAfterSanitize { .. })
+        ));
+    }
+
+    /// astro-plan-3v3r.1.22 through the whole pipeline, not only step 4.
+    #[test]
+    fn full_pipeline_reserved_name_with_extension_rejected() {
+        let err = sanitize_token_value("target", "CON.fits").unwrap_err();
+        assert!(matches!(err, SanitizeError::ReservedName { .. }));
+    }
+
+    /// astro-plan-3v3r.8.39 through the whole pipeline.
+    #[test]
+    fn full_pipeline_accepts_greek_bayer_name() {
+        let out = sanitize_token_value("target", "α Centauri").unwrap();
+        assert_eq!(out, "α Centauri");
     }
 
     // ── Property tests ─────────────────────────────────────────────────────
@@ -370,6 +476,10 @@ mod tests {
             if let Ok(out) = sanitize_token_value("target", &s) {
                 prop_assert!(out.chars().all(|c| !is_windows_reserved_char(c)));
                 prop_assert!(out != "." && out != "..");
+                // The one-segment contract: a success is never empty and never
+                // spans a separator, for every input.
+                prop_assert!(!out.is_empty());
+                prop_assert!(!out.contains('/'));
             }
         }
 

--- a/specs/tiny/segment-sanitizer-yields-one-segment.md
+++ b/specs/tiny/segment-sanitizer-yields-one-segment.md
@@ -1,0 +1,176 @@
+# TinySpec: A sanitized value is exactly one path segment
+
+**Branch**: fix/deriva-segment-sanitizer
+**Date**: 2026-08-23
+**Complexity**: 3 (TinySpec route)
+**Findings**: astro-plan-3v3r.20.24, .1.22, .1.23, .8.39
+
+## What
+
+`safe_filename` turns an arbitrary string — in practice a FITS/XISF metadata value
+— into one path segment, and `patterns` composes those segments into a rendered
+destination. Four properties the pair is relied on for do not hold:
+
+| Site | Behaviour today |
+|------|-----------------|
+| `crates/safe-filename/src/lib.rs:95` `is_windows_reserved_char` | `/` is absent from the substitution set, so a value of `Ha/OIII` passes through and one `{token}` renders two path segments |
+| `crates/safe-filename/src/lib.rs:145` `step4_reserved_name_check` | compares the whole segment, so `CON` is refused and `CON.fits` is accepted |
+| `crates/safe-filename/src/lib.rs:183` `sanitize_token_value` | returns `Ok("")` for `"..."` and `"  ..  "`, so "nothing left" is reported as success |
+| `crates/safe-filename/src/lib.rs:165` `step5_confusables_check` | any mixed-script value is refused, including the Bayer designation `α Centauri` |
+
+## The rule (decision)
+
+**`sanitize_token_value` returns either exactly one usable path segment or an
+error. It never returns a value that spans, collapses, or names something other
+than one segment.**
+
+Four sub-rules implement it.
+
+### `/` is a reserved character, substituted in step 2
+
+`/` joins `\`, `:`, `?`, `*`, `"`, `<`, `>`, `|` in `is_windows_reserved_char` and
+maps to `_`. A sanitized value therefore cannot contain a separator, which is what
+makes "one token, one segment" a property of the sanitizer rather than a hope
+about metadata content.
+
+This does not affect literal directory levels written in a pattern.
+`resolve_pattern_str_with` splits the pattern on `/` *before* any sanitize call
+(`resolver.rs:255`), so a literal run handed to `sanitize_literal` never contains
+`/`. `resolve`'s separator parts are emitted unsanitized (`resolver.rs:172`).
+Only substituted *values* are affected, which is the intent.
+
+A consequence: a token value carrying `../` can no longer produce a traversal,
+because the separators become `_` first. The assembled-path guard
+`check_assembled_path` is kept — it still enforces the segment and total length
+caps, and it remains the guard for any future composition that reintroduces a
+separator — but the traversal arm is no longer reachable from a token value.
+
+### The reserved-device-name check reads the stem
+
+Windows resolves a device name from the text before the **first** dot, so
+`CON.foo.json` names the console. `step4_reserved_name_check` compares
+`segment.split('.').next()`, case-insensitively, against the existing list, and
+stays unconditional on every platform.
+
+`crates/fs/pathsafe/src/export_dest.rs:82` already extracts the stem before
+calling `step4_reserved_name_check`, with the reasoning in a comment. Moving the
+rule into the step makes that call site redundant, not wrong; removing the
+duplicate split is tracked separately and is out of scope here.
+
+### An emptied value is an error, and the token lane answers it with the fallback
+
+`SanitizeError::EmptyAfterSanitize` is returned when step 1 and step 2 together
+consume the whole value. The enum is internal to `safe_filename` and is not part
+of the contract surface.
+
+The two lanes in `patterns` answer it differently, and the difference is the
+decision:
+
+- **Token lane** (`resolve_one_token`): map it to the registry `fallback` and push
+  the token onto `missing_tokens`. This is byte-for-byte the behaviour the
+  `sanitized.is_empty()` branch had, so plan generation does not start failing.
+- **Literal lane** (`sanitize_literal`): propagate it as a hard error, so a
+  literal segment of only dots stops silently vanishing from the rendered path.
+
+`ResolveError::EmptySegment` carries it to the boundary and maps to the existing
+`ErrorCode::PatternInvalid` (`app/core`) and `ErrorCode::PathInvalid`
+(`app/projects`). No `ErrorCode` is added and no TypeScript binding is
+regenerated.
+
+The token branch of `resolve` and `resolve_one_token` were already duplicate
+implementations of lookup → transform → sanitize → fallback. `resolve` now calls
+`resolve_one_token`, so the emptied-value rule exists once.
+
+### A mixed Latin/Greek value is accepted; any other script mix is not
+
+Mixed script alone is the wrong predicate: Bayer designations are Greek letters
+attached to Latin constellation names, so `α Centauri` is a legitimate catalogue
+name and refusing it refuses a real destination.
+
+The rule: a non-ASCII value is accepted when it is single-script (unchanged), or
+when every character's script is one of **Latin, Greek, Common, Inherited**.
+Every other mix is still refused, so a Cyrillic homoglyph inside an otherwise
+Latin word remains rejected.
+
+The tradeoff Principle IV requires recorded: this admits a Latin/Greek homoglyph
+pair (Greek ο against Latin o). Accepted deliberately — the alternative refuses
+every Greek-letter target name, and the two scripts are both first-class in
+astronomical nomenclature. No other script pair is admitted.
+
+Per-character script lookup uses `unicode-script`, already in `Cargo.lock` as a
+dependency of `unicode-security`.
+
+## Per-finding verdict at head efaaf57a0
+
+| Finding | Verified site at this head | Reachable | Verdict |
+|---------|----------------------------|-----------|---------|
+| .20.24 | `safe-filename/src/lib.rs:95-97` omits `/` | YES — a `FILTER` of `Ha/OIII` reaches `app/inbox/src/confirm.rs:463`, and the result becomes the plan destination at `:508` with no separator check between | LIVE |
+| .1.22 | `safe-filename/src/lib.rs:145-151` compares the whole segment | Partly — the sanitizer returning `Ok` for `CON.fits` is proven and platform-independent. The harmful consequence, a write reaching the console device, is Windows-only and was **not** demonstrated; the sabot run was a Linux container | LIVE as a contract violation |
+| .1.23 | `safe-filename/src/lib.rs:183-192` returns `Ok("")` | YES for the literal lane — `sanitize_literal` (`resolver.rs:399`) has no empty handling and `resolve_pattern_str_with:264` drops the empty result, so a dots-only literal segment disappears from the path. The bead title's "the file lands one level up" is **retracted**: the token lane already substitutes the registry fallback (`resolver.rs:387-394`), and literals join *within* a segment, so an emptied literal shortens a name rather than deleting a level | LIVE as an API-shape defect |
+| .8.39 | `safe-filename/src/lib.rs:165` refuses any non-ASCII mixed-script value | YES — executed, `repro_rc=101`, refusing `α Centauri` through `pattern_path_preview` (`apps/desktop/src-tauri/src/commands/patterns.rs:89`) and source-view generation | LIVE |
+
+Two statements in the briefing did not hold at this head and are recorded rather
+than acted on:
+
+- There is **no** comment in `resolver.rs` claiming a reserved-name check runs on
+  the assembled segment. The check is genuinely absent; no false comment needed
+  fixing.
+- The `resolve_segment` doc "a segment never contains an internal `/`"
+  (`resolver.rs:315`) was false and becomes **true** under sub-rule 1, so it is
+  annotated rather than corrected.
+
+## Context
+
+| File | Role |
+|------|------|
+| `crates/safe-filename/src/lib.rs` | Modify: `/` reserved, stem-aware step 4, `EmptyAfterSanitize`, Latin/Greek confusable rule |
+| `crates/safe-filename/Cargo.toml`, `Cargo.toml` | Modify: `unicode-script` workspace dependency |
+| `crates/patterns/src/resolver.rs` | Modify: `resolve` delegates its token branch to `resolve_one_token`; `sanitize_literal` propagates; `ResolveError::EmptySegment`; assembled-segment reserved-name check |
+| `crates/app/core/src/patterns.rs` | Modify: `map_resolve_error` gains the `EmptySegment` arm |
+| `crates/app/projects/src/source_view_generate/mod.rs` | Modify: the source-view error match gains the `EmptySegment` arm |
+
+## Requirements
+
+1. A sanitized token value contains no `/`.
+2. A single-token pattern resolves to exactly one path segment for every metadata
+   value, including one containing `/`.
+3. Two metadata values that differ only in a `/` do not render to the same path by
+   one gaining a directory level.
+4. A segment whose pre-first-dot stem is a Windows device name is refused, on
+   every platform, with or without an extension.
+5. `sanitize_token_value` never returns `Ok` with an empty string.
+6. A token whose value sanitizes to empty resolves to the registry fallback and is
+   reported in `missing_tokens`.
+7. A literal pattern segment that sanitizes to empty is a hard error, not a
+   dropped segment.
+8. A value mixing Latin and Greek is accepted; a value mixing Latin and Cyrillic
+   is refused.
+9. No guard and no test for a guard is gated behind `cfg(unix)`; every fixture
+   asserts the same outcome on macOS, Linux and Windows.
+10. No schema change and no `ErrorCode` addition.
+
+## Tasks
+
+- [x] Add `/` to `is_windows_reserved_char`; update the step-2 doc and rstest table
+- [x] Make `step4_reserved_name_check` compare the stem
+- [x] Add `SanitizeError::EmptyAfterSanitize`; return it from `sanitize_token_value`
+- [x] Relax `step5_confusables_check` to the Latin/Greek/Common/Inherited allowlist
+- [x] `resolve`'s token branch delegates to `resolve_one_token`, which maps
+      `EmptyAfterSanitize` to the fallback
+- [x] `sanitize_literal` propagates `EmptyAfterSanitize` as `ResolveError::EmptySegment`
+- [x] `check_assembled_path` also runs the reserved-name check per segment
+- [x] Map `EmptySegment` in both exhaustive `ResolveError` matches
+- [x] Re-target the two `.9.10` regression tests whose traversal outcome sub-rule 1
+      makes unreachable, keeping the both-resolvers-agree assertion
+- [x] One test per finding, each confirmed failing with its own fix reverted
+- [x] Lint and test the four touched crates
+
+## Done When
+
+- [x] Each of the four findings has a named test that fails at base efaaf57a0 with
+      that finding's fix reverted, recorded per test rather than as a blanket claim
+- [x] Requirement 2 is proven at the `resolve_pattern_str` level, not only at
+      `sanitize_token_value`, so the reachability claim is backed by the caller
+- [x] Both confusable fixtures ship: `α Centauri` accepted, Cyrillic-in-Latin refused
+- [x] `cargo clippy` and tests are green for `safe-filename`, `patterns`,
+      `app_core`, `app_projects`


### PR DESCRIPTION
## Summary

A FITS `FILTER` header written `Ha/OIII`, or an `OBJECT` written `M42/Trapezium`,
passed through the filename sanitizer untouched, so a single `{token}` in a
destination pattern rendered **two** folder levels and the planned destination
gained a level the reviewed plan never described. Two different metadata tuples
could render to the same path.

This establishes one rule: **a sanitized value is exactly one path segment** —
never spanning, collapsing, or naming something other than one segment. Three
further defects in the same sanitizer are fixed with it: device names carrying an
extension (`CON.fits`) were accepted, a value the sanitizer emptied was reported as
success, and legitimate Greek-letter target names such as `α Centauri` were refused.

## Reachability in production, one sentence per finding

- **`.20.24` — reachable.** `Ha/OIII` reaches `sanitize_token_value` through
  `app/inbox/src/confirm.rs:463`, and the resolved path becomes the plan destination
  at `:508` (`format!("{}/{filename}", result.relative_path)`) with no separator or
  segment check in between — a Tier-1 filesystem-mutation destination. Also reached
  by `app/inbox/src/metadata.rs:262`, `classify.rs:1663`,
  `app/projects/src/source_view_generate/generate.rs:209` and `:325`, and
  `app/core/src/patterns.rs:172` from the `pattern_path_preview` command.
- **`.1.22` — partly reachable, and the harmful consequence was not demonstrated.**
  What is proven and platform-independent is that the sanitizer returned `Ok` for
  the device name `CON.fits`, violating its own documented contract of rejection on
  all platforms. The consequence of a write reaching the console device instead of a
  file is **Windows-only and was not demonstrated**: the sabot campaign ran in a
  Linux container.
- **`.1.23` — reachable in the literal lane only.** `sanitize_literal` had no empty
  handling and `resolve_pattern_str_with` dropped the empty result, so a dots-only
  literal segment disappeared from the rendered path. **The bead title's "the file
  lands one level up" is retracted**, per the bead's own triage: the token lane
  already substituted the registry fallback, and literals join *within* a segment, so
  an emptied literal shortens a name rather than deleting a level. The defect is the
  API shape — an `Ok` meaning "nothing left" pushes the check onto every caller.
- **`.8.39` — reachable, and executed.** `repro_rc=101`; the recorded harness output
  is `refused with Unicode confusable in token target: α Centauri`, refusing a real
  catalogue name through `pattern_path_preview`
  (`apps/desktop/src-tauri/src/commands/patterns.rs:89`) and source-view generation.

## Why mapping `/` in step 2 does not break literal pattern segments

`resolve_pattern_str_with` splits the pattern on `/` **before** any sanitize call
(`crates/patterns/src/resolver.rs:255`), so a literal run handed to `sanitize_literal`
never contains a `/` for step 2 to substitute; and `resolve` emits its separator parts
unsanitized. Only substituted *values* are affected, which is the intent.

## The confusable rule

A non-ASCII value is accepted when it is single-script (unchanged) **or when every
character's script is one of Latin, Greek, Common, Inherited**. This deliberately
admits a Latin/Greek homoglyph pair (Greek omicron against Latin o), because the
alternative refuses every Greek-letter Bayer designation; no other script pair is
admitted. Both directions ship as fixtures: `α Centauri` accepted
(`step5_confusables_check_allows` case 3, `full_pipeline_accepts_greek_bayer_name`,
`pattern_str_accepts_greek_bayer_target_name`), and a Cyrillic homoglyph inside a
Latin word still refused (`step5_confusables_check_rejects_cross_script_homoglyphs`,
`pattern_str_still_rejects_cyrillic_homoglyph_target_name`).

## Tests, with the observed failure at base with that fix reverted

Each fix was reverted **individually** and the suite re-run; the rows below are the
recorded per-test results, not a blanket claim.

| Bead | Test | Observed with only this fix reverted |
|---|---|---|
| .20.24 | `step2_substitute_reserved_chars_cases::case_08/09/10` | FAILED (`Ha/OIII` unchanged, no substitution) |
| .20.24 | `sanitize_token_value_never_yields_a_separator` | FAILED |
| .20.24 | `sanitize_token_value_never_panics` (proptest) | FAILED, shrinks to `s = "/"` |
| .20.24 | `pattern_str_slash_in_metadata_does_not_add_a_level` | FAILED (renders 4 segments, not 3) |
| .20.24 | `pattern_str_distinct_metadata_tuples_render_distinct_paths` | FAILED (both tuples render `M42/Trapezium/Ha`) |
| .20.24 | `pattern_str_token_value_cannot_add_a_level_or_traverse` | FAILED |
| .20.24 | `token_value_separators_neutralized_alike_by_both_resolvers` | FAILED |
| .1.22 | `step4_reserved_name_check_cases::case_07/08/09/10` | FAILED (`CON.fits`, `nul.xisf`, `COM1.json`, `CON.foo.json` all accepted) |
| .1.22 | `full_pipeline_reserved_name_with_extension_rejected` | FAILED |
| .1.22 | `pattern_str_reserved_name_assembled_from_literal_and_token_rejected` | FAILED (assembled `CON` accepted) |
| .1.23 | `full_pipeline_empty_after_sanitize_is_an_error::case_1..5` | FAILED (all five returned `Ok("")`) |
| .1.23 | `sanitize_token_value_never_panics` (proptest) | FAILED, shrinks to `s = ""` |
| .1.23 | `pattern_str_literal_all_dots_segment_rejected` | FAILED (segment silently dropped) |
| .1.23 | `pattern_str_token_emptied_by_sanitize_falls_back_and_reports` | FAILED |
| .8.39 | `step5_confusables_check_allows::case_3/4/5` | FAILED (`α Centauri`, `β Cygni`, `μ Cephei` refused) |
| .8.39 | `full_pipeline_accepts_greek_bayer_name` | FAILED: `UnicodeConfusable { token: "target", value: "α Centauri" }` |
| .8.39 | `pattern_str_accepts_greek_bayer_target_name` | FAILED |

Two tests are **not** base-failing and are stated as such: the spoof-direction
fixtures `step5_confusables_check_rejects_cross_script_homoglyphs` and
`pattern_str_still_rejects_cyrillic_homoglyph_target_name` pass with and without the
fix. They exist to stop the Latin/Greek relaxation being widened later, not to
demonstrate the defect.

## Behaviour changes to existing tests

Two `.9.10` regression tests pinned a token value of `Ha/../../etc` producing
`PathTraversal` via `check_assembled_path`. Substituting `/` in step 2 means the value
can no longer express a traversal or a second level at all, so that arm is unreachable
from a token value. The tests now assert the stronger single-segment result and keep
the both-resolvers-agree shape, renamed to
`pattern_str_token_value_cannot_add_a_level_or_traverse` and
`token_value_separators_neutralized_alike_by_both_resolvers`. `check_assembled_path`
is kept — it still enforces the length caps and now also runs the reserved-name check
— and one existing test changed from "dots-only literal segment dropped" to
"rejected".

## Notes

- **No schema change.** No SQL and no migration; `0001_initial_schema.sql` untouched.
- **No `ErrorCode` added.** `ResolveError::EmptySegment` maps to the existing
  `ErrorCode::PatternInvalid` (`app/core`) and `ErrorCode::PathInvalid`
  (`app/projects`). No TypeScript bindings regenerated, `error-messages.ts` untouched.
- **No `cfg(unix)` gate** on any guard or test; every fixture asserts the same outcome
  on macOS, Linux and Windows.
- **No ordering change**; no comparator was touched.
- **Dependency:** `unicode-script` added as a workspace dependency of `safe-filename`
  for per-character script lookup. It was already in `Cargo.lock` at 0.5.8 as a
  dependency of `unicode-security`, so no new transitive graph. This required a
  one-line addition to the root `Cargo.toml`, just outside the node's scope globs.
- **Duplication removed rather than twinned:** `resolve`'s token branch now calls
  `resolve_one_token`, so the emptied-value rule exists once. `check_assembled_path`
  gained the reserved-name check that no per-piece step-4 call could see (literal `CO`
  plus a token resolving to `N` is the device name `CON`).
- **`crates/fs/pathsafe/src/export_dest.rs:82`** already extracted the device stem at
  its call site; the rule now lives in `step4_reserved_name_check`, making that split
  redundant but not wrong. Removing it is out of scope — filed as `astro-plan-vgj29`.

### The recorded pre-existing lint failure, confirmed

`astro-plan-8vxx1` is a `typos` (crate-ci/typos, `.pre-commit-config.yaml`) failure, not a
clippy failure. `pre-commit run typos --all-files` exits 1 at this head on `appliable` in
`crates/app/inbox/src/confirm.rs` (:339, :1399, :3179, :3182, :3226). It is pre-existing and
untouched by this branch; `cargo clippy -p app_core_inbox --all-targets -- -D warnings` exits
0 and says nothing about it.

## Verification

Scoped to the four touched crates, in a dedicated `CARGO_TARGET_DIR`, re-run from a clean
target dir after merging `origin/main` twice: `0f8cff68c` (clean, `app/inbox/src/scan.rs` and
`fs/executor/src/reconcile.rs`) and `5b1fdf702` (clean, CI workflows plus `apps/desktop` and
`packages/contracts` TypeScript). Neither merge touches the four crates:

- `cargo test -p safe-filename -p patterns -p app_core -p app_core_projects` — exit 0, 49 test binaries, 0 failed
- `cargo clippy -p safe-filename -p patterns -p app_core -p app_core_projects --all-targets -- -D warnings` — exit 0
- `cargo fmt --all` — applied

## Spec Context

TinySpec: `specs/tiny/segment-sanitizer-yields-one-segment.md`

Findings `astro-plan-3v3r.20.24`, `.1.22`, `.1.23`, `.8.39` are left **open** — they
close on merge.

Tracks-Bead: astro-plan-i7ugt
Merge-Bead: astro-plan-9l9ag
