### PR TITLE
fix: out-of-range stored values fall back to their documented defaults instead of zero or a fabricated date

### DIFF
--- a/apps/desktop/src-tauri/src/commands/target_lookup.rs
+++ b/apps/desktop/src-tauri/src/commands/target_lookup.rs
@@ -126,8 +126,10 @@ async fn build_simbad_resolver(
         |r| (r.online_enabled != 0, r.simbad_endpoint, r.request_timeout_secs),
     );
 
-    let config =
-        SimbadConfig::from_settings(endpoint, u64::try_from(timeout_secs.max(1)).unwrap_or(10));
+    let config = SimbadConfig::from_settings(
+        endpoint,
+        u64::from(app_core::targets::resolver_settings::positive_or_default(timeout_secs, 10)),
+    );
     // FIX-3 preserved: when offline, `SimbadResolver::new` never builds a
     // reqwest/TLS client (see `EitherNetworkResolver`) — cache hits still
     // resolve; a miss reports an offline-shaped unresolved outcome.

--- a/crates/app/targets/src/ingest_resolution.rs
+++ b/crates/app/targets/src/ingest_resolution.rs
@@ -370,8 +370,10 @@ pub async fn drain_and_backfill_once(
     // `SimbadResolver::new` never builds a reqwest/TLS client when
     // `online_enabled` is false (mirrors target.resolve FIX-3); cache hits
     // still resolve regardless.
-    let config =
-        SimbadConfig::from_settings(endpoint, u64::try_from(timeout_secs.max(1)).unwrap_or(10));
+    let config = SimbadConfig::from_settings(
+        endpoint,
+        u64::from(crate::resolver_settings::positive_or_default(timeout_secs, 10)),
+    );
     let resolver = match SimbadResolver::new(&config, resolve_cache, online_enabled) {
         Ok(resolver) => resolver,
         Err(e) => {

--- a/crates/app/targets/src/ingest_sessions.rs
+++ b/crates/app/targets/src/ingest_sessions.rs
@@ -738,6 +738,17 @@ mod tests {
         RawFileMetadata { image_typ: Some(t.to_owned()), ..RawFileMetadata::default() }
     }
 
+    /// Records whether the observing-night date underflow is reachable from a
+    /// header. `Iso8601::DEFAULT` needs the `time` crate's `large-dates`
+    /// feature to accept a signed expanded year, and the workspace does not
+    /// enable it, so `Date::MIN`'s year cannot arrive through `DATE-OBS`. If
+    /// this assertion ever fails the underflow is header-reachable.
+    #[test]
+    fn a_minimum_date_header_is_not_parsed_as_that_year() {
+        let parsed = parse_date_obs(Some("-9999-01-01T00:00:00"));
+        assert_ne!(parsed.year(), -9999, "DATE-OBS reached sessions::observing_night as Date::MIN");
+    }
+
     #[test]
     fn is_light_recognizes_variants() {
         assert!(is_light_frame(&meta_imagetyp("Light Frame")));

--- a/crates/app/targets/src/resolver_settings.rs
+++ b/crates/app/targets/src/resolver_settings.rs
@@ -34,6 +34,19 @@ fn defaults() -> ResolverSettings {
     }
 }
 
+/// Read a stored resolver interval, falling back to `default` when the stored
+/// value is unusable.
+///
+/// A non-positive interval is a refusal rather than a value to repair: a zero
+/// `debounce_ms` disables throttling on the SIMBAD path and a zero
+/// `request_timeout_secs` fails every request. A value beyond `u32` is equally
+/// unusable. Clamping such a value to `0` or `1` would silently substitute an
+/// edge value for the documented default.
+#[must_use]
+pub fn positive_or_default(stored: i64, default: u32) -> u32 {
+    u32::try_from(stored).ok().filter(|value| *value > 0).unwrap_or(default)
+}
+
 /// Validate a resolver endpoint URL (FIX-5a).
 ///
 /// Accepts `https://…`; accepts `http://…` ONLY when the host is loopback
@@ -82,8 +95,8 @@ async fn read_row(pool: &SqlitePool) -> Result<ResolverSettings, ContractError> 
     let settings = row.map_or_else(defaults, |r| ResolverSettings {
         online_enabled: r.online_enabled != 0,
         simbad_endpoint: r.simbad_endpoint,
-        debounce_ms: u32::try_from(r.debounce_ms.max(0)).unwrap_or(300),
-        request_timeout_secs: u32::try_from(r.request_timeout_secs.max(0)).unwrap_or(10),
+        debounce_ms: positive_or_default(r.debounce_ms, 300),
+        request_timeout_secs: positive_or_default(r.request_timeout_secs, 10),
     });
     crate::caches::store_resolver_settings(std::sync::Arc::new(settings.clone()));
     Ok(settings)
@@ -227,6 +240,61 @@ mod tests {
         let resp = update(db.pool(), &upd).await.unwrap();
         assert_eq!(resp.settings.debounce_ms, 1);
         assert_eq!(resp.settings.request_timeout_secs, 1);
+    }
+
+    /// Write a value the contract type and `update`'s clamp cannot produce, so
+    /// the read side is exercised against genuine out-of-range storage. Asserts
+    /// the seeded singleton exists, otherwise `defaults()` would satisfy every
+    /// assertion below without the read path running.
+    async fn seed_stored(pool: &SqlitePool, update_sql: &'static str, value: i64) {
+        let affected =
+            sqlx::query(update_sql).bind(value).execute(pool).await.unwrap().rows_affected();
+        assert_eq!(affected, 1, "the seeded singleton resolver_settings row must exist");
+        crate::caches::invalidate_resolver_settings();
+    }
+
+    #[tokio::test]
+    async fn stored_out_of_range_debounce_reads_back_as_the_documented_default() {
+        for stored in [-1, 0] {
+            let db = setup().await;
+            seed_stored(
+                db.pool(),
+                "UPDATE resolver_settings SET debounce_ms = ? WHERE id = 1",
+                stored,
+            )
+            .await;
+            let resp = get(db.pool(), &get_req()).await.unwrap();
+            assert_eq!(resp.settings.debounce_ms, 300, "stored debounce_ms {stored}");
+        }
+    }
+
+    #[tokio::test]
+    async fn stored_out_of_range_timeout_reads_back_as_the_documented_default() {
+        for stored in [-1, 0] {
+            let db = setup().await;
+            seed_stored(
+                db.pool(),
+                "UPDATE resolver_settings SET request_timeout_secs = ? WHERE id = 1",
+                stored,
+            )
+            .await;
+            let resp = get(db.pool(), &get_req()).await.unwrap();
+            assert_eq!(resp.settings.request_timeout_secs, 10, "stored timeout {stored}");
+        }
+    }
+
+    #[test]
+    fn positive_or_default_refuses_non_positive_and_unrepresentable_values() {
+        assert_eq!(positive_or_default(-1, 300), 300);
+        assert_eq!(positive_or_default(0, 300), 300);
+        assert_eq!(positive_or_default(i64::from(u32::MAX) + 1, 300), 300);
+        assert_eq!(positive_or_default(1, 300), 1);
+        assert_eq!(positive_or_default(500, 300), 500);
+
+        // The value the `ingest_resolution` and `target.lookup` SIMBAD timeout
+        // sites pass: a stored 0 must become 10 seconds, never 1.
+        assert_eq!(positive_or_default(0, 10), 10);
+        assert_eq!(positive_or_default(-1, 10), 10);
     }
 
     // ── FIX-5a: endpoint URL validation ────────────────────────────────────────

--- a/crates/app/targets/src/resolver_settings.rs
+++ b/crates/app/targets/src/resolver_settings.rs
@@ -165,8 +165,13 @@ pub async fn update(
     })
 }
 
-#[cfg(test)]
 // Guard held across assertions on borrowed data in every test below.
+//
+// This comment must stay above `cfg(test)`: `scripts/check-db-boundary.sh` skips
+// only stacked attribute lines while resolving one, so a comment sitting between
+// the attributes hides the test-module exemption and every query below is
+// counted as a production query site.
+#[cfg(test)]
 #[allow(clippy::significant_drop_tightening)]
 mod tests {
     use super::*;

--- a/crates/sessions/src/key.rs
+++ b/crates/sessions/src/key.rs
@@ -28,6 +28,8 @@ pub enum KeyError {
          (see spec 018 observer_location; emit provenance.unreviewed)"
     )]
     ObserverLocationMissing,
+    #[error("pre-noon observing-night derivation falls before the supported date range")]
+    DateUnderflow,
 }
 
 /// Compute the local-solar-noon-bounded observing night for the given UTC
