### PR TITLE
fix: handle corrupt FITS headers in the parser instead of catching its panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,9 +1862,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fits-header"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f03c8e9bb8afa98de1186e5237a70d2e907b239a9c1f0d523131402cc0b326"
+checksum = "969ed073af9c306b26221d182a258167934916fc249caf9f3fd08fe5bc091431"
 dependencies = [
  "skymath 0.6.0",
  "thiserror 2.0.19",

--- a/crates/app/inbox/src/scan.rs
+++ b/crates/app/inbox/src/scan.rs
@@ -214,8 +214,11 @@ fn is_xisf_extension(ext: &str) -> bool {
 /// Returns `Some(ScannedMasterFile)` when the file is identified as a master.
 /// Returns `None` when not a master or metadata is unreadable.
 fn try_detect_master(abs_path: &Path, rel_path: &str, ext: &str) -> Option<ScannedMasterFile> {
-    // Cached extract (F0): memoized by (path, mtime, size); unsupported
-    // extensions and unparseable files both surface as `Err` here.
+    // Cached extract (F0): memoized by (path, mtime, size). Unsupported
+    // extensions surface as `Err` here. A corrupt FITS header does not: the
+    // parser is lenient and reports no keywords, so such a file reaches
+    // `detect_master` below with every header field `None` and is classified
+    // from its path alone (astro-plan-z7997).
     let bundle = cached_extract(abs_path).ok()?;
 
     let image_typ_raw = bundle.image_typ.as_deref();

--- a/crates/metadata/fits/Cargo.toml
+++ b/crates/metadata/fits/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 metadata_core = { path = "../core" }
-fits-header = "0.4.2"
+fits-header = "0.4.3"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/metadata/fits/src/lib.rs
+++ b/crates/metadata/fits/src/lib.rs
@@ -19,11 +19,11 @@
 //! handle at all — including one that panics inside `fits-header` — yields
 //! [`MetadataExtractError::Parse`]; [`FitsExtractor::extract`] never panics.
 //!
-//! A silent mis-parse passes through this adapter undetected, because it does
-//! not validate that the header block is ASCII: `fits-header` lossy-decodes
-//! each card before slicing it at fixed offsets, so one invalid UTF-8 byte
-//! shifts every later field and can yield a wrong keyword and value with no
-//! panic and no error.
+//! This adapter does not validate that the header block is ASCII. `fits-header`
+//! slices each field from the raw 80 bytes of its card and lossy-decodes the
+//! slice, so an invalid UTF-8 byte garbles the one field that contains it and
+//! cannot shift any later field. Such a field still passes through undetected,
+//! with no panic and no error.
 #![allow(clippy::doc_markdown)]
 
 use std::io::{self, Read};
@@ -73,12 +73,11 @@ impl MetadataExtractor for FitsExtractor {
             msg: e.to_string(),
         })?;
 
-        // `fits-header` 0.4.2 lossy-decodes the block and then slices the
-        // resulting `String` at fixed byte offsets (`parse.rs:38`, `:47`,
-        // `:61`, `:92`, `:98`). A non-ASCII byte widens to a 3-byte U+FFFD, so
-        // those
-        // offsets can land inside a char and panic. Containing that here
-        // depends on panics unwinding: the release profile in the workspace
+        // `Header::parse` is third-party and unvendored, and the inbox scan runs
+        // it over every file it walks, so one panic would abort a whole scan
+        // rather than skip a file. No `fits-header` release currently panics on
+        // malformed bytes; this backstops the next one. Containing a panic here
+        // depends on it unwinding: the release profile in the workspace
         // `Cargo.toml` deliberately keeps the default `panic = "unwind"`.
         let parsed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             fits_header::Header::parse(&bytes)
@@ -376,20 +375,31 @@ mod tests {
         assert!(meta.image_typ.is_none());
     }
 
-    /// Regression for astro-plan-3v3r.20.33 / 20.16: a `.fits` file whose first
-    /// block is non-ASCII drives `fits-header` 0.4.2 into a non-char-boundary
-    /// slice, which in production unwinds out of the inbox scan.
+    /// Regression for astro-plan-3v3r.20.33 / 20.16, asserted against the parser
+    /// rather than the adapter so [`FitsExtractor::extract`]'s `catch_unwind`
+    /// cannot mask a reintroduced panic. `fits-header` 0.4.2 sliced its
+    /// lossy-decoded card at fixed offsets and panicked on this input.
     #[test]
-    fn malformed_header_bytes_are_an_error_not_a_panic() {
+    fn parser_itself_does_not_panic_on_a_non_ascii_block() {
+        let parsed = fits_header::Header::parse(&[0xffu8; BLOCK_SIZE]);
+        assert!(parsed.is_ok(), "expected a lenient parse, got {parsed:?}");
+    }
+
+    /// A block of non-ASCII bytes yields no recognised keywords rather than an
+    /// error: `fits-header` parsing is lenient by design.
+    #[test]
+    fn malformed_header_bytes_yield_no_keywords() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("corrupt.fits");
         std::fs::write(&path, [0xffu8; BLOCK_SIZE]).expect("write fixture");
 
-        let err = FitsExtractor.extract(&path).expect_err("malformed header must be an error");
-        assert!(
-            matches!(err, MetadataExtractError::Parse { .. }),
-            "expected a Parse error, got {err:?}"
-        );
+        let meta = FitsExtractor
+            .extract(&path)
+            .expect("a malformed header must not be an error")
+            .expect("a .fits extension must be supported");
+        assert!(meta.image_typ.is_none());
+        assert!(meta.object.is_none());
+        assert!(meta.date_obs.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bumps `fits-header` from 0.4.2 to 0.4.3, which fixes a panic on malformed FITS header bytes inside the parser instead of relying on this app catching it.
- 0.4.2 lossy-decoded each 80-byte card into a `String` and then sliced that `String` at fixed byte offsets. A non-ASCII byte widens to a 3-byte U+FFFD, so an offset could land inside a char and panic. 0.4.3 slices each field from the raw card bytes and decodes the slice, so offsets index the card as it exists on disk.
- A corrupt FITS header is now read as a header reporting no keywords, where it previously reported a parse error.

## What was actually proved

The upstream changelog was not taken on trust. A new test calls `fits_header::Header::parse` directly, so the adapter's `catch_unwind` cannot mask a panic, and feeds it the known-bad input of 2880 bytes of `0xff`:

- On 0.4.3 it passes.
- Re-pinning 0.4.2 and running that same test panics at `parse.rs:38:31`, `end byte index 8 is not a char boundary`. That is what shows the test exercises the parser rather than the guard.

Scoped gates, each invoked directly: `cargo test -p metadata_fits` 31 passed / 0 failed, `cargo clippy -p metadata_fits --all-targets -- -D warnings` clean, `cargo fmt --all --check` clean, `cargo check -p app_core_inbox` clean, `scripts/check-db-boundary.sh` sealed at zero. The test and clippy runs were repeated independently on a fresh target directory.

## Behaviour change

0.4.3 is lenient rather than fallible on this input: it returns `Ok(header)` with no recognised keywords, so `FitsExtractor::extract` returns `Ok(Some(_))` with every field `None` where it previously returned `MetadataExtractError::Parse`. The test that asserted the pre-bump error is replaced by one asserting the new outcome.

That reaches one caller. `crates/app/inbox/src/scan.rs:219` discards an `Err`, so a corrupt FITS used to leave master detection there. It now falls through to path-only inference in `crates/calibration/master-detect/src/pixinsight.rs:52-63` and can be detected as a calibration master with no header evidence. A valid FITS lacking `IMAGETYP` already took that path, so this widens an existing class rather than adding a mechanism. Whether a keyword-less header should be excluded from it is a product decision, filed as `astro-plan-z7997` and deliberately not decided inside a dependency bump. The stale comment at `scan.rs:217` is corrected to describe what now happens.

## The panic guard is kept

The `catch_unwind` in `FitsExtractor::extract` was added because 0.4.2 panicked, and this bump retires that reason. It is kept rather than removed, and its comment is reworded to the reason that still holds: `Header::parse` is third-party and unvendored, the inbox scan runs it over every file it walks, and one panic there would abort a whole scan rather than skip a file. The sibling XISF adapter's guard already rests on that reason with no known panic to point at (`crates/metadata/xisf/src/lib.rs:54`), so keeping this one leaves the two metadata adapters consistent. This is not a sign the bump was insufficient — the parser test above passes with the guard bypassed.

`xisf-header` was checked for the same defect class and does not have it: it parses via quick-xml over a checked `str::from_utf8`, and its one fixed-offset `str` slice is guarded by an explicit quote-and-length check. It is already on its latest release, 0.4.3.

Tracks-Bead: astro-plan-61v2y
Closes-Bead: astro-plan-61v2y
Merge-Bead: astro-plan-5rkrw
