### PR TITLE
chore!: collapse the database migration chain into one editable baseline (recreate your development database)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -35,8 +35,10 @@ apps/desktop/tokens/*.json text eol=lf
 # present in the actual source.
 specs/**/contracts/*.generated.json text eol=lf
 
-# Migration SQL and Rust test files must use LF so that the frozen baseline
-# checksum (SHA-384 of file bytes) is identical on all platforms.
+# Migration SQL must use LF: sqlx stores `_sqlx_migrations.checksum` as a
+# SHA-384 over each migration file's exact bytes, so a CRLF checkout reports
+# VersionMismatch against a database migrated from an LF checkout. Rust sources
+# are normalized with them so the tree stays byte-identical across platforms.
 *.sql text eol=lf
 *.rs text eol=lf
 

--- a/crates/persistence/core/migrations/0001_initial_schema.sql
+++ b/crates/persistence/core/migrations/0001_initial_schema.sql
@@ -1,4 +1,5 @@
--- Candidate one-file baseline derived from exact base 4cfd2198a81702c1ddb910ceef4e1d5a27d6b357.
+-- The pre-1.0 SQLite schema and seed definition. This is migration version 1,
+-- it stays version 1, and it is edited in place until 1.0; there is no 0002+.
 -- sqlite_* objects and _sqlx_migrations are intentionally excluded.
 -- onboarding_state and onboarding_flags intentionally start empty.
 -- frame_footprint_rtree virtual table is included; shadow tables are
@@ -426,7 +427,6 @@ CREATE TABLE calibration_tolerances (
     temperature_tolerance_c REAL NOT NULL DEFAULT 5.0,
     exposure_tolerance_s    REAL NOT NULL DEFAULT 2.0,
     aging_limit_days        INTEGER NOT NULL DEFAULT 365,
-    require_same_camera     INTEGER NOT NULL DEFAULT 1,
     require_same_gain       INTEGER NOT NULL DEFAULT 1,
     require_same_binning    INTEGER NOT NULL DEFAULT 1,
     updated_at              TEXT NOT NULL
@@ -1788,7 +1788,8 @@ CREATE TABLE "plans" (
     approved_at              TEXT,
     discarded_at             TEXT,
     created_at               TEXT    NOT NULL,
-    chosen_framing_id        TEXT    REFERENCES framing(id)
+    chosen_framing_id        TEXT    REFERENCES framing(id),
+    destination_root         TEXT
 );
 
 CREATE TABLE prepared_source_view (
@@ -4152,7 +4153,7 @@ CREATE TRIGGER session_immutable_update BEFORE UPDATE ON session BEGIN
     SELECT RAISE(ABORT, 'session is append-only');
 END;
 
-INSERT INTO "calibration_tolerances" VALUES('default', 5.0, 2.0, 365, 1, 1, 1, '2026-05-26T00:00:00Z', 1);
+INSERT INTO "calibration_tolerances" VALUES('default', 5.0, 2.0, 365, 1, 1, '2026-05-26T00:00:00Z', 1);
 INSERT INTO "cleanup_policy" VALUES('calibrated_lights', 'keep', '2026-05-26T00:00:00Z');
 INSERT INTO "cleanup_policy" VALUES('registered_lights', 'keep', '2026-05-26T00:00:00Z');
 INSERT INTO "cleanup_policy" VALUES('drizzle_data', 'keep', '2026-05-26T00:00:00Z');

--- a/crates/persistence/core/migrations/0002_drop_require_same_camera.sql
+++ b/crates/persistence/core/migrations/0002_drop_require_same_camera.sql
@@ -1,4 +1,0 @@
--- Drop the unused `require_same_camera` flag from the calibration tolerances
--- singleton. The matching engine has no camera dimension to relax, so nothing
--- ever read the column.
-ALTER TABLE calibration_tolerances DROP COLUMN require_same_camera;

--- a/crates/persistence/core/migrations/0003_plans_destination_root.sql
+++ b/crates/persistence/core/migrations/0003_plans_destination_root.sql
@@ -1,7 +1,0 @@
--- Absolute destination root a plan's items must resolve under.
---
--- Source-view generation stores an absolute `plan_items.to_relative_path` with
--- `to_root_id` NULL, so the executor had no root to contain the destination
--- against and fell back to the item's SOURCE root. NULL keeps the destination
--- gate inactive for plans that predate the column.
-ALTER TABLE "plans" ADD COLUMN destination_root TEXT;

--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -218,7 +218,7 @@ impl Database {
         Ok(())
     }
 
-    /// Run all pending migrations from the frozen baseline and future append-only files.
+    /// Run all pending migrations, starting from the `0001` baseline.
     ///
     /// # Errors
     ///

--- a/crates/persistence/core/src/schema_cache.rs
+++ b/crates/persistence/core/src/schema_cache.rs
@@ -3,9 +3,9 @@
 
 //! Embedded database migrations.
 //!
-//! The pre-1.0 schema is a single frozen baseline. Keep `0001_initial_schema.sql`
-//! append-only after it lands; future schema changes must use a new `0002+`
-//! migration rather than rewriting the baseline.
+//! Before 1.0 the schema is a single editable baseline. Make schema changes
+//! directly in `0001_initial_schema.sql` rather than adding a `0002+` migration;
+//! every such edit requires existing development databases to be recreated.
 
-/// The append-only migration set consumed by [`crate::Database`].
+/// The migration set consumed by [`crate::Database`].
 pub static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations");

--- a/crates/persistence/core/tests/baseline_invariants.rs
+++ b/crates/persistence/core/tests/baseline_invariants.rs
@@ -3,8 +3,10 @@
 
 //! Invariants for the pre-1.0 database reset.
 //!
-//! The schema is now a frozen 0001 baseline. These tests intentionally verify
-//! the resulting database, rather than replaying the deleted historical chain.
+//! Before 1.0 the schema is a single editable 0001 baseline: schema changes are
+//! made in place there instead of appended as new migrations, and each such edit
+//! requires every existing development database to be recreated. These tests
+//! verify the database the baseline produces; there is no chain to replay.
 
 use std::collections::HashSet;
 
@@ -12,7 +14,7 @@ use persistence_core::Database;
 
 async fn migrated() -> Database {
     let db = Database::in_memory().await.expect("in-memory database");
-    db.migrate().await.expect("frozen baseline applies cleanly");
+    db.migrate().await.expect("baseline applies cleanly");
     db
 }
 
@@ -108,25 +110,15 @@ async fn representative_repository_queries_cover_seeded_and_empty_surfaces() {
 }
 
 #[test]
-fn migration_set_has_frozen_0001_and_unique_append_only_versions() {
+fn migration_set_starts_at_baseline_with_unique_versions() {
     let mut migrations = Database::migrator().iter();
-    let first = migrations.next().expect("0001 baseline migration is embedded");
+    let first = migrations.next().expect("baseline migration is embedded");
     assert_eq!(first.version, 1);
     assert_eq!(first.description, "initial schema");
-    assert_eq!(first.sql.as_str(), include_str!("../migrations/0001_initial_schema.sql"));
-    assert_eq!(
-        first.checksum.as_ref(),
-        &[
-            0x38, 0x87, 0xe6, 0xde, 0x23, 0xf8, 0xc4, 0xc0, 0x3a, 0x36, 0x5f, 0xa1, 0x7a, 0xf3,
-            0x7e, 0xa8, 0x29, 0x80, 0xce, 0x94, 0x93, 0x70, 0xca, 0x47, 0xaa, 0x27, 0xad, 0x1b,
-            0x25, 0xe3, 0x9d, 0xad, 0x3f, 0xf7, 0x93, 0x9d, 0x04, 0xe5, 0x17, 0xb0, 0xbb, 0x93,
-            0xdc, 0x0d, 0x72, 0x84, 0xae, 0xd7,
-        ]
-    );
 
     let mut versions = HashSet::new();
     for migration in migrations {
-        assert!(migration.version >= 2, "future migrations append after frozen 0001");
+        assert!(migration.version >= 2, "no migration shares version 1 with the baseline");
         assert!(
             versions.insert(migration.version),
             "duplicate migration version {}",

--- a/docs/development/database-baseline-and-migrations.md
+++ b/docs/development/database-baseline-and-migrations.md
@@ -5,9 +5,9 @@ This guide defines the development database boundary for the SQLite store.
 ## Unsupported databases
 
 Any database created before the pre-1.0 baseline is unsupported. Recreate it
-from the migrations shipped by the checkout under test. Do not edit
-`_sqlx_migrations`, copy tables between schema generations, or skip migration
-versions to preserve test data.
+from the baseline migration shipped by the checkout under test. Do not edit
+`_sqlx_migrations` or copy tables between schema generations to preserve test
+data.
 
 The reset is destructive to the selected SQLite file. Preserve fixtures or
 exports outside the database file before removing it.
@@ -20,7 +20,7 @@ exports outside the database file before removing it.
 3. Remove the selected file and its SQLite sidecars (`<file>-wal` and
    `<file>-shm`) if present.
 4. Start the app or test command. `Database::migrate` creates the file and
-   applies the embedded migration chain from `0001`.
+   applies the embedded baseline migration.
 5. Confirm the first-run flow or test fixture creates the expected seed data.
 
 For the Windows native development checkout, the default file is:
@@ -34,22 +34,53 @@ For an explicit development URL, remove the path named by `PV_DB_URL` after
 stripping the `sqlite://` prefix and query string. Use a path-specific remove
 command; never delete an entire app-data directory.
 
-## Frozen baseline and append-only changes
+## Single editable baseline
 
-Migration `0001` is the frozen pre-1.0 schema and seed baseline. Once it lands,
-its filename, version, checksum, table definitions, and seed statements are
-immutable. Any later change must append a new migration (`0002+`) and must not
-rewrite an earlier migration to make an existing database appear fresh.
+The pre-1.0 schema is stated once, in
+`crates/persistence/core/migrations/0001_initial_schema.sql`, at migration
+version 1. Schema and seed changes edit that file in place. The baseline is
+version 1 and stays version 1 until 1.0; there is no `0002` or later. This
+supersedes the earlier freeze-and-append rule (bead `adr-1`).
 
-Each migration change follows this workflow:
+Each schema change follows this workflow:
 
-1. Add the next unused version under `crates/persistence/db/migrations/`.
+1. Edit `0001_initial_schema.sql`.
 2. Update repository queries and tests in the same change.
-3. Run the migration tests against a fresh database.
-4. Run the migration tests against a database created by the preceding
-   migration set.
-5. Review the SQL and migration version in the diff before merging.
+3. Delete your development database (see below) and run the persistence tests
+   against a fresh one.
+4. Review the SQL in the diff before merging. Once `astro-plan-0zog4` lands,
+   reseal the schema-shape snapshot by reading its diff, not by blessing it.
 
-A final pre-1.0 resquash may replace the append-only chain only after a fresh
-owner decision. That decision must include a new baseline version, a reset
-window for every development database, and updated release instructions.
+### Every schema edit destroys your development database
+
+Any development database created before the edit is unusable. Delete the file
+and its `-wal` and `-shm` sidecars yourself. The app does not back it up first,
+because the version-1 edit is invisible to the pending-migration check:
+
+- `has_pending_migrations` returns `applied_count < total`
+  (`crates/persistence/core/src/lib.rs:180-185`). With three applied rows from
+  an older chain and one embedded migration, `3 < 1` is false, so it reports no
+  pending work.
+- The desktop shell therefore skips its pre-migration `VACUUM INTO` backup
+  (`apps/desktop/src-tauri/src/lib.rs:542`, skip condition at `:543`, the
+  `backup_to` call at `:554`). Nobody gets a `.bak`.
+- `MIGRATOR.run` then fails on the version-1 checksum mismatch, classified by
+  `persistence_core::migration_divergence_detail`
+  (`crates/persistence/core/src/lib.rs:257`) and surfaced at boot
+  (`apps/desktop/src-tauri/src/lib.rs:631`).
+
+The failure is loud and does not corrupt the file, but it is not recoverable in
+place. That boot error means delete the database. It is not a bug report.
+
+### Drift detection
+
+Runtime tamper detection is unchanged and remains the stronger control: sqlx
+compares the recorded `_sqlx_migrations` checksum against the embedded migration
+on every `run()`.
+
+Compile-time detection of an edit to the baseline file is gone. It was a 48-byte
+SHA-384 literal pinning the file bytes. Its replacement, a schema-shape
+snapshot, is deferred to bead `astro-plan-0zog4` and ships immediately after
+this change; until then the baseline has no compile-time drift control. The
+snapshot will not catch seed content beyond the filters it checks, SQL
+behaviour, a blind reseal, or formatting-only edits.

--- a/docs/development/persistence-layer-hardening.md
+++ b/docs/development/persistence-layer-hardening.md
@@ -69,9 +69,9 @@ not this table, as authoritative — it will drift as unrelated work lands.)
 
 - **sqlx 0.9** (sqlite, `runtime-tokio`, `tls-rustls`, `macros`, `migrate`,
   `uuid`, `time`, `json`) — async, ratified in spec 002.
-- Canonical store: SQLite. Migrations in `crates/persistence/db/migrations/`,
-  applied via `sqlx::migrate!("./migrations")`. Latest migration as of this
-  branch: `0050`.
+- Canonical store: SQLite. Migrations in `crates/persistence/core/migrations/`,
+  applied via `sqlx::migrate!("./migrations")`. Before 1.0 there is exactly one
+  migration, `0001_initial_schema.sql`, edited in place.
 
 ---
 

--- a/docs/release/pre-1-0-database-baseline.md
+++ b/docs/release/pre-1-0-database-baseline.md
@@ -1,27 +1,28 @@
 # Pre-1.0 database release boundary
 
-The pre-1.0 release uses migration `0001` as its frozen SQLite baseline.
-Development databases from before this baseline are not supported upgrade
+The pre-1.0 release ships a single SQLite baseline migration at version 1.
+Development databases from before the current baseline are not supported upgrade
 inputs.
 
 ## Release reset requirement
 
 Before validating the release, stop the app and remove each development
 database created before the baseline. Remove its `-wal` and `-shm` sidecars as
-well. Launching the app against the same path recreates the file and applies
-`0001` through the embedded migrator. Use `PV_DB_URL` to make the path
+well. Launching the app against the same path recreates the file and applies the
+baseline through the embedded migrator. Use `PV_DB_URL` to make the path
 explicit in automated checks.
 
 Do not ship a release validation result from a database that was upgraded from
 a pre-baseline development file. Run the fresh-database first-run checks after
 the reset.
 
-## Post-baseline migration contract
+## Baseline migration contract
 
-`0001` is immutable after landing. Schema and data changes append new
-migrations as `0002+`; they do not edit or reorder an earlier migration.
-Release validation must cover both a fresh database and an upgrade from the
-immediately preceding migration.
+Pre-1.0 schema and data changes edit the baseline migration in place at version
+1. There is no `0002` or later, so there is no upgrade from a preceding migration
+to validate. Release validation covers the fresh-database path only (bead
+`adr-1`).
 
-A final pre-1.0 resquash is optional and requires a new owner decision. Without
-that decision, the append-only `0002+` policy remains in force.
+Every baseline edit invalidates existing development databases, and the app does
+not back them up. See
+[`docs/development/database-baseline-and-migrations.md`](../development/database-baseline-and-migrations.md).

--- a/specs/tiny/editable-pre-1-0-database-baseline.md
+++ b/specs/tiny/editable-pre-1-0-database-baseline.md
@@ -1,0 +1,180 @@
+# TinySpec: One editable database baseline before 1.0
+
+**Branch**: fix/baseline-consolidate-r2
+**Date**: 2026-08-23
+**Complexity**: 3 (TinySpec route)
+**Findings**: `adr-1` (decision), `astro-plan-90u05` (this work)
+
+## What
+
+The schema was stated in three places. `0001_initial_schema.sql` created the
+tables, `0002_drop_require_same_camera.sql` removed a column from one of them,
+and `0003_plans_destination_root.sql` added a column to another. A reader asking
+"what shape is the `plans` table" had to replay the chain, and a reader asking
+"may I edit `0001`" got contradictory answers: a compile-time SHA-384 literal in
+`crates/persistence/core/tests/baseline_invariants.rs` froze the file's bytes,
+while `adr-1` had already decided that pre-1.0 schema changes are made in place.
+
+Nothing consumes the chain. Before 1.0 there is no released database to upgrade,
+so every database is created by running the migration set from empty. The two
+appended files bought replay fidelity that no installation needs, and paid for it
+with three statements of one schema.
+
+## The rule (decision)
+
+**Before 1.0 there is exactly one migration, `0001_initial_schema.sql` at version
+1. Schema and seed-data changes are made in place in that file. No `0002` or
+later file is added. Every such edit destroys every existing development
+database, and recreating it is the user's step.**
+
+The three parts are one rule and none of them stands alone:
+
+| Part | Consequence |
+|------|-------------|
+| One file at version 1 | the schema is readable in one pass; no replay reconstructs a table's shape |
+| Edited in place | `0002+` is not the mechanism for a pre-1.0 change, so the freeze that forbade editing `0001` is removed with the chain |
+| Existing dev databases die | an in-place edit changes the recorded checksum of a migration already marked applied, which sqlx refuses at boot |
+
+### The destruction is loud, not silent, and not automatic
+
+`has_pending_migrations` compares applied count against total
+(`crates/persistence/core/src/lib.rs:167-186`). An in-place edit to version 1
+changes no count, so it reports no pending work and the desktop shell skips its
+`VACUUM INTO` backup (`apps/desktop/src-tauri/src/lib.rs:542-554`).
+`MIGRATOR.run` then fails on the checksum comparison, classified for the user by
+`migration_divergence_detail` (`crates/persistence/core/src/lib.rs:257`) and
+surfaced at `apps/desktop/src-tauri/src/lib.rs:631`.
+
+The database is refused, not corrupted, and it is not repairable in place: the
+recorded checksum belongs to a schema generation that no longer exists in the
+checkout. The reset procedure is
+[`docs/development/database-baseline-and-migrations.md`](../../docs/development/database-baseline-and-migrations.md).
+
+Making the backup fire instead would mean teaching `has_pending_migrations` to
+compare checksums rather than counts, which is a boot-time read of every
+migration against the applied table. That is the 1.0 problem, when a real
+upgrade path exists; before 1.0 a developer recreating a database loses nothing
+that was not re-derivable.
+
+### Removing the checksum literal leaves no compile-time drift control
+
+The 48-byte SHA-384 literal asserted the migration file's bytes against a
+committed constant. It cannot survive a rule that says the file is edited: every
+intended edit fails it, so the only possible response is to update the literal in
+the same commit, which is a step that proves nothing. A second assertion in the
+same test compared `include_str!` of the migration against itself and was
+tautological in any case.
+
+Runtime tamper detection is unaffected, because it is sqlx's own comparison of
+`_sqlx_migrations.checksum` against the embedded script, not ours. It has a test
+(`crates/persistence/core/src/lib.rs:403` `real_sqlx_divergence_is_classified`).
+
+What is genuinely lost is a compile-time signal that the schema changed without
+anyone intending it. Replacing it with a snapshot of the schema's *shape* —
+tables, columns, indexes — rather than the file's bytes is tracked on
+`astro-plan-0zog4` and is out of scope here. Until it lands there is no
+compile-time drift control, and `docs/development/database-baseline-and-migrations.md:75-86`
+says so.
+
+### Two shipped specs still cite the deleted checksum test
+
+`specs/tiny/documented-fallbacks-on-out-of-range-values.md:98` reasons from
+"Migration `0001_initial_schema.sql` is frozen by a checksum test", and
+`specs/tiny/bundled-seed-asset-digest.md:70-74` cites that test as the precedent
+for its own digest shape. Both are true of the head each was written against and
+false now.
+
+Neither is edited. Both are dated, head-pinned records of a decision taken while
+the freeze existed, and rewriting their reasoning would misrepresent why the
+choice was made. Neither statement drives live behaviour: the first explains why
+a read-side guard was chosen over a `CHECK` constraint, and that conclusion is
+unchanged; the second borrows a digest-assertion shape that still exists in
+`crates/targeting/resolver/tests/bundled_seed_digest.rs`. This section is the
+supersession note a reader following either citation needs, and
+`astro-plan-ydnh1` tracks adding a forward pointer to each.
+
+## Per-finding verdict, equivalence at base 660d665ec
+
+Equivalence was proven before the two files were deleted, which is the order
+`adr-1` requires: a folded baseline that produces a different database than the
+chain is a silent schema change, and proving it afterwards proves only that the
+folded file matches itself.
+
+Two databases were built, one by running the three-file chain and one by running
+the folded `0001`, and compared:
+
+| Check | Verdict | Evidence |
+|-------|---------|----------|
+| Object count | equivalent | 578 objects in `sqlite_master` on both sides |
+| Normalized schema | equivalent | diff of normalized `sqlite_master` SQL is empty |
+| Seed data | equivalent | seed `INSERT` statements byte-identical, md5 `9a9f5853b54f321859547e3bfc8645ec` |
+| `plans` column list | equivalent | 22 columns both sides, `destination_root` at index 21 |
+| Referential integrity | clean | `PRAGMA foreign_key_check` returns no rows |
+| `require_same_camera` | absent both sides | removed from the `calibration_tolerances` column list and from the seed row's positional values in one edit |
+
+The seed row and the column list had to change together. The seed `INSERT` is
+positional, so dropping the column without dropping its value shifts every
+later value by one — a schema-equivalent baseline with wrong seed data, which
+the object-count and schema-diff checks would both have passed. The
+byte-identical seed comparison is the check that covers it.
+
+## Context
+
+| File | Role |
+|------|------|
+| `crates/persistence/core/migrations/0001_initial_schema.sql` | Modify: `require_same_camera` column and its positional seed value removed; `destination_root TEXT` added to the `plans` column list |
+| `crates/persistence/core/migrations/0002_drop_require_same_camera.sql` | Delete: folded into `0001` |
+| `crates/persistence/core/migrations/0003_plans_destination_root.sql` | Delete: folded into `0001` |
+| `crates/persistence/core/tests/baseline_invariants.rs` | Modify: SHA-384 literal and tautological `include_str!` comparison removed; test renamed `migration_set_starts_at_baseline_with_unique_versions`; module doc restated |
+| `crates/persistence/core/src/schema_cache.rs` | Modify: `MIGRATOR` doc stated append-only and `0002+`; now states the editable baseline |
+| `crates/persistence/core/src/lib.rs` | Modify: `migrate` doc referred to a frozen baseline and future append-only files |
+| `docs/release/pre-1-0-database-baseline.md` | Modify: baseline migration contract, release reset requirement |
+| `docs/development/database-baseline-and-migrations.md` | Modify: single-editable-baseline rule, reset procedure, drift-detection state |
+| `docs/development/persistence-layer-hardening.md` | Modify: migrations path corrected; the `0050` latest-migration claim replaced |
+| `specs/tiny/editable-pre-1-0-database-baseline.md` | Add: this file |
+
+## Requirements
+
+1. `crates/persistence/core/migrations/` contains exactly one file, at version 1
+   with description `initial schema`.
+2. The folded baseline produces a database equivalent to the one the chain
+   produced, proven before the chain files are deleted.
+3. No assertion in the crate fails merely because `0001` was edited as intended.
+4. Every statement in the crate's source and in `docs/` that describes migrations
+   as frozen or append-only is restated, so no reader is told the opposite of the
+   rule.
+5. The loss of compile-time drift control is recorded where a reader looking for
+   it will be, rather than left to be discovered.
+
+## Tasks
+
+- [x] Prove chain-versus-folded equivalence on object count, normalized schema,
+      seed bytes, `plans` column list, and `foreign_key_check`
+- [x] Fold `0002` and `0003` into `0001`, removing the `require_same_camera`
+      column together with its positional seed value
+- [x] Delete `0002_drop_require_same_camera.sql` and
+      `0003_plans_destination_root.sql`
+- [x] Remove the SHA-384 literal and the tautological `include_str!` comparison
+      from `baseline_invariants.rs`; rename the surviving test
+- [x] Restate the frozen/append-only language in `schema_cache.rs` and `lib.rs`
+- [x] Restate the three affected `docs/` files, including the reset procedure and
+      the current absence of compile-time drift control
+- [x] Write this spec, carrying the equivalence evidence
+- [x] `cargo test -p persistence_core`
+- [ ] Schema-shape snapshot replacing the deleted byte checksum — deferred to
+      `astro-plan-0zog4`, out of scope by the brief
+- [ ] Forward pointers on the two shipped specs that cite the deleted checksum
+      test — deferred to `astro-plan-ydnh1`; both are dated records and are not
+      rewritten here
+
+## Done When
+
+- [x] One migration file remains, and `migration_set_starts_at_baseline_with_unique_versions`
+      asserts version 1 and description `initial schema`
+- [x] Equivalence holds on all five checks in the verdict table
+- [x] `cargo test -p persistence_core` is green (66 passed, 6 suites)
+- [x] No source or documentation statement in scope describes the baseline as
+      frozen or the chain as append-only
+- [ ] Compile-time drift control exists — it does not; `astro-plan-0zog4` owns
+      the replacement and the gap is documented at
+      `docs/development/database-baseline-and-migrations.md:75-86`


### PR DESCRIPTION
## Summary

Before 1.0 the database schema was stated in three migration files: `0001` created
the tables, `0002` dropped a column, and `0003` added one. Reading a table's shape
meant replaying the chain, and the crate contradicted itself about whether `0001`
could be edited — a compile-time checksum froze its bytes while the recorded
decision (`adr-1`) said pre-1.0 schema changes are made in place.

`0002` and `0003` are folded into `0001` and deleted. There is now exactly one
migration, at version 1, edited in place. There is no released database to
upgrade, so nothing replays the chain.

## Breaking changes

**Every existing development database must be recreated.** This is accepted by the
owner and is the intended consequence, not a regression.

An in-place edit to version 1 changes no migration count, so the app reports
nothing pending, skips its pre-migration backup, and then refuses the database on
a checksum mismatch at boot. The refusal is loud and does not corrupt the file,
but it cannot be repaired in place: the recorded checksum belongs to a schema
generation that no longer exists in the checkout.

Delete the database file plus its `-wal` and `-shm` sidecars and relaunch; the
embedded migrator recreates it. Full procedure:
`docs/development/database-baseline-and-migrations.md`.

This applies to developer databases only. No released version ships a database
this branch invalidates.

## What else changed

- The compile-time SHA-384 literal over the migration file's bytes is removed. It
  fails on every intended edit, so the only possible response was to update the
  literal in the same commit, which proves nothing. A second assertion in the same
  test compared the file against itself.
- Runtime tamper detection is unaffected: it is sqlx's own comparison of
  `_sqlx_migrations.checksum` against the embedded script, and it keeps its test.
- **No compile-time schema-drift control remains** until the replacement
  schema-shape snapshot lands (`astro-plan-0zog4`). The gap is documented rather
  than left to be discovered.
- Source and documentation statements describing the baseline as frozen or the
  chain as append-only are restated. `docs/development/persistence-layer-hardening.md`
  no longer claims the latest migration is `0050`.

## Equivalence evidence

Proven before the two files were deleted, which is the order `adr-1` requires.
A chain-built and a folded-built database were compared:

| Check | Result |
|-------|--------|
| `sqlite_master` object count | 578 both sides |
| Normalized schema diff | empty |
| Seed `INSERT` bytes | identical, md5 `9a9f5853b54f321859547e3bfc8645ec` |
| `plans` columns | 22 both sides, `destination_root` at index 21 |
| `PRAGMA foreign_key_check` | clean |

The seed comparison is load-bearing. The seed `INSERT` is positional, so dropping
`require_same_camera`'s column without dropping its value shifts every later value
by one — a wrong-data baseline that the count and schema-diff checks would both
have passed.

## Verification

`cargo test -p persistence_core` — 66 passed, 6 suites, exit 0.

Not run: the full workspace build, deliberately, and the repository check, which
fails on a pre-existing unrelated typo (`astro-plan-8vxx1`).

## Spec Context

- `specs/tiny/editable-pre-1-0-database-baseline.md` states the rule and carries
  the per-finding verdict.
- Two shipped tinyspecs still cite the deleted checksum test
  (`documented-fallbacks-on-out-of-range-values.md:98`,
  `bundled-seed-asset-digest.md:70-74`). Both are left as dated, head-pinned
  records; `astro-plan-ydnh1` tracks adding a forward pointer to each.

Merge-Bead: astro-plan-q43gl
Closes-Bead: astro-plan-90u05
Tracks-Bead: astro-plan-90u05
Tracks-Bead: adr-1