@@ -38,14 +40,17 @@ pub enum KeyError {
 /// last night until local solar noon).
 ///
 /// # Errors
-/// Returns [`KeyError::ObserverLocationMissing`] when `observer` is `None`.
+/// Returns [`KeyError::ObserverLocationMissing`] when `observer` is `None`, and
+/// [`KeyError::DateUnderflow`] when a pre-noon timestamp falls before
+/// [`Date::MIN`].
 pub fn observing_night(
     utc_capture_at: OffsetDateTime,
     observer: Option<&ObserverContext>,
 ) -> Result<String, KeyError> {
     let observer = observer.ok_or(KeyError::ObserverLocationMissing)?;
     let local = utc_capture_at.to_offset(observer.utc_offset);
-    let date = if local.hour() < 12 { previous_day(local.date()) } else { local.date() };
+    let date = crate::observing_night::noon_bounded_date(local.date(), local.hour())
+        .map_err(|_| KeyError::DateUnderflow)?;
     Ok(format_date_iso(date))
 }
 
@@ -69,7 +74,9 @@ impl SessionKey {
     /// not here. This method is the pure key-canonicalisation step.
     ///
     /// # Errors
-    /// Returns [`KeyError::ObserverLocationMissing`] when `observer` is `None`.
+    /// Returns [`KeyError::ObserverLocationMissing`] when `observer` is `None`,
+    /// and [`KeyError::DateUnderflow`] when a pre-noon timestamp falls before
+    /// [`Date::MIN`].
     pub fn new(
         target_id: &str,
         filter: &str,
@@ -134,10 +141,6 @@ pub struct SessionKeyParts {
     pub night: Option<String>,
 }
 
-fn previous_day(d: Date) -> Date {
-    d.previous_day().unwrap_or(d)
-}
-
 fn format_date_iso(d: Date) -> String {
     let month = u8::from(d.month());
     format!("{:04}-{:02}-{:02}", d.year(), month, d.day())
@@ -195,6 +198,58 @@ mod tests {
             observing_night(utc(2026, Month::March, 15, 21, 0), None),
             Err(KeyError::ObserverLocationMissing)
         ));
+    }
+
+    #[test]
+    fn pre_noon_on_the_minimum_date_refuses_instead_of_naming_that_date() {
+        let at_min = PrimitiveDateTime::new(Date::MIN, Time::from_hms(0, 0, 0).unwrap())
+            .assume_offset(UtcOffset::UTC);
+
+        assert!(matches!(
+            observing_night(at_min, Some(&observer(0))),
+            Err(KeyError::DateUnderflow)
+        ));
+    }
+
+    #[test]
+    fn at_noon_on_the_minimum_date_still_names_that_date() {
+        let at_min_noon = PrimitiveDateTime::new(Date::MIN, Time::from_hms(12, 0, 0).unwrap())
+            .assume_offset(UtcOffset::UTC);
+
+        let night = observing_night(at_min_noon, Some(&observer(0))).unwrap();
+        assert_eq!(night, format_date_iso(Date::MIN));
+    }
+
+    #[test]
+    fn both_derivations_name_the_same_date_for_a_pre_noon_negative_year() {
+        let local = PrimitiveDateTime::new(
+            Date::from_calendar_date(-1, Month::January, 1).unwrap(),
+            Time::from_hms(0, 0, 0).unwrap(),
+        )
+        .assume_offset(UtcOffset::UTC);
+
+        let via_key = observing_night(local, Some(&observer(0))).unwrap();
+        let via_typed =
+            crate::observing_night::ObservingNight::from_acquisition_timezone(local, "UTC")
+                .unwrap();
+
+        assert_eq!(via_key, format_date_iso(via_typed.date()));
+    }
+
+    #[test]
+    fn format_date_iso_pads_every_year_width_unchanged() {
+        assert_eq!(
+            format_date_iso(Date::from_calendar_date(7, Month::January, 2).unwrap()),
+            "0007-01-02"
+        );
+        assert_eq!(
+            format_date_iso(Date::from_calendar_date(-2, Month::January, 2).unwrap()),
+            "-002-01-02"
+        );
+        assert_eq!(
+            format_date_iso(Date::from_calendar_date(2026, Month::March, 15).unwrap()),
+            "2026-03-15"
+        );
     }
 
     #[test]

--- a/crates/sessions/src/observing_night.rs
+++ b/crates/sessions/src/observing_night.rs
@@ -97,7 +97,14 @@ pub enum ObservingNightError {
     DateUnderflow,
 }
 
-fn noon_bounded_date(local_date: Date, local_hour: u8) -> Result<Date, ObservingNightError> {
+/// The single noon-bounded observing-night date derivation in this crate.
+///
+/// A pre-noon local timestamp belongs to the previous night; when that day does
+/// not exist the derivation is refused rather than substituting `local_date`.
+pub(crate) fn noon_bounded_date(
+    local_date: Date,
+    local_hour: u8,
+) -> Result<Date, ObservingNightError> {
     if local_hour < 12 {
         local_date.previous_day().ok_or(ObservingNightError::DateUnderflow)
     } else {

--- a/specs/tiny/documented-fallbacks-on-out-of-range-values.md
+++ b/specs/tiny/documented-fallbacks-on-out-of-range-values.md
@@ -2,7 +2,6 @@
 
 **Branch**: fix/dbs5-documented-fallbacks
 **Date**: 2026-08-23
-**Status**: draft
 **Complexity**: small
 
 ## What
@@ -128,23 +127,23 @@ fabricates a date where the other refuses.
 
 ## Tasks
 
-- [ ] Add the out-of-range-to-default helper in `crates/app/targets` with the
+- [x] Add the out-of-range-to-default helper in `crates/app/targets` with the
       refusal invariant in its docstring
-- [ ] Apply it at `resolver_settings.rs:85`, `:86`, `ingest_resolution.rs:374`,
+- [x] Apply it at `resolver_settings.rs:85`, `:86`, `ingest_resolution.rs:374`,
       and `target_lookup.rs:130`
-- [ ] Add an underflow arm to `KeyError` and route `key::observing_night`
+- [x] Add an underflow arm to `KeyError` and route `key::observing_night`
       through `observing_night::noon_bounded_date`
-- [ ] Delete `key.rs`'s private `previous_day`
-- [ ] Add the tests for requirements 1-6 and 8-13, each confirmed failing at
+- [x] Delete `key.rs`'s private `previous_day`
+- [x] Add the tests for requirements 1-6 and 8-13, each confirmed failing at
       base where it targets a defect
-- [ ] `cargo test -p sessions -p app_core_targets`, `cargo check -p desktop_shell`,
+- [x] `cargo test -p sessions -p app_core_targets`, `cargo check -p desktop_shell`,
       `cargo clippy -p sessions -p app_core_targets --all-targets`
 
 ## Done When
 
-- [ ] Every requirement above has a test, and each test that targets a defect
+- [x] Every requirement above has a test, and each test that targets a defect
       was recorded failing at base with its actual output
-- [ ] `crates/sessions` contains exactly one noon-bounded date derivation
-- [ ] The four read sites call one helper, not four copies of one expression
-- [ ] `format_date_iso` and migration files are untouched
-- [ ] Touched-crate test, check, and clippy gates are green
+- [x] `crates/sessions` contains exactly one noon-bounded date derivation
+- [x] The four read sites call one helper, not four copies of one expression
+- [x] `format_date_iso` and migration files are untouched
+- [x] Touched-crate test, check, and clippy gates are green

--- a/specs/tiny/documented-fallbacks-on-out-of-range-values.md
+++ b/specs/tiny/documented-fallbacks-on-out-of-range-values.md
@@ -1,0 +1,150 @@
+# TinySpec: An out-of-range stored value falls back to its documented default, never to a clamped edge or a fabricated date
+
+**Branch**: fix/dbs5-documented-fallbacks
+**Date**: 2026-08-23
+**Status**: draft
+**Complexity**: small
+
+## What
+
+Two families of read-side fallback in this repo declare a default that the code
+cannot reach, because a clamp runs first and produces an in-range value the
+declared default never sees.
+
+- `crates/app/targets` and one `apps/desktop/src-tauri` line read `i64` resolver
+  settings, clamp with `.max(0)` / `.max(1)`, then `try_from` into `u32`/`u64`
+  with `.unwrap_or(300)` / `.unwrap_or(10)`. A stored `-1` reaches the caller as
+  `0` or `1`, never as `300` or `10`.
+- `crates/sessions` derives the observing night twice. `key.rs` fabricates a date
+  on pre-noon underflow (`previous_day().unwrap_or(d)`); `observing_night.rs`
+  refuses it (`ok_or(DateUnderflow)`).
+
+## The rule (decision)
+
+### A non-positive or unrepresentable stored resolver setting is not a setting
+
+A stored `debounce_ms` or `request_timeout_secs` that is `<= 0`, or larger than
+the target integer type, MUST yield the documented default — `300` ms and `10`
+seconds — and MUST NOT yield a clamped edge value. A zero debounce disables
+throttling on the SIMBAD path and a zero timeout fails every request, so both
+are refusals, not values to be repaired by clamping.
+
+One helper implements this rule for all four read sites. The write side is
+unchanged: `resolver_settings::update` keeps clamping user input to `>= 1`.
+
+### One observing-night date producer, and it refuses rather than fabricates
+
+`observing_night::noon_bounded_date` is the single derivation of the
+noon-bounded date. `key::observing_night` MUST obtain its date from that
+function and MUST propagate the underflow as an error. `key.rs` MUST NOT hold a
+second derivation, and no derivation may substitute an unshifted date for a date
+it cannot compute.
+
+### The persisted session-key night format is frozen
+
+`key::format_date_iso`'s `{:04}` year padding is unchanged. That string is the
+`night` segment of `SessionKey`, persisted on `acquisition_session.session_key`
+and read back by `SessionKey::parse`. Changing the padding would orphan existing
+session rows. The padding divergence the finding reports disappears because
+there is one date producer, not because the format changed.
+
+## Per-finding verdict at head `5b1fdf702f7ad12d52ea429a255cc69874ef5a2b`
+
+| Bead | Site at this head | Reachable with real inputs | Verdict |
+| --- | --- | --- | --- |
+| `astro-plan-3v3r.11.24` | `crates/app/targets/src/resolver_settings.rs:85` (`debounce_ms`) | NO | fix as unreachable hardening |
+| `astro-plan-3v3r.11.24` | `crates/app/targets/src/resolver_settings.rs:86` (`request_timeout_secs`) | NO | same defect, not named in the bead; fixed |
+| `astro-plan-3v3r.11.24` | `crates/app/targets/src/ingest_resolution.rs:374` | NO | same shape, not named in the bead; fixed |
+| `astro-plan-3v3r.11.24` | `apps/desktop/src-tauri/src/commands/target_lookup.rs:130` | NO | same shape, not named in the bead; fixed |
+| `astro-plan-3v3r.13.31` | `crates/sessions/src/key.rs:138` | NO | fabrication removed; duplicate derivation collapsed |
+| `astro-plan-3v3r.13.31` | `crates/sessions/src/observing_night.rs:102` | n/a — this is the correct behaviour | kept as the single producer |
+
+Why unreachable:
+
+- **11.24.** The only writer of the `resolver_settings` row is
+  `q_targets_mgmt::upsert_resolver_settings`, called from exactly one site,
+  `resolver_settings.rs:132`, which passes `i64::from(s.debounce_ms.max(1))`
+  from a contract `u32` (`crates/contracts/core/src/targets.rs`). The stored
+  value is therefore always in `1..=u32::MAX`. The column carries no `CHECK` and
+  the table is not `STRICT`, so an out-of-range value is storable only by an
+  out-of-band database edit or corruption.
+- **13.31.** The underflow needs a pre-noon local timestamp on `Date::MIN`
+  (`-9999-01-01`). Every `capture_at` reaching `sessions::observing_night` comes
+  from `ingest_sessions::parse_date_obs`, which parses with `Iso8601::DEFAULT`.
+  The workspace does not enable the `time` crate's `large-dates` feature
+  (`Cargo.toml:116`), so a signed expanded year is not a parseable ISO 8601 year
+  and the function falls back to `OffsetDateTime::now_utc()`.
+
+The observing-night divergence was never observable through a session key: no
+production path constructs an `ObservingNight`. Its only constructor call
+outside its own module is a `#[cfg(test)]` helper at
+`crates/sessions/src/identity.rs:266`; the production type that holds one
+(`identity.rs:216`) is never built with a real value. The finding's claim that
+grouping and lookup disagree for the same frame does not hold at this head. The
+defect being fixed is the duplicate derivation itself, one half of which
+fabricates a date where the other refuses.
+
+## Context
+
+- `read_row` (`resolver_settings.rs:73-90`) is read-through a process-wide
+  snapshot cache. A test asserting a value from it must invalidate the cache and
+  serialize against the other resolver-settings tests via
+  `target_management::cache_test_lock`.
+- `defaults()` (`resolver_settings.rs:28-35`) also returns `300`/`10`, so a test
+  that fails to seed the singleton row passes vacuously. Seeding must be
+  asserted before the value is.
+- `key::observing_night` gains an error arm. Both call sites already discard the
+  error: `ingest_sessions.rs:377` with `.ok()` and `:499` with
+  `unwrap_or_else`.
+- Migration `0001_initial_schema.sql` is frozen by a checksum test. No migration
+  is added: a `CHECK` constraint would not apply to the existing table without a
+  rebuild, and the read-side guard is the fix.
+
+## Requirements
+
+1. A stored `debounce_ms` of `-1` reads back as `300`.
+2. A stored `debounce_ms` of `0` reads back as `300`.
+3. A stored `request_timeout_secs` of `-1` reads back as `10`.
+4. A stored `request_timeout_secs` of `0` reads back as `10`.
+5. The helper yields `10` for the stored `0` and `-1` that the
+   `ingest_resolution` and `target.lookup` timeout sites pass it, not `1`.
+   `SimbadConfig` is an external type with no timeout accessor, so the timeout
+   those two sites hand it is not observable from a test; the helper call is the
+   assertable boundary.
+6. `resolver_settings::update` still clamps a submitted `0` to `1`.
+7. A single helper implements requirements 1-5 for all four read sites.
+8. `key::observing_night` returns an error for a pre-noon timestamp on
+   `Date::MIN`, rather than the string `-9999-01-01`.
+9. `key::observing_night` returns the unshifted date for an at-or-after-noon
+   timestamp on `Date::MIN`.
+10. `key::observing_night` and `ObservingNight::from_acquisition_timezone` name
+    the same date for `-0001-01-01T00:00 +00:00`.
+11. `key.rs` holds no date-shifting helper of its own.
+12. `format_date_iso`'s output is unchanged for every year width.
+13. An evidence test records whether `parse_date_obs` parses
+    `-9999-01-01T00:00:00` as year `-9999`. If it ever does, requirement 8's
+    defect is reachable from a hand-edited FITS header and this spec's verdict
+    table is wrong.
+
+## Tasks
+
+- [ ] Add the out-of-range-to-default helper in `crates/app/targets` with the
+      refusal invariant in its docstring
+- [ ] Apply it at `resolver_settings.rs:85`, `:86`, `ingest_resolution.rs:374`,
+      and `target_lookup.rs:130`
+- [ ] Add an underflow arm to `KeyError` and route `key::observing_night`
+      through `observing_night::noon_bounded_date`
+- [ ] Delete `key.rs`'s private `previous_day`
+- [ ] Add the tests for requirements 1-6 and 8-13, each confirmed failing at
+      base where it targets a defect
+- [ ] `cargo test -p sessions -p app_core_targets`, `cargo check -p desktop_shell`,
+      `cargo clippy -p sessions -p app_core_targets --all-targets`
+
+## Done When
+
+- [ ] Every requirement above has a test, and each test that targets a defect
+      was recorded failing at base with its actual output
+- [ ] `crates/sessions` contains exactly one noon-bounded date derivation
+- [ ] The four read sites call one helper, not four copies of one expression
+- [ ] `format_date_iso` and migration files are untouched
+- [ ] Touched-crate test, check, and clippy gates are green


### PR DESCRIPTION
## Summary

Two read-side fallback families in this repo declared a default the code could
not reach, because a clamp ran first and produced an in-range value the declared
default never saw.

- Four resolver-setting read sites clamped a stored `i64` with `.max(0)` /
  `.max(1)` before converting, so a stored `-1` arrived as `0` or `1` rather
  than as the documented 300 ms or 10 s. A non-positive interval is now treated
  as not-a-setting: a zero debounce disables throttling on the SIMBAD path and a
  zero timeout fails every request, so neither is worth repairing by clamping.
  One helper serves all four sites. The write side is unchanged — submitted
  input is still clamped to at least 1.
- `crates/sessions` held two derivations of the observing night. `key.rs`
  fabricated a date on pre-noon underflow; `observing_night.rs` refused it.
  There is now one date producer, and it refuses.

## Neither defect is reachable in production

**The resolver settings.** The only writer of the `resolver_settings` row is
`q_targets_mgmt::upsert_resolver_settings`, called from exactly one site
(`crates/app/targets/src/resolver_settings.rs:132`), which passes
`i64::from(s.debounce_ms.max(1))` from a contract `u32`. The stored value is
therefore always in `1..=u32::MAX`. The column carries no `CHECK` and the table
is not `STRICT`, so an out-of-range value is storable — but only by an
out-of-band database edit or corruption. *Established by reading:* enumerated
every reference to `resolver_settings` across `crates/` and `apps/` and found
one writer.

**The date underflow.** It needs a pre-noon local timestamp on `Date::MIN`
(`-9999-01-01`). Every `capture_at` reaching `sessions::observing_night` comes
from `ingest_sessions::parse_date_obs`, which parses with `Iso8601::DEFAULT`;
the workspace does not enable the `time` crate's `large-dates` feature, so a
signed expanded year is not a parseable ISO 8601 year and the function falls
back to `OffsetDateTime::now_utc()`. *Established by execution:*
`a_minimum_date_header_is_not_parsed_as_that_year` asserts that
`parse_date_obs(Some("-9999-01-01T00:00:00"))` does not yield year `-9999`, and
it passes. It is committed as a standing tripwire: if it ever fails, the
underflow has become reachable from a hand-edited FITS header.

## Correcting the record on the duplicate derivation

The finding for the observing-night divergence claims that a session key built
through `key.rs` and a night derived through the typed API name different nights
for the same frame, so grouping and lookup disagree. That was not observable at
this head. No production path constructs an `ObservingNight`: its only
constructor call outside its own module is a `#[cfg(test)]` helper at
`crates/sessions/src/identity.rs:266`, and the production type that holds one
(`identity.rs:216`) is never built with a real value. No user-visible grouping
bug was fixed here.

What was genuinely wrong is the defect the finding states last: two derivations
of one domain concept, one of which fabricated a date where the other refused.
That is now one derivation.

## The persisted session-key night format is unchanged

`key::format_date_iso`'s `{:04}` year padding is what produced the `-002` vs
`-0002` divergence the finding reports, and it is deliberately untouched. That
string is the `night` segment of `SessionKey`, persisted on
`acquisition_session.session_key` and read back by `SessionKey::parse`;
repadding it would silently orphan every existing session row. With one date
producer the divergence no longer exists, so the format did not need to move. A
guard test pins the output for positive, negative, and four-digit years.

## Tests, and the exact failure each produced at base

| Finding | Test | Failure at base |
| --- | --- | --- |
| `11.24` | `stored_out_of_range_debounce_reads_back_as_the_documented_default` (`-1` and `0`) | `assertion left == right failed: stored debounce_ms -1` / `left: 0` / `right: 300` |
| `11.24` | `stored_out_of_range_timeout_reads_back_as_the_documented_default` (`-1` and `0`) | `assertion left == right failed: stored timeout -1` / `left: 0` / `right: 10` |
| `11.24` | `positive_or_default_refuses_non_positive_and_unrepresentable_values` | none — it tests the new helper, which does not exist at base, so it is not a base-failing test |
| `11.24` | `update_clamps_zero_timeout_and_debounce` (pre-existing) | none — green at base and after; the write-side clamp is deliberately unchanged |
| `13.31` | `pre_noon_on_the_minimum_date_refuses_instead_of_naming_that_date` | `assertion failed: matches!(observing_night(at_min, Some(&observer(0))), Err(KeyError::DateUnderflow))` |
| `13.31` | `at_noon_on_the_minimum_date_still_names_that_date` | none — guard against over-refusal, green at base and after |
| `13.31` | `both_derivations_name_the_same_date_for_a_pre_noon_negative_year` | none — the two derivations already agreed on the `Date` for `-0001-01-01T00:00 +00:00`; the reported divergence was in the formatted string, which is unchanged. Guard only. |
| `13.31` | `format_date_iso_pads_every_year_width_unchanged` | none — freezes the persisted format |
| reachability | `a_minimum_date_header_is_not_parsed_as_that_year` | none — evidence test recording that the underflow is not header-reachable |

Each base failure quoted above was produced by reverting the source change while
keeping the test, and is taken from the actual run output.

## What this does not fix

- **`astro-plan-uzcbj`**, filed from this work:
  `crates/app/inbox/src/grouping/engine.rs:182` is a *third* observing-night
  derivation that slices the date out of `DATE-LOC` / `DATE-OBS` with no noon
  boundary at all, documented there as deliberate. It disagrees with
  `crates/sessions` for every pre-noon frame. Whether it should adopt the
  boundary is a product question, not a defect with an obvious answer.
- **`validate_endpoint`'s hand-rolled URL prefix match**, mentioned as an aside
  in `11.24`'s description, is untouched: a separate concern and a `url` crate
  dependency decision.
- Ten other `try_from(x.max(0))` sites across the repo are benign —
  `unwrap_or(0)` after `.max(0)`, or `unwrap_or(u32::MAX)` on a row count where
  saturation is the intent — and are left alone.
- No migration is added. A `CHECK` constraint would not apply to the existing
  table without a rebuild, and the read-side guard is the fix the findings ask
  for.

Neither finding's description is covered in full; the exclusions above are
deliberate.

## Verification

- `cargo test -p sessions -p app_core_targets` — 181 passed, 0 failed
- `cargo check -p desktop_shell` — clean
- `cargo clippy -p sessions -p app_core_targets --all-targets` — no warnings

## Spec Context

`specs/tiny/documented-fallbacks-on-out-of-range-values.md` states the rule, the
per-finding reachability verdict at this head, and the numbered requirements.

Merge bead `astro-plan-7wdml`; work bead `astro-plan-tnyes`.

Tracks-Bead: astro-plan-tnyes
Tracks-Bead: astro-plan-3v3r.11.24
Tracks-Bead: astro-plan-3v3r.13.31
Merge-Bead: astro-plan-7wdml
