### PR TITLE
fix(ci): deepen the integration checkout so the dead-caller ratchet can resolve a base on a main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      # fetch-depth 2: the `Dead-caller ratchet` step below needs HEAD~1 on a main
+      # push, where `origin/main` is the commit just pushed and the ratchet's
+      # merge base is HEAD itself. The default depth-1 checkout has no HEAD~1 and
+      # the ratchet fails closed. Matches `dead-caller-main`.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       # Tauri's desktop_shell crate needs system webview libs to build on Linux.
       - name: Install Tauri Linux system deps


### PR DESCRIPTION
## Summary

- Fixes a CI configuration defect that turned `main` red. One workflow file; no
  product behaviour changes, no Rust, no TypeScript, no script touched.
- The `integration` job now checks out with `fetch-depth: 2` so the dead-caller
  ratchet can resolve a base on a push to `main`.

## The defect

`main` at `c8b2e53` failed the `Unit + integration (L1+L2) — ubuntu-latest` job with:

```
FAIL: cannot resolve a base to compare the baseline against (base ref origin/main).
```

`resolve_base_commit` in `scripts/check-dead-callers.sh` resolves a merge base
between HEAD and `origin/main`. On a push to `main` those are the same commit, so
the merge base equals HEAD and the function falls back to `HEAD~1`
(`scripts/check-dead-callers.sh:423-425`). The `integration` job checked out at the
`actions/checkout` default depth of 1, which contains no `HEAD~1`, so the ratchet
failed closed.

The deepen/unshallow loop at `scripts/check-dead-callers.sh:415-420` cannot rescue
this: it only iterates while the merge base is empty, and here the merge base
resolves to HEAD. That is why PR runs survive a depth-1 checkout and main pushes
do not — the same reason the depth-1 case is invisible to the script's own
base-resolution self-test, which exercises only the feature-branch shape.

The `dead-caller-main` job already carries `fetch-depth: 2` and a comment
recording this exact failure mode (`.github/workflows/ci.yml:950-956`). The fix was
understood and applied to one of the ratchet's two callers, not the other.

Latent until PR #1726 added a seed glob to the `rust` paths filter, which changed
which pushes select the `integration` job.

## The change

`fetch-depth: 2` on the `integration` job's checkout, matching the
`dead-caller-main` precedent. `scripts/check-dead-callers.sh` is unchanged: its
fail-closed behaviour is deliberate and the defect is the checkout depth.

At depth 2 a PR checkout is still shallow, so `origin/main` is absent, the merge
base starts empty and the unshallow loop resolves it exactly as it does today. No
change to PR or merge-queue behaviour.

## Verification

- `actionlint .github/workflows/ci.yml` — exit 0.
- No `cargo` or workspace build: the change is YAML only.
- The main-push case is established by reading the base-resolution code path, not
  by a green PR run, which cannot exercise it. Running the script against a local
  shallow clone was attempted and refused by the sandbox.

## Sweep of every base-resolving caller

| Caller | Checkout | Verdict |
| --- | --- | --- |
| `check-dead-callers.sh` via `integration` (`ci.yml:462`) | `ci.yml:301`, now `fetch-depth: 2` | fixed here |
| `check-dead-callers.sh` via `dead-caller-main` (`ci.yml:961`) | `ci.yml:956`, `fetch-depth: 2` | adequate |
| `check-merged-pr-paths.sh` (`merged-pr-path-gate.yml:35`) | `merged-pr-path-gate.yml:28`, `fetch-depth: 0` | adequate |
| `bd-close-guard.sh` | no workflow caller; agent-local, fetches `origin/main` itself and warns | not a CI risk |

The other ratchets — `db-boundary`, `hot-read`, `lifecycle-strings`,
`pv-selector`, `test-targets`, `check-generated-drift`, `check-perf-baseline`,
`check-eslint-baseline` — compare against checked-in baseline files and resolve no
base ref, so they are depth-independent. No workflow step resolves a base ref
inline.

## `dead-caller-main` is not redundant

Keep it. `integration`'s ratchet step is gated on
`runner.os == 'Linux' && (rust || scripts)` (`ci.yml:469`) and the job itself on
the `changes` path filters (`ci.yml:292-294`), so a main push touching neither
Rust nor scripts runs no ratchet at all. `dead-caller-main` is gated only on
`github.event_name == 'push'`, which is main-only for this workflow, and that
unconditional post-merge coverage is its stated purpose (`ci.yml:936-939`). The
two now double-run on Rust-touching main pushes; the duplicate is a pure grep and
costs negligible wall-clock. Left for the owner to decide separately.

Tracks-Bead: astro-plan-9tbwc
Merge-Bead: astro-plan-w2yo4
