### PR TITLE
fix(gates): three repo checks that could not fail

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,9 +8,11 @@
 # fails when no hook looked at the paths given.
 #
 # specs/ carries no recorded rationale (present since the initial scaffold,
-# 0fe246eb0). It stays excluded because un-gating it needs a 328-file
-# whitespace sweep and 20 typo fixes, 7 of them inside a specs/*/tasks.md that
-# a repo guard refuses to let anyone write.
+# 0fe246eb0). Measured cost of un-gating it, over 503 tracked spec files:
+# trailing-whitespace rewrites 34 files / 129 lines, end-of-file-fixer 5 files,
+# and typos reports 20 findings across 14 files. 9 of those findings sit in
+# tasks.md files, which the speckit-tasks-guard hook denies writing under an
+# active beads workspace.
 exclude: '^(\.specify/|specs/|\.claude/|\.agents/|\.codex/|\.mcp\.json|apps/desktop/src/bindings/)'
 
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,16 @@
 # apps/desktop/src/bindings/ is generated (tauri-specta); its doc comments
 # carry trailing whitespace, so whitespace/EOF fixers would corrupt it and
 # break the `just check-generated` drift gate.
+#
+# This exclude is global, so `pre-commit run --files <path under any prefix
+# below>` exits 0 with every hook reporting "(no files to check) Skipped" —
+# indistinguishable from a passing run. Use `just precommit <paths>`, which
+# fails when no hook looked at the paths given.
+#
+# specs/ carries no recorded rationale (present since the initial scaffold,
+# 0fe246eb0). It stays excluded because un-gating it needs a 328-file
+# whitespace sweep and 20 typo fixes, 7 of them inside a specs/*/tasks.md that
+# a repo guard refuses to let anyone write.
 exclude: '^(\.specify/|specs/|\.claude/|\.agents/|\.codex/|\.mcp\.json|apps/desktop/src/bindings/)'
 
 repos:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,24 @@ publicly available under the project's open-source license (AGPL-3.0) regardless
 4. Ensure tests pass (if applicable)
 5. Open a pull request with a clear description of the change
 
+## Verifying gates
+
+A green `pre-commit` run is not by itself evidence that your files were checked,
+and neither is a clean commit.
+
+- `pre-commit run --files <paths>` exits 0 when no hook looked at any of those
+  paths. The global `exclude:` in `.pre-commit-config.yaml` drops whole trees
+  (including `specs/`, `.claude/` and `.specify/`) from every hook's file list,
+  and the run then reports success having checked nothing. Use
+  `just precommit <paths>` instead: it fails when no hook ran and prints how
+  many did.
+- Some machines set `core.hooksPath` outside the repository, in which case git
+  never runs this repo's pre-commit hooks at all and a successful commit proves
+  nothing. Check with `git config --get core.hooksPath`.
+
+So when you report a check as passing, say which hooks ran, not which command
+exited 0. When you review, ask for that.
+
 ## Code of conduct
 
 Be respectful. Contributions are evaluated on technical merit.

