### PR TITLE
fix: pin the bundled star-catalogue files to committed checksums so a swapped catalogue fails the build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -39,3 +39,9 @@ specs/**/contracts/*.generated.json text eol=lf
 # checksum (SHA-384 of file bytes) is identical on all platforms.
 *.sql text eol=lf
 *.rs text eol=lf
+
+# The bundled star-catalogue blobs are pinned by a SHA-256 of their exact bytes
+# in `crates/targeting/resolver/tests/bundled_seed_digest.rs`. A Windows checkout
+# would otherwise convert them to CRLF and fail that digest there — and only
+# there. The committed blobs are already LF, so the pinned digests are unchanged.
+assets/seed/*.json text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,11 @@ jobs:
               - 'apps/desktop/src-tauri/**'
               - 'tests/**'
               - '**/*.rs'
+              # Compiled into Rust artifacts by `include_bytes!`, so a change
+              # here invalidates the Rust lane even though no `.rs` file moved.
+              # Without this entry a seed-refresh PR touching only these blobs
+              # skips `integration` entirely, including the digest guard.
+              - 'assets/seed/**'
             frontend:
               - 'apps/desktop/src/**'
               - 'apps/desktop/public/**'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6497,6 +6497,7 @@ dependencies = [
  "persistence_targets",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "simbad-resolver",
  "skymath 0.7.2",
  "sqlx",

--- a/crates/targeting/resolver/Cargo.toml
+++ b/crates/targeting/resolver/Cargo.toml
@@ -64,6 +64,9 @@ tokio = { workspace = true }
 # this test constructs the crate's facade directly.
 simbad-resolver = { version = "0.5.0", features = ["test-util"] }
 tempfile = { workspace = true }
+# `tests/bundled_seed_digest.rs` only: pins the out-of-crate `assets/seed/*.json`
+# embeds to committed SHA-256 literals.
+sha2.workspace = true
 
 [features]
 # Enables the seeded in-memory test fixture (FakeResolver) for use in

--- a/crates/targeting/resolver/tests/bundled_seed_digest.rs
+++ b/crates/targeting/resolver/tests/bundled_seed_digest.rs
@@ -1,0 +1,49 @@
+//! Pins the two out-of-crate seed blobs embedded by `src/seed.rs` to committed
+//! SHA-256 literals, so a byte change inside a multi-megabyte JSON file is
+//! visible in review instead of invisible.
+//!
+//! Two invariants make this non-vacuous and must survive any edit here:
+//!
+//! - The bytes come from `include_bytes!` of the same paths the production
+//!   loaders use, so a wrong path fails at compile time and the digest covers
+//!   what actually ships rather than a file re-read at test runtime.
+//! - The expected values are literals a human edits. Deriving them from the
+//!   working tree (a recipe, a `SHA256SUMS` file, a `build.rs`) would give a
+//!   swapped blob a matching digest in the same commit.
+//!
+//! No OS `cfg` gate and no newline normalization: `.gitattributes` pins
+//! `assets/seed/*.json` to `eol=lf` so these digests hold on every platform,
+//! and normalizing bytes before hashing would defeat a byte digest.
+
+use sha2::{Digest, Sha256};
+
+const SEED_JSON: &[u8] =
+    include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../../assets/seed/seed.json"));
+
+const SEED_E2E_JSON: &[u8] =
+    include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/../../../assets/seed/seed-e2e.json"));
+
+const SEED_JSON_SHA256: &str = "aa442354ca1f36cd0f56acea209ae19390c479e9affe94e10fd135d09313365a";
+
+const SEED_E2E_JSON_SHA256: &str =
+    "ec41a79461c76693dbfa67b7526f7178d059f62b931696a0317b0829ab545c9f";
+
+fn assert_pinned(path: &str, bytes: &[u8], expected: &str) {
+    let actual = format!("{:x}", Sha256::digest(bytes));
+    assert_eq!(
+        actual, expected,
+        "{path} no longer matches its pinned digest\n  expected: {expected}\n  \
+         actual:   {actual}\nEither the committed blob changed or the literal in this \
+         test is stale. Confirm the blob change was intended before updating the literal."
+    );
+}
+
+#[test]
+fn bundled_seed_matches_pinned_digest() {
+    assert_pinned("assets/seed/seed.json", SEED_JSON, SEED_JSON_SHA256);
+}
+
+#[test]
+fn bundled_e2e_seed_matches_pinned_digest() {
+    assert_pinned("assets/seed/seed-e2e.json", SEED_E2E_JSON, SEED_E2E_JSON_SHA256);
+}

--- a/specs/tiny/bundled-seed-asset-digest.md
+++ b/specs/tiny/bundled-seed-asset-digest.md
@@ -1,0 +1,130 @@
+# TinySpec: Out-of-crate bundled seed blobs are pinned to committed SHA-256 literals
+
+**Branch**: fix/lp3-seed-asset-digest
+**Date**: 2026-08-23
+**Status**: draft
+**Complexity**: small
+
+## What
+
+`crates/targeting/resolver/src/seed.rs` embeds two JSON blobs that live outside the
+crate, at `assets/seed/seed.json` (4 764 178 B, ~13 073 entries) and
+`assets/seed/seed-e2e.json` (90 490 B). The full blob is produced by a SIMBAD TAP
+network fetch in `crates/tools/seed-builder`, and it ships: it is compiled into the
+desktop binary and warmed into the user's resolve cache on first run.
+
+`git ls-tree` of `assets/seed/` carries no `.sha256`, no signature and no manifest, so
+nothing in the repository asserts what those bytes are. A one-byte change inside a
+4.5 MB JSON file is not detectable by a human reading the diff, and `opengrep` skips
+files over 1 MB, so no scanner reads it either. The blobs are intact today; what is
+missing is the ability to notice if they stop being intact.
+
+## The rule (decision)
+
+Bytes compiled into a shipped artifact from outside the compiling crate are pinned by
+a SHA-256 hex literal committed in the test source, and the digest is taken from the
+embedded bytes rather than from a runtime file read.
+
+### One digest literal per blob, in the test source
+
+Each embedded blob gets its own `const` hex literal and its own assertion. A shared or
+combined digest is not acceptable: it cannot say which blob moved. The literal is a
+short line a reviewer reads in the diff.
+
+### The digest is computed, never regenerated
+
+No recipe, `build.rs` or committed `SHA256SUMS` file derives the expected value from
+the working tree. A generator run in the same commit as a swapped blob produces a
+matching digest and proves nothing. The expected value is only ever changed by a human
+editing the literal, which puts the change in the diff.
+
+### The digest covers what ships
+
+The assertion hashes bytes obtained through `include_bytes!` of the same paths the
+production loaders use. A path typo then fails at compile time rather than passing
+vacuously, and a file re-read at test runtime cannot diverge from the embed.
+
+### An assets-only change reaches the Rust lane
+
+`assets/seed/**` is part of the `rust` paths filter in `.github/workflows/ci.yml`.
+Those bytes are compiled into Rust artifacts, so a change there invalidates the Rust
+lane, and without the filter entry a pull request touching only the blobs skips the
+`integration` job entirely (gate at `.github/workflows/ci.yml:287-289`).
+
+### The blobs are LF on every platform
+
+`.gitattributes` pins `assets/seed/*.json` to `text eol=lf`. A byte digest is
+platform-dependent otherwise: `windows-latest` checks out with `core.autocrlf=true`,
+the working tree gets CRLF, and the digest mismatches on Windows alone. The digest is
+never made to pass by an OS `cfg` gate or by normalizing newlines, both of which would
+defeat a byte digest.
+
+## Per-finding verdict at head efaaf57a0d800a91efab5437d6d4eac32cc78ad5
+
+| Bead | Verified site | Reachable with real inputs | Verdict |
+| --- | --- | --- | --- |
+| `astro-plan-3v3r.19.18` | `crates/targeting/resolver/src/seed.rs:201` (`seed.json`), `:218` (`seed-e2e.json`) | Yes for `:201` — `apps/desktop/src-tauri/src/lib.rs:896` and `apps/desktop/src-tauri/src/resolve_cache.rs:138` call `seed::warm_bundled_on_first_run`, which calls `bundled()` at `crates/targeting/resolver/src/seed.rs:407`. `:218` is reached only by the E2E pre-warm harness. | Confirmed as a review-visibility gap, not a runtime fault. Both blobs hash at this head to the values pinned by this spec, so no tampering has occurred. |
+
+## Context
+
+- Precedent for the shape: `crates/persistence/core/tests/baseline_invariants.rs:111-125`
+  freezes the `0001` migration against a committed 48-byte checksum literal.
+- Precedent for the `eol=lf` reasoning: `.gitattributes` already pins `*.sql` and
+  `*.rs` with the comment that the frozen baseline checksum must be identical on all
+  platforms.
+- `sha2 = "0.10"` is already a workspace dependency (`Cargo.toml:61`), used as
+  `sha2.workspace = true` by five crates.
+- Measured digests at this head:
+
+```
+assets/seed/seed.json      aa442354ca1f36cd0f56acea209ae19390c479e9affe94e10fd135d09313365a
+assets/seed/seed-e2e.json  ec41a79461c76693dbfa67b7526f7178d059f62b931696a0317b0829ab545c9f
+```
+
+## Requirements
+
+1. A test in `crates/targeting/resolver` hashes the `include_bytes!` embed of
+   `assets/seed/seed.json` with SHA-256 and asserts it equals a committed hex literal.
+2. The same test file does the equivalent for `assets/seed/seed-e2e.json` against its
+   own separate hex literal.
+3. Mutating one byte of either blob fails the corresponding assertion, and the failure
+   message names the blob and prints both the expected and actual digests.
+4. `assets/seed/**` matches the `rust` filter in `.github/workflows/ci.yml`, so a
+   change confined to those files runs the Rust lane.
+5. `.gitattributes` pins `assets/seed/*.json` to `text eol=lf`, so requirement 1 and 2
+   hold byte-identically on Windows, macOS and Linux.
+6. Neither assertion is gated on target OS, and neither normalizes newlines before
+   hashing.
+
+## Tasks
+
+- [ ] Add `sha2` to `[dev-dependencies]` of `crates/targeting/resolver/Cargo.toml` as
+      `sha2.workspace = true`
+- [ ] Add the digest test with one `const` literal and one assertion per blob
+- [ ] Add `'assets/seed/**'` to the `rust` paths filter in `.github/workflows/ci.yml`
+- [ ] Add `assets/seed/*.json text eol=lf` to `.gitattributes` with its reason
+- [ ] Prove non-vacuity: mutate one byte of each blob, observe the failure naming that
+      blob, restore, observe the pass
+- [ ] `cargo fmt`, `cargo clippy -p targeting_resolver --all-targets`,
+      `cargo nextest run -p targeting_resolver`, `cargo machete`
+
+## Done When
+
+- [ ] `cargo nextest run -p targeting_resolver` passes with both digest assertions present
+- [ ] A single-byte mutation of either blob fails that blob's assertion and no other
+- [ ] `git status --porcelain` is clean for `assets/` before the commit
+- [ ] The `rust` filter block in `.github/workflows/ci.yml` contains `'assets/seed/**'`
+- [ ] `.gitattributes` contains `assets/seed/*.json text eol=lf`
+- [ ] Clippy and fmt are clean for `targeting_resolver`
+
+## Out of scope
+
+Named here so the boundary is explicit, not implied:
+
+- Authenticity and provenance. There is no signature and no repository key, so this
+  establishes tamper-evidence in review and nothing more.
+- Verification inside `crates/tools/seed-builder`, which still fetches over the network
+  unverified. Tracked as `astro-plan-3v3r.10`.
+- The other out-of-crate embeds. `crates/metadata/core/src/profile.rs:13` is in-crate
+  and hand-authored; `crates/e2e-tests/tests/common/boot.rs:250` is test-only, in-repo,
+  hand-authored and ships in nothing. Neither is network-derived.


### PR DESCRIPTION
## Summary

- The desktop app compiles two JSON blobs into its binary from outside the compiling crate: `assets/seed/seed.json` (4 764 178 B, ~13 073 entries, produced by a SIMBAD TAP network fetch in `crates/tools/seed-builder`) at `crates/targeting/resolver/src/seed.rs:201`, and `assets/seed/seed-e2e.json` (90 490 B) at `:218`. Nothing in the repository asserted what those bytes were.
- This pins both blobs to committed SHA-256 literals, adds `assets/seed/**` to the `rust` CI paths filter, and pins those files to `eol=lf`.

## The defect, stated precisely

**Reachable in production.** `apps/desktop/src-tauri/src/lib.rs:896` and `apps/desktop/src-tauri/src/resolve_cache.rs:138` call `targeting_resolver::seed::warm_bundled_on_first_run`, which calls `bundled()` (`crates/targeting/resolver/src/seed.rs:407`), which reads the `:201` embed. Those bytes ship in the desktop binary and are warmed into the user's resolve cache on first run.

**No runtime misbehaviour existed and nothing was exploited.** The committed blob hashes to `aa442354ca1f36cd0f56acea209ae19390c479e9affe94e10fd135d09313365a`, the same value it had at `d583a7e81`. What was missing is the ability to notice a change: `git ls-tree` of `assets/seed/` carried no checksum, no signature and no manifest; a one-byte edit inside a 4.5 MB JSON file is not visible to a human reading the diff; and `opengrep` skips files over 1 MB, so no scanner read it either. This closes a review gap.

**What it gives is tamper-evidence in review, not authenticity or provenance.** There is no signature and no repository key.

## Which check fails at base

| Item | Evidence at base | Exit code |
| --- | --- | --- |
| digest of `seed.json` | test absent at base; with the test present, flipping one byte at offset 2000000 fails `bundled_seed_matches_pinned_digest` and no other test (`2 tests run: 1 passed, 1 failed`) | 100 |
| digest of `seed-e2e.json` | test absent at base; flipping one byte at offset 40000 fails `bundled_e2e_seed_matches_pinned_digest` and no other test (`2 tests run: 1 passed, 1 failed`) | 100 |
| both blobs restored | `git checkout --` on each, digests re-derived to the pinned values, `2 tests run: 2 passed` | 0 |
| `assets/seed/**` reaches the Rust lane | at base the filter block at `.github/workflows/ci.yml:161-165` had no `assets` entry, so an assets-only change matched no filter and skipped `integration` (job gate at `.github/workflows/ci.yml:287-289`, whose Rust step is additionally gated on `rust == 'true'`) | n/a, config |
| `eol=lf` for the seed blobs | at base absent; `windows-latest` checks out with `core.autocrlf=true`, so a byte digest would fail on the Windows leg alone | n/a, config |

Each failure message names the blob and prints both the expected and the actual digest. `git status --porcelain assets/` was verified empty before committing, so no mutated blob reached the branch.

## Why a committed literal

The expected value is a short line a reviewer reads in the diff, changed only by a human editing it. A recipe regenerating a `SHA256SUMS` file, or a `build.rs` digest computed from the working tree, would hand a swapped blob a matching digest in the same commit and prove nothing. The shape follows the existing precedent at `crates/persistence/core/tests/baseline_invariants.rs:111-125`, which freezes the `0001` migration against a committed checksum literal.

The digest is taken from an `include_bytes!` embed of the same paths the production loaders use, not from a runtime file read: a wrong path then fails at compile time rather than passing vacuously, and the assertion covers what actually ships.

Neither assertion is gated on target OS and neither normalizes newlines before hashing, since both would defeat a byte digest. The `eol=lf` attribute is what makes them hold on Windows. Adding that attribute does not change the committed blobs, which are already LF, so the pinned digests are unaffected.

## What this does not fix

- No signature and no provenance chain for the SIMBAD fetch.
- `crates/tools/seed-builder` still fetches over the network with no verification. Routed to `astro-plan-3v3r.10`.
- The other out-of-crate embeds are deliberately untouched and are not this defect class: `crates/metadata/core/src/profile.rs:13` (`include_str!` of `../data/capture_profiles.toml`) is in-crate and hand-authored; `crates/e2e-tests/tests/common/boot.rs:250` (`include_str!` of `tauri.conf.json`) is out-of-crate but test-only, in-repo, hand-authored, and ships in nothing. Neither is network-derived.
- `crates/tools/seed-builder` and the `justfile` are untouched despite being named in the originating plan row: `git grep -i seed <base> -- justfile .github/workflows` returns zero hits, and seed-builder is `publish = false`, maintainer-run, and gates nothing.

## Verification

`cargo nextest run -p targeting_resolver` reports 93 tests run, 93 passed, 0 skipped. `cargo clippy -p targeting_resolver --all-targets` reports no issues. `cargo fmt --check` is clean. `cargo machete` exits 1 on pre-existing unused dependencies in ten other crates and does not flag `targeting_resolver`. All re-run green after merging `origin/main` at `5b1fdf702`.

## Spec Context

`specs/tiny/bundled-seed-asset-digest.md` states the rule this establishes and carries the per-finding verdict at base `efaaf57a0d800a91efab5437d6d4eac32cc78ad5`.

Refs `astro-plan-3v3r.19.18`, which stays open until merge.

Tracks-Bead: astro-plan-c1vux
Tracks-Bead: astro-plan-3v3r.19.18
Merge-Bead: astro-plan-d9h6u
