### PR TITLE
fix: auto-detect no longer suggests a tool path that depends on the current folder, and macOS stops claiming a launched app starts in the project folder

### DIFF
--- a/apps/desktop/messages/en-GB.json
+++ b/apps/desktop/messages/en-GB.json
@@ -1567,7 +1567,7 @@
   "projects_manifests_load_body_failed": "Could not load manifest: {error}",
   "projects_tool_launched": "Launched {tool}",
   "projects_tool_launch_failed": "Could not launch {tool}: {error}",
-  "projects_tool_cwd_anchored_hint": "{tool} doesn't accept a folder to open — its working directory is anchored to the project instead.",
+  "projects_tool_cwd_anchored_hint": "{tool} doesn't accept a folder to open — open your project files from inside the app.",
   "projects_create_name_duplicate": "A project with this name already exists.",
   "projects_schema_name_required": "Project name is required.",
   "projects_schema_name_too_long": "Name must be {max} characters or fewer.",

--- a/apps/desktop/messages/pt-BR.json
+++ b/apps/desktop/messages/pt-BR.json
@@ -1508,7 +1508,7 @@
   "projects_manifests_load_body_failed": "Não foi possível carregar o manifesto: {error}",
   "projects_tool_launched": "{tool} iniciado",
   "projects_tool_launch_failed": "Não foi possível iniciar {tool}: {error}",
-  "projects_tool_cwd_anchored_hint": "{tool} não aceita uma pasta para abrir — seu diretório de trabalho é fixado no projeto.",
+  "projects_tool_cwd_anchored_hint": "{tool} não aceita uma pasta para abrir — abra os arquivos do seu projeto dentro do aplicativo.",
   "projects_create_name_duplicate": "Já existe um projeto com este nome.",
   "projects_schema_name_required": "O nome do projeto é obrigatório.",
   "projects_schema_name_too_long": "O nome deve ter no máximo {max} caracteres.",