--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -336,7 +336,7 @@ pub async fn confirm(
     //
     // Ordered before the three writes below, not after: frame-to-framing
     // attribution is a Tier-1 record (Constitution V) that the filesystem cannot
-    // re-derive, and those writes are what make the plan applicable. Running them
+    // re-derive, and those writes are what leave the plan ready to apply. Running them
     // first left a `ready_for_review` plan on a failed attribution, so the frames
     // could move with the user's decision missing. The plan stays in `draft` on
     // failure, which `plans.approve` refuses.
@@ -1396,7 +1396,7 @@ mod tests {
 
     /// Confirm one inbox item holding two light frames, one per session folder,
     /// under identical pattern tokens. Returns the confirm error and asserts
-    /// that nothing applicable was left behind.
+    /// that no plan was left ready to apply.
     async fn confirm_two_session_frames(item_id: &str, names: (&str, &str)) -> ContractError {
         let tmp = tempfile::tempdir().unwrap();
         for (session, name) in [("session-a", names.0), ("session-b", names.1)] {
@@ -3176,10 +3176,10 @@ mod tests {
 
     /// Frame-to-framing attribution is a Tier-1 record (Constitution V): it
     /// cannot be re-derived from the filesystem. A confirm whose attribution
-    /// fails must therefore leave nothing applicable behind, or the frames move
+    /// fails must therefore leave no plan ready to apply, or the frames move
     /// with the user's decision missing.
     #[tokio::test]
-    async fn failed_attribution_leaves_no_applicable_plan() {
+    async fn failed_attribution_leaves_no_plan_ready_to_apply() {
         let tmp = tempfile::tempdir().unwrap();
         write_fits(
             tmp.path(),
@@ -3223,7 +3223,7 @@ mod tests {
         assert_eq!(
             count_plans_in_state(db.pool(), "ready_for_review").await,
             0,
-            "a failed attribution must leave no applicable plan"
+            "a failed attribution must leave no plan ready to apply"
         );
         assert!(inbox_repo::get_plan_link(db.pool(), "item-attr-fail").await.unwrap().is_none());
         let item = inbox_repo::get_inbox_item(db.pool(), "item-attr-fail").await.unwrap();

--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -336,7 +336,7 @@ pub async fn confirm(
     //
     // Ordered before the three writes below, not after: frame-to-framing
     // attribution is a Tier-1 record (Constitution V) that the filesystem cannot
-    // re-derive, and those writes are what make the plan appliable. Running them
+    // re-derive, and those writes are what make the plan applicable. Running them
     // first left a `ready_for_review` plan on a failed attribution, so the frames
     // could move with the user's decision missing. The plan stays in `draft` on
     // failure, which `plans.approve` refuses.
@@ -1396,7 +1396,7 @@ mod tests {
 
     /// Confirm one inbox item holding two light frames, one per session folder,
     /// under identical pattern tokens. Returns the confirm error and asserts
-    /// that nothing appliable was left behind.
+    /// that nothing applicable was left behind.
     async fn confirm_two_session_frames(item_id: &str, names: (&str, &str)) -> ContractError {
         let tmp = tempfile::tempdir().unwrap();
         for (session, name) in [("session-a", names.0), ("session-b", names.1)] {
@@ -3176,10 +3176,10 @@ mod tests {
 
     /// Frame-to-framing attribution is a Tier-1 record (Constitution V): it
     /// cannot be re-derived from the filesystem. A confirm whose attribution
-    /// fails must therefore leave nothing appliable behind, or the frames move
+    /// fails must therefore leave nothing applicable behind, or the frames move
     /// with the user's decision missing.
     #[tokio::test]
-    async fn failed_attribution_leaves_no_appliable_plan() {
+    async fn failed_attribution_leaves_no_applicable_plan() {
         let tmp = tempfile::tempdir().unwrap();
         write_fits(
             tmp.path(),
@@ -3223,7 +3223,7 @@ mod tests {
         assert_eq!(
             count_plans_in_state(db.pool(), "ready_for_review").await,
             0,
-            "a failed attribution must leave no appliable plan"
+            "a failed attribution must leave no applicable plan"
         );
         assert!(inbox_repo::get_plan_link(db.pool(), "item-attr-fail").await.unwrap().is_none());
         let item = inbox_repo::get_inbox_item(db.pool(), "item-attr-fail").await.unwrap();

--- a/docs/development/persistence-layer-hardening.md
+++ b/docs/development/persistence-layer-hardening.md
@@ -122,8 +122,10 @@ So the **authoritative** guard is `scripts/check-db-boundary.sh`, and clippy is 
   - `query_builder_example.rs` (the reference module).
 - For each remaining file, counts query/exec sites
   (`sqlx::query | query_as | query_scalar | .fetch_(one|all|optional) |
-  .execute(`) that appear **before** the first `#[cfg(test)]` line. Inline unit
-  test modules are not production code and are excluded.
+  .execute(`) outside every inline `#[cfg(test)]` item's own brace scope. Unit
+  test modules are not production code, but production code *following* one in
+  the same file still counts, and a comment or blank line between the attribute
+  and the item it applies to does not break the exemption.
 - **Now sealed at zero (2026-07-11).** `scripts/db-boundary-baseline.txt` is
   empty, so the check fails (exit 1) on **any** production query site outside
   `persistence/db`. It also rejects a non-empty (hand-edited) baseline

--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@ test:
     node scripts/check-eslint-baseline.test.mjs
     node scripts/check-mock-baseline.test.mjs
     node scripts/check-orphan-ve-modules.test.mjs
+    node scripts/precommit-verify.test.mjs
 
 # Lint and format. This recipe is the single local definition of the lint set;
 # the root package.json `lint` script delegates here so the two cannot drift.
@@ -36,6 +37,12 @@ lint:
     # protection policy. That comparison is offline; the live-protection
     # comparison after it skips with a NOTE when there is no network or token.
     bash scripts/check-required-contexts.sh
+
+# Run pre-commit over specific paths and FAIL if no hook looked at any of them.
+# Prefer this over a bare `pre-commit run --files ...`, which exits 0 when the
+# config's global `exclude:` drops every path given.
+precommit *FILES:
+    bash scripts/precommit-verify.sh {{FILES}}
 
 # Build the Rust workspace and package workspaces when present.
 build:

--- a/scripts/check-db-boundary.sh
+++ b/scripts/check-db-boundary.sh
@@ -133,8 +133,13 @@ count_file() {
     }
 
     # Line after a #[cfg(test)] attribute decides how far the exemption reaches.
+    #
+    # Blank lines and full-line comments compile to nothing, so they do not end the
+    # search for the attributed item. Only `//` comments are recognised here: a
+    # multi-line `/* */` between the attribute and its item ends the exemption early,
+    # which over-counts rather than under-counts.
     pending {
-      if ($0 ~ /^[[:space:]]*#\[/) { next }        # stacked attributes
+      if ($0 ~ /^[[:space:]]*(#\[|\/\/)/ || $0 ~ /^[[:space:]]*$/) { next }
       pending = 0
       if ($0 ~ /\{/) { skipping = 1 }              # braced item: skip its scope
       next                                         # else `mod x;` — just this line
@@ -277,6 +282,8 @@ self_test() {
     'tracing_target|0|if event.metadata().target() == "sqlx::query" { n += 1; }'
     'doc_mention|0|/// Wraps sqlx::query_as::<_, Row>() for callers.'
     'cfg_test_scope|0|#[cfg(test)]\nmod tests {\n    fn t() { sqlx::query("SELECT 1"); }\n}'
+    'cfg_test_comment_before_attr|0|#[cfg(test)]\n// why this module allows the lint\n#[allow(clippy::too_many_lines)]\nmod tests {\n    fn t() { sqlx::query("SELECT 1"); }\n}'
+    'cfg_test_blank_before_item|0|#[cfg(test)]\n\nmod tests {\n    fn t() { sqlx::query("SELECT 1"); }\n}'
     'after_cfg_test|1|#[cfg(test)]\nmod tests {\n    fn t() {}\n}\nfn prod() { sqlx::query("SELECT 1"); }'
   )
 

--- a/scripts/precommit-verify.sh
+++ b/scripts/precommit-verify.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# pre-commit wrapper that refuses a vacuous run.
+#
+# `pre-commit run --files <paths>` exits 0 when NO hook looked at any of those
+# paths: the global `exclude:` in .pre-commit-config.yaml drops whole trees
+# (specs/, .claude/, .specify/, .agents/, .codex/, .mcp.json,
+# apps/desktop/src/bindings/) from every hook's file list, every hook prints
+# "(no files to check) Skipped", and the run reports success. A checked-nothing
+# run and a checked-everything run are then byte-identical in their exit status,
+# which is how a specs-only change reached review with no gate behind it.
+#
+# This wrapper exits 1 on that case and always names the hooks that actually ran,
+# so the count is reviewable evidence rather than an inference from exit 0.
+#
+# Usage: scripts/precommit-verify.sh <file>...
+set -uo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "usage: $0 <file>..." >&2
+  exit 2
+fi
+
+out="$(pre-commit run --color=never --files "$@" 2>&1)"
+status=$?
+printf '%s\n' "$out"
+
+# pre-commit terminates every hook's status line with Passed, Failed or Skipped.
+ran="$(printf '%s\n' "$out" | grep -cE '(Passed|Failed)$' || true)"
+
+echo ""
+echo "pre-commit hooks that actually ran on these $# path(s): $ran"
+
+if [[ "$ran" -eq 0 ]]; then
+  echo "" >&2
+  echo "VACUOUS RUN: no hook checked any of the $# path(s) given." >&2
+  echo "Every hook skipped, so pre-commit's exit status says nothing about these files." >&2
+  echo "Cause is almost always the global 'exclude:' in .pre-commit-config.yaml." >&2
+  echo "Gate these paths with a check that sees them, or narrow the exclude." >&2
+  exit 1
+fi
+
+exit "$status"

--- a/scripts/precommit-verify.test.mjs
+++ b/scripts/precommit-verify.test.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+//
+// Tests for precommit-verify.sh.
+//
+// The wrapper exists to separate "every hook skipped" from "every hook passed",
+// which pre-commit itself reports with the same exit 0. The discrimination lives
+// entirely in how it reads hook status lines, so the tests drive it against a
+// stubbed `pre-commit` on PATH rather than the real one: a real run depends on
+// installed hook environments and on the repo's own exclude list, neither of
+// which this behaviour should be coupled to.
+//
+// Pure Node — no Vitest (matches check-mock-baseline.test.mjs). Run via
+// `node scripts/precommit-verify.test.mjs`.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT_PATH = path.join(here, 'precommit-verify.sh');
+
+const failures = [];
+
+// Real `pre-commit run --files` output, one status line per hook.
+const ALL_SKIPPED = [
+  'check for added large files.............................(no files to check)Skipped',
+  'check json.............................................(no files to check)Skipped',
+  'typos..................................................(no files to check)Skipped',
+].join('\n');
+
+const SOME_PASSED = [
+  'check for added large files..............................................Passed',
+  'check json.............................................(no files to check)Skipped',
+  'typos....................................................................Passed',
+].join('\n');
+
+const ONE_FAILED = [
+  'check for added large files..............................................Passed',
+  'typos....................................................................Failed',
+].join('\n');
+
+/** Run the wrapper with a stub `pre-commit` that prints `output` and exits `code`. */
+function runWithStub(output, code, args = ['some/file.md']) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'precommit-verify-'));
+  try {
+    const stub = path.join(dir, 'pre-commit');
+    fs.writeFileSync(stub, `#!/bin/sh\ncat <<'EOF'\n${output}\nEOF\nexit ${code}\n`);
+    fs.chmodSync(stub, 0o755);
+    return spawnSync('bash', [SCRIPT_PATH, ...args], {
+      encoding: 'utf8',
+      env: { ...process.env, PATH: `${dir}:${process.env.PATH}` },
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function check(label, run, expectedStatus, expectedStdoutPattern) {
+  if (run.status !== expectedStatus) {
+    failures.push(
+      `${label}: expected exit ${expectedStatus}, got ${run.status}\n  stdout: ${run.stdout}\n  stderr: ${run.stderr}`,
+    );
+    return;
+  }
+  if (expectedStdoutPattern && !expectedStdoutPattern.test(run.stdout ?? '')) {
+    failures.push(`${label}: stdout did not match ${expectedStdoutPattern}\n  stdout: ${run.stdout}`);
+  }
+}
+
+// A run where every hook skipped is the vacuous case pre-commit reports as 0.
+check('all hooks skipped', runWithStub(ALL_SKIPPED, 0), 1, /actually ran on these 1 path\(s\): 0/);
+
+// The same output, but pre-commit's own exit status must not be what decides it.
+check('all hooks skipped, non-zero pre-commit', runWithStub(ALL_SKIPPED, 1), 1, /: 0/);
+
+// A run where hooks did look at the files passes through unchanged.
+check('some hooks passed', runWithStub(SOME_PASSED, 0), 0, /actually ran on these 1 path\(s\): 2/);
+
+// A real hook failure keeps pre-commit's status; the wrapper must not mask it.
+check('a hook failed', runWithStub(ONE_FAILED, 1), 1, /actually ran on these 1 path\(s\): 2/);
+
+// No paths is a caller error, not a vacuous run.
+const noArgs = spawnSync('bash', [SCRIPT_PATH], { encoding: 'utf8' });
+if (noArgs.status !== 2) {
+  failures.push(`no arguments: expected exit 2, got ${noArgs.status}`);
+}
+
+if (failures.length > 0) {
+  console.error(`precommit-verify.test.mjs FAILED:\n\n${failures.join('\n\n')}`);
+  process.exitCode = 1;
+} else {
+  console.log('precommit-verify.test.mjs: OK (5 assertions).');
+}


### PR DESCRIPTION
## Why these three travel together

All three defects have the same shape: **a check that reports success having
checked nothing, byte-identical in its exit status to a check that checked
everything.** That is the same shape as the four vacuous tests this repo has
already shipped (empty joined table, pruned join, detector short-circuit,
`does_not_panic`). Fixing them as one unit is the point — separately they look
like three unrelated chores.

## 1. `appliable` typo failed `typos` for every worktree (`astro-plan-8vxx1`)

`crates/app/inbox/src/confirm.rs` misspelled `appliable` in 5 places (`:339`,
`:1399`, `:3179`, `:3182`, `:3226`), so `typos` — and therefore `just check` —
exited 1 in every checkout. A permanently red gate makes a real failure
indistinguishable from the known one; every agent this session had to be told
"that failure is pre-existing".

Round-1 review caught that my first pass was grammatically right and
semantically wrong: `applicable` means "relevant" or "pertinent", while the
misspelled `appliable` was reaching for "can be applied". Re-read all five sites,
and the surrounding code names the concrete state the prose meant — a plan in
`ready_for_review`, which is the state `plans.approve` proceeds from. So the
wording is now **"ready to apply"**, which keeps the intended sense and ties it to
the state machine:

| Site | Now reads |
|---|---|
| `:339` | "those writes are what leave the plan **ready to apply**" |
| `:1399` | "asserts that **no plan was left ready to apply**" |
| `:3179` | "must therefore leave **no plan ready to apply**" |
| `:3182` | `failed_attribution_leaves_no_plan_ready_to_apply` (test name) |
| `:3226` | "a failed attribution must leave **no plan ready to apply**" |

No `typos` allowlist entry was added — the misspelling is satisfied, not silenced.
`pre-commit run typos --all-files` exits 0, and the renamed test runs and passes
(`confirm::tests::failed_attribution_leaves_no_plan_ready_to_apply`).
`unappliable` in `e2e-agentic-test/003-first-run-source-setup/.../scenario.md:120`
is left alone: `typos` does not flag it, and it is unrelated prose.

## 2. db-boundary gate's `#[cfg(test)]` exemption defeated by a comment (`astro-plan-co45d`)

`scripts/check-db-boundary.sh`'s awk `pending` state advanced only on
`^[[:space:]]*#\[`, so a comment — or a blank line — between `#[cfg(test)]` and
the item it applies to cleared `pending` and voided the exemption. Test SQL was
then counted as a production boundary violation, in a lane whose name gives no
hint that comment position caused it. PR #1727 lost a round to exactly this.

Fixed by also skipping full-line `//` comments and blank lines while `pending`.
A multi-line `/* */` in that position still ends the exemption early, which
over-counts rather than under-counts; that limit is stated at the call site.

Two self-test cases added to the existing 17-case detector fixture:
`cfg_test_comment_before_attr` and `cfg_test_blank_before_item`, both expecting
0. Confirmed failing against the pre-fix script (each counted 1). The fixture
runs on every `just db-boundary`, so the gate cannot silently regress.

## 3. `pre-commit run --files` exits 0 having checked nothing (`astro-plan-vi96h`, PARTIAL)

`.pre-commit-config.yaml`'s global `exclude:` drops whole trees from every hook's
file list, so `pre-commit run --files specs/…/data-model.md` exits **0** with all
10 file-stage hooks reporting `(no files to check) Skipped`.

Added `scripts/precommit-verify.sh`, exposed as `just precommit <paths>`. It
fails when zero hooks looked at the paths given, and always prints how many did,
so the count is reviewable evidence instead of an inference from exit 0. It
passes through pre-commit's own status otherwise, so a real hook failure is not
masked. Covered by `scripts/precommit-verify.test.mjs` (5 assertions, wired into
`just test`), which drives a stubbed `pre-commit` on `PATH` rather than the real
one so the discrimination is tested independently of installed hook envs.

### Wrapper, not narrowing — and why

The brief offered narrowing the `specs/` exclude as the alternative. The exclude
carries **no recorded rationale**: `specs/` has been in it since the initial
scaffold (`0fe246eb0`, empty commit body) and the only comment on the block
justifies `apps/desktop/src/bindings/` alone. So narrowing is not blocked by a
real reason — it is blocked by cost.

Round-1 review caught two wrong numbers here, both of which I had taken from a
subagent's report without measuring myself. Re-measured directly, over the 503
tracked files under `specs/`, by copying the config to `/tmp` and deleting only
the `specs/` alternative from its `exclude:` line, then running each hook against
that copy and counting what git saw as changed:

| Hook | Cost of checking `specs/` | Earlier claim |
|---|---|---|
| `trailing-whitespace` | **34 files, 129 lines** | ~~328 files~~ |
| `typos` | 20 findings across 14 files | unchanged |
| `end-of-file-fixer` | **5 files** | ~~2 files~~ |
| `check-json`, `check-yaml`, `check-toml`, `check-added-large-files`, `detect-private-key` | 0 | unchanged |

Commands, for reproduction (note `xargs -a` is GNU-only and silently fails on
macOS — that is how the wrong figures were produced):

```
python3 -c "…"                       # /tmp/g-nospecs.yaml = config minus 'specs/|'
git ls-files 'specs/*' > /tmp/g-specs.txt          # 503 files
xargs < /tmp/g-specs.txt pre-commit run trailing-whitespace -c /tmp/g-nospecs.yaml --files
git diff --name-only -- specs | wc -l              # 34
git diff --numstat -- specs | awk '{a+=$1} END{print a}'   # 129
```

The argument the numbers support is unchanged, and 9 of the 20 typo findings sit
inside `tasks.md` files (7 in `specs/049-source-view-generation/`, 1 each in
`051-tauri-shell-integration/` and `061-selectable-app-language/`). Those are not
fixable by an agent in this workflow: the `speckit-tasks-guard` hook denies writes
to `specs/*/tasks.md` under an active beads workspace, where task state lives in
beads and `tasks.md` is read-only legacy.

Correcting a second overstatement from round 1: that guard is **not** "a repo
guard". It is a user-level hook
(`~/.claude/hooks/speckit-conductor/scripts/speckit-tasks-guard.py`), outside this
repository, and it denies `Write`/`Edit`/`MultiEdit`/`apply_patch` **and** Bash
commands that write such a path. So narrowing is *possible* for a human editing
files directly; it is the agent workflow that cannot complete it. The wrapper is
the better answer regardless, because it fixes the general case — every tree in
the exclude — rather than `specs/` alone.

Filed while measuring this: **`astro-plan-2ppxa`**. That guard's module docstring
(`:10-12`) states its Bash branch is "ADVISORY ONLY … No redirect parsing", while
`writes_tasks_md()` (`:73-95`) parses redirects and denies. It also false-positives
on quoted text — it denied the `bd create` that filed this very bead, because the
description *quoted* a write shape, in a command that opened no file. A guard
whose docstring understates what it blocks is this PR's own defect class, which is
why it gets a bead rather than a footnote. Not fixable from platevault.

### Deliberately NOT done

- **`core.hooksPath` is untouched.** It is redirected machine-wide by tooling
  outside this repository, so `.git/hooks/pre-commit` does not exist and git
  never runs these hooks on commit. Overriding it reaches past platevault and is
  the owner's call. `astro-plan-vi96h` therefore stays **open** — this PR closes
  only its fact-2 half. `CONTRIBUTING.md` now warns readers to check it.
- **`scripts/check-hot-read-ratchet.sh:115-120` carries the identical defect and
  is not fixed here.** Its `self_test()` covers only the empty-scope refusal and
  has no detector case array to extend, so the same one-line fix would ship
  unverified. Filed as `astro-plan-k7azh`.
  (`scripts/check-dead-callers.sh:114-115` does not have the defect.)
- **The adjacency workaround advice does not exist in this repo, so nothing was
  removed.** Searched `.claude/rules/`, `docs/`, `CLAUDE.md`, `AGENTS.md`,
  `CONTRIBUTING.md`, `justfile`, `scripts/` and `specs/` for guidance to keep
  `#[cfg(test)]` adjacent to the next attribute: zero hits
  (`rg -i 'adjacent|interleav'` filtered to cfg(test)/attribute/db-boundary
  context, exit 1). It lives only in agent dispatch briefs and in
  `astro-plan-co45d`'s own comments, both outside this tree.
- What *was* stale in-repo is the only description of the rule this PR changes:
  `docs/development/persistence-layer-hardening.md:124` claimed the guard counts
  sites "before the first `#[cfg(test)]` line". That has been false since #1192
  scoped the exemption per item, and it understated the guard. Corrected in the
  second commit.
- `scripts/precommit-verify.test.mjs` is not covered by biome: `scripts/` is
  outside its include set, so `biome check` reports the path as ignored (exit 1).
  Its siblings `check-mock-baseline.test.mjs` and `check-eslint-baseline.test.mjs`
  are ignored identically, so this matches the existing convention rather than
  introducing an unlinted file. Not changed here.

## Verification — hooks that actually ran, not exit codes

| Check | Command | Result |
|---|---|---|
| typos, repo-wide | `pre-commit run typos --all-files` | exit 0 (was 1) |
| all hooks on changed files | `bash scripts/precommit-verify.sh <7 changed paths>` | exit 0 on 8 paths, **7 of 10 file-stage hooks ran** (check-added-large-files, check-yaml, detect-private-key, end-of-file-fixer, trailing-whitespace, gitleaks, typos; check-json/check-toml/rustfmt-included-sources correctly had no matching files) |
| db-boundary gate | `bash scripts/check-db-boundary.sh` | exit 0, 0 sites across 427 files |
| db-boundary detector | `bash scripts/check-db-boundary.sh --self-test` | exit 0, 19 detector cases PASS |
| db-boundary revert proof | pre-fix script + the 2 new cases | exit 1, both counted 1 (expected 0) |
| wrapper test | `node scripts/precommit-verify.test.mjs` | exit 0, 5 assertions |
| wrapper revert proof | vacuous-run check stripped | exit 1, `all hooks skipped: expected exit 1, got 0` |
| wrapper live behaviour | `precommit-verify.sh specs/001-astro-library-manager/data-model.md` | exit 1, 0 hooks ran — where bare `pre-commit run --files` on the same path exits 0 |
| shellcheck | `shellcheck scripts/precommit-verify.sh scripts/check-db-boundary.sh` | exit 0 |
| rust fmt | `cargo fmt -p app_core_inbox -- --check` | exit 0 |
| rust clippy | `cargo clippy -p app_core_inbox --all-targets -- -D warnings` | exit 0 |
| renamed test | `cargo nextest run -p app_core_inbox` | 253 passed, 0 failed, 1 skipped |
| merge | `git merge origin/main` | merged `3326320ba` (#1735) as `aec073bfd`, **0 conflicted files** |

Tracks-Bead: astro-plan-8vxx1
Tracks-Bead: astro-plan-co45d
Tracks-Bead: astro-plan-vi96h
Closes-Bead: astro-plan-8vxx1
Closes-Bead: astro-plan-co45d
Merge-Bead: astro-plan-x0s96