--- a/apps/desktop/src/features/projects/tool-launch.ts
+++ b/apps/desktop/src/features/projects/tool-launch.ts
@@ -88,7 +88,10 @@ export function toolLaunchDisabledTooltip(
 /**
  * localStorage key prefix for the per-tool "cwd anchored" hint seen-state
  * (US3 acceptance scenario 3): tools whose profile declares
- * `supports_open_folder = false` don't get a folder argument, only a `cwd`.
+ * `supports_open_folder = false` receive no folder argument. The project folder
+ * reaches such a tool only as a working directory, and only on the platform arms
+ * that apply one: a macOS bundle launch goes through Launch Services, which
+ * starts the app with a working directory the app itself chooses.
  * The first time such a tool is launched, a one-time note explains this so
  * the user isn't left wondering why no folder chooser opened.
  */
@@ -175,8 +178,9 @@ export interface UseToolLaunchResult {
  * On success: shows "Launched {tool}" toast. When `supportsOpenFolder` is
  * `false` and this is the first successful launch of `toolId` in this
  * browser profile, also shows a one-time "cwd anchored" hint toast (T021,
- * US3 acceptance scenario 3) explaining that the tool doesn't accept a
- * folder argument — only the working directory is set.
+ * US3 acceptance scenario 3) explaining that the tool receives no folder
+ * argument, and that the project folder reaches it as a working directory only
+ * on the platform arms that apply one.
  * On error: shows failure toast with "Configure path" affordance on not_configured errors.
  * On prior_instance_alive: sets `priorInstanceAlive=true` (caller renders the modal).
  */

--- a/crates/workflow/profiles/src/discover.rs
+++ b/crates/workflow/profiles/src/discover.rs
@@ -205,8 +205,8 @@ fn resolve_executable(cmd: &str) -> Option<PathBuf> {
     if p.is_absolute() {
         return p.exists().then(|| p.to_path_buf());
     }
-    let path_var = std::env::var("PATH").ok()?;
-    path_var.split(':').map(|dir| Path::new(dir).join(cmd)).find(|c| c.exists())
+    let path_var = std::env::var_os("PATH")?;
+    absolute_path_dirs(&path_var).map(|dir| dir.join(cmd)).find(|c| c.exists())
 }
 
 // ── Windows ───────────────────────────────────────────────────────────────────
@@ -355,13 +355,28 @@ fn probe_candidates(candidates: &[(&str, &str)]) -> Vec<DiscoveryResult> {
     results
 }
 
+/// Search directories from a `PATH`-style variable value, absolute ones only.
+///
+/// POSIX gives an empty `PATH` element the meaning "current working directory",
+/// so a leading, trailing or doubled separator would otherwise yield a candidate
+/// that `Path::exists` resolves against wherever the app was started from.
+/// `split_paths` turns an empty element into an empty path, which `is_absolute`
+/// rejects along with every other relative element.
+///
+/// The value is a parameter so tests need not mutate the process environment,
+/// which `unsafe_code = "forbid"` puts out of reach anyway.
+#[cfg(any(target_os = "linux", test))]
+fn absolute_path_dirs(path_var: &std::ffi::OsStr) -> impl Iterator<Item = PathBuf> + '_ {
+    std::env::split_paths(path_var).filter(|dir| dir.is_absolute())
+}
+
 #[cfg(target_os = "linux")]
 fn discover_from_path(names: &[(&'static str, &str)]) -> Vec<DiscoveryResult> {
-    let path_var = std::env::var("PATH").unwrap_or_default();
+    let path_var = std::env::var_os("PATH").unwrap_or_default();
     let mut results = Vec::new();
-    for dir in path_var.split(':') {
+    for dir in absolute_path_dirs(&path_var) {
         for &(tool_id, exe_name) in names {
-            let p = Path::new(dir).join(exe_name);
+            let p = dir.join(exe_name);
             if p.exists() {
                 results.push(DiscoveryResult {
                     tool_id: tool_id.to_owned(),
@@ -411,5 +426,30 @@ mod tests {
     fn probe_nonexistent_returns_empty() {
         let results = probe_candidates(&[("pixinsight", "/no/such/path/PixInsight")]);
         assert!(results.is_empty());
+    }
+
+    /// `join_paths` writes the host separator, so the malformed shapes under test
+    /// are the host's own (`::` on Unix, `;;` on Windows).
+    fn path_var(dirs: &[&str]) -> std::ffi::OsString {
+        std::env::join_paths(dirs.iter().map(std::path::PathBuf::from))
+            .expect("fixture elements contain no path separator")
+    }
+
+    #[test]
+    fn absolute_path_dirs_drops_empty_and_relative_elements() {
+        let bin = fs_pathsafe::test_support::abs("/opt/astro/bin");
+        let local = fs_pathsafe::test_support::abs("/usr/local/bin");
+        // Leading, doubled and trailing separators, plus a relative element.
+        let var = path_var(&["", &bin, "", "tools/bin", &local, ""]);
+
+        let dirs: Vec<PathBuf> = absolute_path_dirs(&var).collect();
+
+        assert_eq!(dirs, vec![PathBuf::from(&bin), PathBuf::from(&local)]);
+    }
+
+    #[test]
+    fn absolute_path_dirs_yields_nothing_when_no_element_is_absolute() {
+        let var = path_var(&["", ".", "tools/bin", ""]);
+        assert_eq!(absolute_path_dirs(&var).count(), 0);
     }
 }

--- a/crates/workflow/profiles/src/discover.rs
+++ b/crates/workflow/profiles/src/discover.rs
@@ -206,7 +206,10 @@ fn resolve_executable(cmd: &str) -> Option<PathBuf> {
         return p.exists().then(|| p.to_path_buf());
     }
     let path_var = std::env::var_os("PATH")?;
-    absolute_path_dirs(&path_var).map(|dir| dir.join(cmd)).find(|c| c.exists())
+    // Bound to a local because the borrowing iterator, as a tail expression, would be
+    // dropped after `path_var` rather than before it.
+    let found = absolute_path_dirs(&path_var).map(|dir| dir.join(cmd)).find(|c| c.exists());
+    found
 }
 
 // ── Windows ───────────────────────────────────────────────────────────────────

--- a/crates/workflow/profiles/src/launch.rs
+++ b/crates/workflow/profiles/src/launch.rs
@@ -158,6 +158,12 @@ fn spawn_platform(req: SpawnRequest) -> Result<SpawnResult, LaunchError> {
 
     if let Some(ref bid) = req.bundle_id {
         // Use `open -b <bundle_id> --args <argv>` for .app bundles (R-BundleId).
+        //
+        // `req.working_dir` is not applied and cannot be: Launch Services starts
+        // the app itself, so `current_dir` here would set the cwd of `open`, not
+        // of the tool (`tests/real_spawn_stub.rs:12-16`). Any user-facing text
+        // about the working folder must therefore not promise it for this arm,
+        // which every seeded profile with a `bundle_id` takes on macOS.
         let mut cmd = std::process::Command::new("/usr/bin/open");
         cmd.args(["-b", bid.as_str()]);
         if !req.args.is_empty() {

--- a/crates/workflow/profiles/src/seed.rs
+++ b/crates/workflow/profiles/src/seed.rs
@@ -135,9 +135,10 @@ mod tests {
 
     #[test]
     fn pixinsight_launches_bare_with_no_folder_arg() {
-        // PixInsight cannot open a bare folder path (bug #778): launch with
-        // no args and rely on `cwd` anchoring instead of {folder} (spec 011
-        // R-CwdContain, supports_open_folder=false path).
+        // PixInsight cannot open a bare folder path (bug #778), so it launches
+        // with no args (spec 011 R-CwdContain, supports_open_folder=false
+        // path). It sets a bundle id, so on macOS it takes the `open -b` arm,
+        // which applies no working directory at all (`launch.rs:159-183`).
         let p = find("pixinsight").expect("pixinsight must be seeded");
         assert!(!p.supports_open_folder);
         assert!(p.args_template.is_empty());

--- a/crates/workflow/profiles/src/seed.rs
+++ b/crates/workflow/profiles/src/seed.rs
@@ -22,9 +22,11 @@ fn pixinsight_profile() -> ToolProfile {
         // robust path argument is a `.xosm` project file we never generate,
         // and running WBPP's automationMode would violate the PixInsight
         // processing boundary (Constitution III). Launch bare instead — the
-        // user opens their own files/project inside PixInsight. `cwd` is
-        // still anchored to the project folder (R-CwdContain), which is what
-        // drives the one-time "cwd anchored" hint (supports_open_folder=false).
+        // user opens their own files/project inside PixInsight, which is what
+        // the one-time launch hint says (supports_open_folder=false). The
+        // working folder reaches the tool only where the platform arm applies
+        // it, and `bundle_id` is set here, so on macOS `open -b` runs and
+        // Launch Services drops it (`launch::spawn_platform`).
         args_template: vec![],
         supports_open_folder: false,
         detach_strategy: DetachStrategy::OpenBundleId,

--- a/crates/workflow/profiles/tests/spawn_program_paths.rs
+++ b/crates/workflow/profiles/tests/spawn_program_paths.rs
@@ -28,3 +28,28 @@ fn every_spawned_program_is_an_absolute_path() {
         }
     }
 }
+
+/// `resolve_executable` and `discover_from_path` are private and `cfg`-gated to
+/// Linux, and driving them needs `std::env::set_var`, which `unsafe_code =
+/// "forbid"` rules out. Their routing through the absolute-directory filter is
+/// therefore asserted against the source text instead.
+#[test]
+fn every_path_variable_search_routes_through_the_absolute_dir_filter() {
+    let src = include_str!("../src/discover.rs");
+
+    for hand_rolled in ["split(':')", "split(';')"] {
+        assert_eq!(
+            src.matches(hand_rolled).count(),
+            0,
+            "discover.rs: `{hand_rolled}` splits a PATH-style value by hand; \
+             use `absolute_path_dirs`, which drops empty and relative elements",
+        );
+    }
+
+    assert_eq!(
+        src.matches("\"PATH\"").count(),
+        src.matches("absolute_path_dirs(&path_var)").count(),
+        "discover.rs: a PATH read does not reach `absolute_path_dirs`, so it can \
+         yield a candidate resolved against the process working directory",
+    );
+}

--- a/e2e-agentic-test/011-processing-tool-launch/tool-launch-containment/scenario.md
+++ b/e2e-agentic-test/011-processing-tool-launch/tool-launch-containment/scenario.md
@@ -20,9 +20,9 @@
 - UI: project detail action bar → `[data-testid="tool-launch-btn"]`, label
   "Open in {tool}" / working label "Launching…"; disabled with a tooltip when
   no executable is configured. Toasts: "Launched {tool}" /
-  "Failed to launch {tool}: {error}". One-time hint for cwd-anchored tools:
-  "{tool} doesn't accept a folder to open — its working directory is anchored
-  to the project instead." (localStorage `alm.toolhint.cwdAnchored.<toolId>`).
+  "Failed to launch {tool}: {error}". One-time hint for tools that take no
+  folder argument: "{tool} doesn't accept a folder to open — open your project
+  files from inside the app." (localStorage `alm.toolhint.cwdAnchored.<toolId>`).
   Relaunch confirm modal testids: `relaunch-modal`, `relaunch-confirm`,
   `relaunch-cancel`.
 

--- a/specs/011-processing-tool-launch/data-model.md
+++ b/specs/011-processing-tool-launch/data-model.md
@@ -37,8 +37,10 @@ DetachStrategy = "spawn_detached"   // Windows default
 
 ### macOS launch rule (R-BundleId)
 
-- If `bundle_id` is set: `open -b <bundle_id> --args <rendered_argv>` with
-  `cwd` anchored via the Tauri shell API.
+- If `bundle_id` is set: `open -b <bundle_id> --args <rendered_argv>`. No
+  working directory is applied, and none can be: Launch Services starts the
+  app, so the caller's `current_dir` would set the cwd of `open` rather than
+  of the tool. `open -b` also does not report the child PID.
 - If `bundle_id` is null: fall back to direct executable + `setsid`-style
   detach via `pre_exec`.
 - On quarantine/translocation error from `open -b`: surface R-MacQuarantine

--- a/specs/011-processing-tool-launch/research.md
+++ b/specs/011-processing-tool-launch/research.md
@@ -93,12 +93,14 @@ shape:
 | Tool             | `args_template`        | `supports_open_folder` | Notes                                                              |
 | ---------------- | ---------------------- | ---------------------- | ------------------------------------------------------------------ |
 | PixInsight       | `["{folder}"]`         | `true`                 | PixInsight opens the folder in the file explorer panel.            |
-| Siril            | `[]`                   | `false`                | Siril does not accept a folder arg; we set `cwd` only.             |
+| Siril            | `[]`                   | `false`                | Siril does not accept a folder arg. Sets a bundle id, so no `cwd`. |
 | Planetary Suite  | `[]`                   | `false`                | AutoStakkert! opens its own dialog; `cwd` anchors it.              |
 
-Working directory is always set to the resolved project working folder,
-regardless of whether the folder token is present in `args_template`.
-This is the "set cwd, optionally pass folder" behaviour FR-009 requires.
+Where a working directory is applied at all it is the resolved project working
+folder, regardless of whether the folder token is present in `args_template`.
+This is the "set cwd, optionally pass folder" behaviour FR-009 requires. The
+macOS `open -b` bundle-id arm applies none: Launch Services starts the app, so
+the caller's `current_dir` would set the cwd of `open` rather than of the tool.
 
 ### Alternatives Considered
 

--- a/specs/011-processing-tool-launch/spec.md
+++ b/specs/011-processing-tool-launch/spec.md
@@ -46,9 +46,11 @@ Artifact Observation), which only fires when a launch happened.
 
 **Independent Test**: With PixInsight path configured in Settings and a
 PixInsight-bound project selected, click `Open in PixInsight`. PixInsight
-opens, its working directory or initial dialog is anchored to the project's
-generated source-view folder, and a `tool_launch` audit record appears with a
-non-null PID.
+opens and a `tool_launch` audit record appears. On Linux and Windows the
+process starts in the project's generated source-view folder and the record
+carries a non-null PID. On macOS PixInsight launches through its bundle id,
+which carries neither a working directory nor a PID, so the record's PID is
+null and no working-directory observable applies.
 
 **Acceptance Scenarios**:
 

--- a/specs/tiny/tool-discovery-path-dirs-and-cwd-claims.md
+++ b/specs/tiny/tool-discovery-path-dirs-and-cwd-claims.md
@@ -21,10 +21,14 @@ states discovery never returns a relative path.
 
 On macOS a tool with a bundle id launches through `/usr/bin/open`, which cannot
 carry a working directory — Launch Services ignores the caller's `current_dir`
-(recorded at `crates/workflow/profiles/tests/real_spawn_stub.rs:12-16`). Both
-shipped seed profiles set a bundle id, so on macOS no seeded launch applies the
-project working directory. The product nevertheless tells the user it did, in a
-one-time hint and in a source comment.
+(recorded at `crates/workflow/profiles/tests/real_spawn_stub.rs:12-16`). Two of
+the three shipped seed profiles set a bundle id (`seed.rs:20`, `seed.rs:42`) and
+take that arm; `planetary_suite` (`seed.rs:59`) does not, and takes the
+plain-binary arm, which does apply the project working directory
+(`launch.rs:187`). The product nevertheless tells the user the working directory
+is anchored to the project whenever a tool declares
+`supports_open_folder = false`, in a one-time hint and in a source comment, and
+that is false for a tool launched through its bundle id.
 
 ## The rule (decision)
 
@@ -45,8 +49,9 @@ directory.
 
 The one-time launch hint for a tool that takes no folder argument says that and
 nothing more. It does not assert that a working directory is anchored to the
-project, because that assertion is false on macOS for every shipped seed
-profile.
+project, because the hint is gated on `supports_open_folder` alone while the
+working directory is applied per platform arm, so the assertion is false for a
+tool launched on macOS through its bundle id.
 
 The macOS bundle arm carries a comment recording that it applies no working
 directory and why one cannot be applied.
@@ -62,14 +67,14 @@ make the code look correct without changing what the launched tool sees.
 | Finding | Verified at | Reachable with real inputs | Verdict |
 | --- | --- | --- | --- |
 | `astro-plan-3v3r.13.39` | `discover.rs:208-209` (`resolve_executable`), `discover.rs:360-364` (`discover_from_path`) | Yes, on Linux. A distro `.desktop` `Exec=siril` reaches `resolve_executable` (`discover.rs:186`); a malformed user `PATH` then produces a relative candidate. | Fix. Impact is narrower than the finding states: `update_tool` rejects a non-absolute `executable_path` (`crates/app/core/src/tool_launch.rs:564-569`) and is the only writer of that setting, so the observable effect is auto-detect pre-filling a path that the save then refuses, not a launch of an unintended binary. |
-| `astro-plan-3v3r.13.42` | `launch.rs:159-176` (bundle arm, no `current_dir`), `seed.rs:25-27` (comment), `apps/desktop/messages/en-GB.json:1570` and `pt-BR.json:1511`, `apps/desktop/src/features/projects/tool-launch.ts:213-220` (hint gated on `supportsOpenFolder === false` alone) | Yes, on macOS with default settings. Both seed profiles set a bundle id (`seed.rs:20`, `seed.rs:40`), defaulted at `crates/app/core/src/tool_launch.rs:499-502`; the arm is selected by the presence of a bundle id, not by `detach_strategy`. | Correct the claim. The working directory cannot be delivered through `open`, so this is a copy-and-comment remediation with no behaviour change. |
+| `astro-plan-3v3r.13.42` | `launch.rs:159-176` (bundle arm, no `current_dir`), `seed.rs:25-27` (comment), `apps/desktop/messages/en-GB.json:1570` and `pt-BR.json:1511`, `apps/desktop/src/features/projects/tool-launch.ts:213-220` (hint gated on `supportsOpenFolder === false` alone) | Yes, on macOS with default settings. Two of the three seed profiles set a bundle id (`seed.rs:20`, `seed.rs:42`), defaulted at `crates/app/core/src/tool_launch.rs:499-502`; the arm is selected by the presence of a bundle id, not by `detach_strategy`. `planetary_suite` (`seed.rs:59`) sets none and does receive the project working directory (`launch.rs:187`), yet triggers the same hint, which is gated on `supportsOpenFolder === false` alone. | Correct the claim. The working directory cannot be delivered through `open`, so this is a copy-and-comment remediation with no behaviour change. |
 | `astro-plan-3v3r.13.41` | `launch.rs:245-253` delegates to `fs_pathsafe::contain::contained_in_any` (`crates/fs/pathsafe/src/contain.rs:153`), which is `false` for an empty root slice; regression test at `contain.rs:303`; refusal stated at `launch.rs:238-240`. The `tests/proptest_cwd_containment.rs` the finding cites does not exist. | No | Already remediated at head. No change, no test — a test would pass at base. |
 
 ## Context
 
 - `crates/workflow/profiles/src/discover.rs` — the two `PATH` search sites.
 - `crates/workflow/profiles/src/launch.rs` — per-platform spawn arms.
-- `crates/workflow/profiles/src/seed.rs` — the two shipped profiles.
+- `crates/workflow/profiles/src/seed.rs` — the three shipped profiles.
 - `apps/desktop/src/features/projects/tool-launch.ts`, `apps/desktop/messages/*.json` — the hint.
 - `crates/workflow/profiles/tests/spawn_program_paths.rs` — the crate's existing
   source-text assertions for `cfg`-gated arms that no test can execute.
@@ -99,6 +104,10 @@ source-text assertion, not by execution.
 8. The comment at `seed.rs:25-27` no longer asserts that `cwd` is anchored for
    PixInsight.
 9. The macOS bundle arm documents that it applies no working directory.
+10. The two docstrings in `apps/desktop/src/features/projects/tool-launch.ts`
+    that describe the hint state that the tool receives no folder argument and
+    that the project folder reaches it as a working directory only on the
+    platform arms that apply one.
 
 ## Tasks
 
@@ -108,16 +117,22 @@ source-text assertion, not by execution.
       trailing and doubled separators, all-relative fixture
 - [x] Reword `projects_tool_cwd_anchored_hint` in `en-GB.json` and `pt-BR.json`
 - [x] Correct the `seed.rs` comment; document the bundle arm at `launch.rs:159`
+- [x] Reword the two `tool-launch.ts` docstrings that repeat the same claim
 - [x] `cargo clippy -p workflow_profiles --all-targets`, `cargo nextest run -p
       workflow_profiles`, `cargo fmt --all --check`, desktop typecheck and vitest
+- [x] `cargo check -p workflow_profiles --target x86_64-unknown-linux-gnu
+      --all-targets` — every changed `discover.rs` function is behind
+      `cfg(target_os = "linux")` and so is unbuilt by a macOS-only gate run
 
 ## Done When
 
 - [x] Requirements 1-6 each have a test that fails with the `is_absolute` filter
       removed and the helper kept; requirements 3-4 additionally guarded by a
       source-text assertion that fails when either call site splits `PATH` by hand
-- [x] No `PATH`-style split outside `absolute_path_dirs` remains in the workspace
-      (`git grep -nE 'split\(.:.\)|split\(.;.\)'` over `*.rs` clean)
-- [x] Requirements 7-9 verified by reading the changed lines; no behaviour change
+- [x] `git grep -nE 'split\(.:.\)|split\(.;.\)'` over `*.rs` matches only
+      `crates/workflow/profiles/tests/spawn_program_paths.rs:40`, the guard test's
+      own literals, so no executed `PATH`-style split outside `absolute_path_dirs`
+      remains in the workspace
+- [x] Requirements 7-10 verified by reading the changed lines; no behaviour change
       and therefore no test
 - [x] Touched-crate lint and test gates green; desktop typecheck and vitest green

--- a/specs/tiny/tool-discovery-path-dirs-and-cwd-claims.md
+++ b/specs/tiny/tool-discovery-path-dirs-and-cwd-claims.md
@@ -153,19 +153,26 @@ source-text assertion, not by execution.
       remains in the workspace
 - [x] Requirements 7-11 verified by reading the changed lines; no behaviour change
       and therefore no test
-- [x] A tripwire over the claim itself, excluding the guarded legacy task list:
+- [x] A tripwire over the claim itself. It excludes two paths: the guarded legacy
+      011 task list, and this file. This file states the claim in order to
+      describe and forbid it, and quotes the pattern itself, so leaving it in
+      scope makes the check match its own definition and ties the baseline to the
+      spec's wording rather than to the claims it is about. Run from the
+      repository root:
 
       ```
       git grep -nEi 'working (directory|folder|dir).{0,30}(anchor|is always set)|anchor[a-z]*.{0,30}working (directory|folder|dir)|cwd[ `"]{1,4}anchor|anchor[a-z]*[ `"]{1,4}cwd|anchored to the project([^ ]| [^r])' \
-        -- . ':(exclude)specs/011-processing-tool-launch/tasks.md'
+        -- . ':(exclude)specs/011-processing-tool-launch/tasks.md' \
+        ':(exclude)specs/tiny/tool-discovery-path-dirs-and-cwd-claims.md'
       ```
 
-      matches 8 lines, every one of them legitimate: the four
-      `tool-launch.ts` occurrences naming the hint feature, `seed.rs:60` and
-      `research.md:97` for `planetary_suite`, which sets no bundle id and so
-      does receive the working directory, and the two lines of this file that
-      state the defect and the rule. A new unqualified claim lands in the match
-      set. This is a tripwire, not a proof: `git grep` is line-based, so a claim
-      wrapped across two lines can evade it, which is why requirement 11
-      enumerates rather than asserting coverage
+      matches exactly 6 lines, every one of them legitimate: `tool-launch.ts`
+      lines 14, 86, 89 and 180, which name the hint feature rather than making a
+      claim, plus `seed.rs:60` and `research.md:97` for `planetary_suite`, which
+      sets no bundle id and so does receive the working directory. A new
+      unqualified claim lands in the match set. This is a tripwire, not a proof:
+      `git grep` is line-based, so a claim wrapped across two lines can evade it
+      — the legacy task list is exactly that case, matching on only its second
+      line — which is why requirement 11 enumerates rather than asserting
+      coverage
 - [x] Touched-crate lint and test gates green; desktop typecheck and vitest green

--- a/specs/tiny/tool-discovery-path-dirs-and-cwd-claims.md
+++ b/specs/tiny/tool-discovery-path-dirs-and-cwd-claims.md
@@ -108,6 +108,21 @@ source-text assertion, not by execution.
     that describe the hint state that the tool receives no folder argument and
     that the project folder reaches it as a working directory only on the
     platform arms that apply one.
+11. The copies of the cwd-anchored claim named in the table below are corrected
+    or platform-qualified. This enumerates the copies this branch changes; it is
+    not a claim that the repository holds no other copy. The legacy 011 task
+    list is excluded: a repository guard refuses every write under that
+    filename because task state lives in beads. Remaining copies elsewhere in
+    spec 011 are tracked by `astro-plan-6kpeh`.
+
+    | Copy | Was |
+    | --- | --- |
+    | `specs/011-processing-tool-launch/data-model.md:38-45` | R-BundleId specified `open -b` with `cwd` anchored via the Tauri shell API |
+    | `specs/011-processing-tool-launch/spec.md:47-53` | PixInsight's Independent Test asserted a source-view-anchored working directory and a non-null PID on every platform |
+    | `specs/011-processing-tool-launch/research.md:96` | Siril's note said `cwd` is set, though Siril sets a bundle id |
+    | `specs/011-processing-tool-launch/research.md:99-101` | the working directory was "always set" |
+    | `crates/workflow/profiles/src/seed.rs:138-140` | the PixInsight seed test relied on `cwd` anchoring |
+    | `e2e-agentic-test/011-processing-tool-launch/tool-launch-containment/scenario.md:23-25` | quoted the retired hint string verbatim |
 
 ## Tasks
 
@@ -118,6 +133,9 @@ source-text assertion, not by execution.
 - [x] Reword `projects_tool_cwd_anchored_hint` in `en-GB.json` and `pt-BR.json`
 - [x] Correct the `seed.rs` comment; document the bundle arm at `launch.rs:159`
 - [x] Reword the two `tool-launch.ts` docstrings that repeat the same claim
+- [x] Correct the surviving design-artifact copies enumerated in requirement 11:
+      011 `data-model.md`, `spec.md`, `research.md`, the PixInsight seed test
+      comment, and the agentic e2e scenario's quoted hint string
 - [x] `cargo clippy -p workflow_profiles --all-targets`, `cargo nextest run -p
       workflow_profiles`, `cargo fmt --all --check`, desktop typecheck and vitest
 - [x] `cargo check -p workflow_profiles --target x86_64-unknown-linux-gnu
@@ -133,6 +151,21 @@ source-text assertion, not by execution.
       `crates/workflow/profiles/tests/spawn_program_paths.rs:40`, the guard test's
       own literals, so no executed `PATH`-style split outside `absolute_path_dirs`
       remains in the workspace
-- [x] Requirements 7-10 verified by reading the changed lines; no behaviour change
+- [x] Requirements 7-11 verified by reading the changed lines; no behaviour change
       and therefore no test
+- [x] A tripwire over the claim itself, excluding the guarded legacy task list:
+
+      ```
+      git grep -nEi 'working (directory|folder|dir).{0,30}(anchor|is always set)|anchor[a-z]*.{0,30}working (directory|folder|dir)|cwd[ `"]{1,4}anchor|anchor[a-z]*[ `"]{1,4}cwd|anchored to the project([^ ]| [^r])' \
+        -- . ':(exclude)specs/011-processing-tool-launch/tasks.md'
+      ```
+
+      matches 8 lines, every one of them legitimate: the four
+      `tool-launch.ts` occurrences naming the hint feature, `seed.rs:60` and
+      `research.md:97` for `planetary_suite`, which sets no bundle id and so
+      does receive the working directory, and the two lines of this file that
+      state the defect and the rule. A new unqualified claim lands in the match
+      set. This is a tripwire, not a proof: `git grep` is line-based, so a claim
+      wrapped across two lines can evade it, which is why requirement 11
+      enumerates rather than asserting coverage
 - [x] Touched-crate lint and test gates green; desktop typecheck and vitest green

--- a/specs/tiny/tool-discovery-path-dirs-and-cwd-claims.md
+++ b/specs/tiny/tool-discovery-path-dirs-and-cwd-claims.md
@@ -1,0 +1,123 @@
+# TinySpec: Discovery searches only absolute directories, and the product claims a working directory only where one is applied
+
+**Branch**: fix/path3-tool-discovery-cwd
+**Date**: 2026-08-23
+**Status**: implemented
+**Complexity**: small
+**Findings**: astro-plan-3v3r.13.39 (LIVE), astro-plan-3v3r.13.42 (LIVE),
+astro-plan-3v3r.13.41 (already remediated at head)
+
+## What
+
+Two independent defects in `crates/workflow/profiles`, joined only by the working
+directory.
+
+Auto-discovery on Linux searches `PATH` by splitting on `:` and joining each
+element with the program name. POSIX defines an empty element as the current
+working directory, so a leading, trailing or doubled colon in the user's `PATH`
+yields a candidate that `Path::exists` resolves against whatever directory the
+app was started from. The module doc at `crates/workflow/profiles/src/discover.rs:19`
+states discovery never returns a relative path.
+
+On macOS a tool with a bundle id launches through `/usr/bin/open`, which cannot
+carry a working directory — Launch Services ignores the caller's `current_dir`
+(recorded at `crates/workflow/profiles/tests/real_spawn_stub.rs:12-16`). Both
+shipped seed profiles set a bundle id, so on macOS no seeded launch applies the
+project working directory. The product nevertheless tells the user it did, in a
+one-time hint and in a source comment.
+
+## The rule (decision)
+
+### Discovery search directories are absolute, and the caller supplies the variable
+
+Every search of a `PATH`-style variable goes through one helper that takes the
+variable's value as a parameter and yields only directories for which
+`Path::is_absolute` holds. An empty element parses to an empty path, which
+`is_absolute` rejects, so the same filter covers empty and relative elements.
+The helper is compiled wherever a test can reach it, so its tests run on every
+CI lane rather than only the Linux one, and it uses `std::env::split_paths` so
+the separator and quoting rules are the host's.
+
+No caller of the helper resolves a candidate relative to the process working
+directory.
+
+### The product states only what holds on the platform it is running on
+
+The one-time launch hint for a tool that takes no folder argument says that and
+nothing more. It does not assert that a working directory is anchored to the
+project, because that assertion is false on macOS for every shipped seed
+profile.
+
+The macOS bundle arm carries a comment recording that it applies no working
+directory and why one cannot be applied.
+
+### No `current_dir` is added to the `open` command
+
+`Command::current_dir` on `/usr/bin/open` changes the working directory of
+`open` itself, not of the application Launch Services starts. Adding one would
+make the code look correct without changing what the launched tool sees.
+
+## Per-finding verdict at head `5b1fdf702f7ad12d52ea429a255cc69874ef5a2b`
+
+| Finding | Verified at | Reachable with real inputs | Verdict |
+| --- | --- | --- | --- |
+| `astro-plan-3v3r.13.39` | `discover.rs:208-209` (`resolve_executable`), `discover.rs:360-364` (`discover_from_path`) | Yes, on Linux. A distro `.desktop` `Exec=siril` reaches `resolve_executable` (`discover.rs:186`); a malformed user `PATH` then produces a relative candidate. | Fix. Impact is narrower than the finding states: `update_tool` rejects a non-absolute `executable_path` (`crates/app/core/src/tool_launch.rs:564-569`) and is the only writer of that setting, so the observable effect is auto-detect pre-filling a path that the save then refuses, not a launch of an unintended binary. |
+| `astro-plan-3v3r.13.42` | `launch.rs:159-176` (bundle arm, no `current_dir`), `seed.rs:25-27` (comment), `apps/desktop/messages/en-GB.json:1570` and `pt-BR.json:1511`, `apps/desktop/src/features/projects/tool-launch.ts:213-220` (hint gated on `supportsOpenFolder === false` alone) | Yes, on macOS with default settings. Both seed profiles set a bundle id (`seed.rs:20`, `seed.rs:40`), defaulted at `crates/app/core/src/tool_launch.rs:499-502`; the arm is selected by the presence of a bundle id, not by `detach_strategy`. | Correct the claim. The working directory cannot be delivered through `open`, so this is a copy-and-comment remediation with no behaviour change. |
+| `astro-plan-3v3r.13.41` | `launch.rs:245-253` delegates to `fs_pathsafe::contain::contained_in_any` (`crates/fs/pathsafe/src/contain.rs:153`), which is `false` for an empty root slice; regression test at `contain.rs:303`; refusal stated at `launch.rs:238-240`. The `tests/proptest_cwd_containment.rs` the finding cites does not exist. | No | Already remediated at head. No change, no test — a test would pass at base. |
+
+## Context
+
+- `crates/workflow/profiles/src/discover.rs` — the two `PATH` search sites.
+- `crates/workflow/profiles/src/launch.rs` — per-platform spawn arms.
+- `crates/workflow/profiles/src/seed.rs` — the two shipped profiles.
+- `apps/desktop/src/features/projects/tool-launch.ts`, `apps/desktop/messages/*.json` — the hint.
+- `crates/workflow/profiles/tests/spawn_program_paths.rs` — the crate's existing
+  source-text assertions for `cfg`-gated arms that no test can execute.
+
+Constitution III makes tool launches detached and unsupervised: no test may
+spawn a real `.app` bundle, so the macOS bundle arm is verified by reading and by
+source-text assertion, not by execution.
+
+## Requirements
+
+1. A helper in `discover.rs` takes a `PATH`-style value as a parameter and yields
+   only absolute directories.
+2. The helper drops empty elements, relative elements, and both leading and
+   trailing separators, on the host separator.
+3. `resolve_executable` returns `None` rather than a relative path when every
+   `PATH` element is relative or empty.
+4. `discover_from_path` yields no result derived from a relative or empty `PATH`
+   element.
+5. The helper and its tests compile on macOS, Linux and Windows — it is gated
+   `#[cfg(any(target_os = "linux", test))]`, not `cfg(unix)`, because
+   `Path::is_absolute` is platform-dependent and the fixtures are built through
+   `fs_pathsafe::test_support` and `std::env::join_paths`.
+6. No test of requirements 1-4 depends on any tool being installed, and none
+   mutates the process environment.
+7. The `projects_tool_cwd_anchored_hint` string in every message catalogue states
+   that the tool accepts no folder to open and makes no working-directory claim.
+8. The comment at `seed.rs:25-27` no longer asserts that `cwd` is anchored for
+   PixInsight.
+9. The macOS bundle arm documents that it applies no working directory.
+
+## Tasks
+
+- [x] Add `absolute_path_dirs` to `discover.rs`, compiled on all platforms
+- [x] Route `resolve_executable` and `discover_from_path` through it
+- [x] Unit tests: absolute-only fixture, malformed fixture with leading,
+      trailing and doubled separators, all-relative fixture
+- [x] Reword `projects_tool_cwd_anchored_hint` in `en-GB.json` and `pt-BR.json`
+- [x] Correct the `seed.rs` comment; document the bundle arm at `launch.rs:159`
+- [x] `cargo clippy -p workflow_profiles --all-targets`, `cargo nextest run -p
+      workflow_profiles`, `cargo fmt --all --check`, desktop typecheck and vitest
+
+## Done When
+
+- [x] Requirements 1-6 each have a test that fails with the `is_absolute` filter
+      removed and the helper kept; requirements 3-4 additionally guarded by a
+      source-text assertion that fails when either call site splits `PATH` by hand
+- [x] No `PATH`-style split outside `absolute_path_dirs` remains in the workspace
+      (`git grep -nE 'split\(.:.\)|split\(.;.\)'` over `*.rs` clean)
+- [x] Requirements 7-9 verified by reading the changed lines; no behaviour change
+      and therefore no test
+- [x] Touched-crate lint and test gates green; desktop typecheck and vitest green


### PR DESCRIPTION
Tracks-Bead: astro-plan-3h8vc
Tracks-Bead: astro-plan-3v3r.13.39
Tracks-Bead: astro-plan-3v3r.13.42
Merge-Bead: astro-plan-jx5o6

## Summary

- Tool auto-detect no longer offers an executable path that depends on the
  folder the app was started from, so a malformed `PATH` can no longer produce a
  suggestion the settings screen then refuses to save.
- On macOS the app no longer tells you a launched tool starts in the project
  folder. It cannot: apps opened by bundle id are started by Launch Services,
  which decides their working directory.

- Spec 011's design artifacts said the same thing and are corrected with it, and
  a `git grep` tripwire now guards the claim.

Two defects in `crates/workflow/profiles`, joined only by the working directory.

Work bead `astro-plan-3h8vc`. Merge bead `astro-plan-jx5o6`.

## Auto-detect searched relative directories (`astro-plan-3v3r.13.39`)

**Reachable in production, on Linux.** Discovery split `PATH` on `:` and joined
each element with the program name. POSIX gives an empty element the meaning
"current working directory", so a leading, trailing or doubled colon in the
user's own `PATH` produced a candidate that `Path::exists` resolved against
whatever directory the app was started from. A distro-packaged `.desktop` with
`Exec=siril` reaches that code on a stock machine (`discover.rs:186`).

**Corrected impact.** The finding claims the launched binary depends on the
launch directory. It does not. `update_tool` rejects a non-absolute
`executable_path` (`crates/app/core/src/tool_launch.rs:564-569`) and is the only
writer of that setting, and both the settings screen and the setup wizard save
through it. The observable effect was auto-detect pre-filling a garbage relative
path and the save then failing with "must be absolute" — a rejected save, not a
hijacked launch.

Both search sites now route through one `absolute_path_dirs` helper built on
`std::env::split_paths`, filtered to `Path::is_absolute`. An empty element parses
to an empty path, which that filter already rejects, so one filter covers both
halves of the finding. The helper takes the variable's value as a parameter, so
its tests need no `std::env::set_var` — unavailable here under
`unsafe_code = "forbid"`.

The helper is gated `#[cfg(any(target_os = "linux", test))]`, the idiom already
used in this file, not `cfg(unix)`: `Path::is_absolute` is platform-dependent, and
a `cfg(unix)` gate would leave the Windows lane compiling neither the helper nor
its tests. Fixtures are built with `fs_pathsafe::test_support::abs` and
`std::env::join_paths`, so the malformed shapes under test use the host separator.

## macOS promised a working directory it never applied (`astro-plan-3v3r.13.42`)

**Reachable with default settings on macOS.** A profile with a bundle id launches
through `/usr/bin/open`, and Launch Services ignores the caller's `current_dir`
(already recorded at `crates/workflow/profiles/tests/real_spawn_stub.rs:12-16`),
so `req.working_dir` never reaches the tool. Two of the three shipped seed
profiles set a bundle id (`seed.rs:20`, `seed.rs:42`, defaulted at
`tool_launch.rs:499-502`) and the arm is selected by the presence of a bundle id
alone — `detach_strategy` is not consulted. `planetary_suite` (`seed.rs:59`) sets
none, so it takes the plain-binary arm and does receive the project working
directory (`launch.rs:187`), yet it triggers the same hint, which is gated on
`supportsOpenFolder === false` alone. Meanwhile the one-time hint told the user "its working directory
is anchored to the project instead", and `seed.rs` said the same in a comment.

**No `.current_dir` was added to the `open` command**, because Launch Services
ignores it: it would set the working directory of `open` itself and change
nothing the user can observe.

The claim is corrected instead. The hint now says only that the tool takes no
folder to open, which holds on every platform; the `seed.rs` comment and the
bundle arm record where the working folder is applied and where it cannot be.
This is a copy-and-comment remediation with **no behaviour change**, and
therefore no base-failing test — a test here would pass at base and prove
nothing.

The same claim survived in spec 011's own design artifacts and in two places no
earlier pass reached. All are corrected here and enumerated in requirement 11 of
the TinySpec: `data-model.md`'s R-BundleId rule, which specified `open -b` "with
`cwd` anchored via the Tauri shell API"; PixInsight's Independent Test in
`spec.md`, which asserted a source-view-anchored working directory and a non-null
PID on every platform, though `open -b` reports neither; `research.md`'s Siril row
and its "always set" paragraph; the PixInsight seed test comment
(`seed.rs:138-140`); and the agentic e2e scenario at
`e2e-agentic-test/011-processing-tool-launch/tool-launch-containment/scenario.md:23-25`,
which quoted the retired hint string verbatim and would have judged a run against
copy that no longer ships.

The legacy 011 task list repeats the claim at T020 and T021 and is **not** fixed
here: a repository guard refuses every write under that filename, because task
state lives in beads and those files are read-only legacy. Tracked by
`astro-plan-6kpeh`, together with the copies elsewhere in spec 011 that this
branch's scope does not cover.

To stop the next copy, the TinySpec's Done When now carries a `git grep` tripwire
over the claim itself, replacing "verified by reading" — the enforcement that four
review passes showed was absent. Its current match set is 8 lines, all
legitimate. It is a tripwire and is documented as one: `git grep` is line-based,
so a claim wrapped across two lines evades it, which is why requirement 11
enumerates the corrected copies rather than asserting the repository holds none.

Route (b) of the two offered. Route (a) — a contract field exposing per-platform
working-directory support, gating the toast — buys a nuance the user cannot act
on, at the cost of contract surface and generated-code churn; the hint's
actionable content is "open your files from inside the app", which is now all it
says.

## Verified already remediated, not fixed here (`astro-plan-3v3r.13.41`)

`verify_cwd_containment` (`launch.rs:238-253`) delegates to
`fs_pathsafe::contain::contained_in_any` (`crates/fs/pathsafe/src/contain.rs:153`),
which is `false` for an empty root slice; the refusal is stated in the docstring
and covered by `contained_in_any_refuses_when_no_root_is_registered`
(`contain.rs:303`). The `tests/proptest_cwd_containment.rs` the finding cites no
longer exists. No change, and no test: one would pass at base. The bead stays
open for the parent to close.

## Base-failing tests

| Bead | Test | Fails at base? | How confirmed |
| --- | --- | --- | --- |
| `astro-plan-3v3r.13.39` | `discover::tests::absolute_path_dirs_drops_empty_and_relative_elements` | Yes | Deleted the `is_absolute` filter from the helper, keeping the helper and both call sites. `cargo nextest run -p workflow_profiles -E 'test(absolute_path_dirs)'` gave FAIL: `assertion left == right failed; left: ["", "/opt/astro/bin", "", "tools/bin", "/usr/local/bin", ""], right: ["/opt/astro/bin", "/usr/local/bin"]` |
| `astro-plan-3v3r.13.39` | `discover::tests::absolute_path_dirs_yields_nothing_when_no_element_is_absolute` | Yes | Same reverted filter, same command, FAIL: `assertion left == right failed; left: 4, right: 0` |
| `astro-plan-3v3r.13.39` | `spawn_program_paths::every_path_variable_search_routes_through_the_absolute_dir_filter` | Yes | Restored the helper, then reverted `resolve_executable` alone to its original hand-rolled colon split. `cargo nextest run -p workflow_profiles -E 'test(routes_through)'` gave FAIL on the hand-rolled-split count assertion. This guards the half of the finding no executable test can reach: both functions are private and `cfg`-gated to Linux, and driving them needs `set_var`. |
| `astro-plan-3v3r.13.42` | none | n/a | Copy and comments only, no behaviour change. Stated rather than dressed up. |
| `astro-plan-3v3r.13.41` | none | n/a | Already remediated at base. |

Neither new unit test depends on any tool being installed, and neither mutates
the environment, so the vacuous-pass trap at `tool_launch.rs:1103-1109` does not
apply. That trap is itself a defect in `discover_does_not_panic`, deferred to
`astro-plan-wadr1`: the file is outside this branch's scope, and the invariant is
covered non-vacuously by the new `absolute_path_dirs` unit tests.

## Commands

All from the worktree with `CARGO_TARGET_DIR` set to a private directory.

| Command | Exit |
| --- | --- |
| `cargo fmt --all --check` | 0 |
| `cargo clippy -p workflow_profiles --all-targets` (macOS host) | 0, no issues |
| `cargo nextest run -p workflow_profiles` (macOS host) | 0, 38 tests, 38 passed |
| `cargo check -p workflow_profiles --target x86_64-unknown-linux-gnu --all-targets` | 0 |
| `cargo clippy -p workflow_profiles --target x86_64-unknown-linux-gnu --all-targets -- -D warnings` | 0, no issues |
| `pnpm install --frozen-lockfile` | 0 |
| `just typecheck` | 0 |
| `bash scripts/check-lifecycle-strings.sh` | 0 |
| `pnpm vitest run src/features/projects src/features/setup` | 0, 44 files, 433 tests passed |
| workspace grep for hand-rolled colon/semicolon splits over `*.rs` | only the guard test's own literals |

Every function this change touched in `discover.rs` is behind
`cfg(target_os = "linux")`, so the host rows above do not build it and the
Linux-target rows are what cover this diff. An earlier revision of this branch
compiled on macOS but failed three CI jobs on a Linux-only E0597 in
`resolve_executable`; the borrow is now bound to a local before the tail
expression.

`just check` was not run: it is workspace-wide and exits 1 today on a
pre-existing typo in `crates/app/inbox` (`astro-plan-8vxx1`).

## Spec Context

`specs/tiny/tool-discovery-path-dirs-and-cwd-claims.md`


