### PR TITLE
fix: cleanup plans that send files to the Trash now review as destructive and require confirmation

### DIFF
--- a/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
@@ -15,7 +15,13 @@
  * 5. A zero-item plan cannot be approved (FR-014).
  */
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -731,6 +737,97 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
       expect(approveBtn).toHaveAttribute('data-variant', 'destructive'),
     );
     expect(approveBtn).not.toHaveAttribute('data-variant', 'primary');
+  });
+
+  // A plan bound for the OS bin carries NO `delete` items: both generators
+  // always store `action = "archive"` and only apply time reroutes to trash
+  // (`plan_apply::paths::item_row_to_executor_item`). Judging destructiveness
+  // from the item action alone rendered such a plan neutral and gate-free
+  // while applying it removed the user's files (constitution II).
+  it('renders a trash-destination plan as destructive though every item action is archive', async () => {
+    mockProtectionCheck.mockResolvedValue(
+      ok(protectionCheck({ hasProtectedItems: false, protectedItems: [] })),
+    );
+    mockPlansGet.mockResolvedValue(
+      ok(
+        plan({
+          destructiveDestination: 'os_trash',
+          items: [item({ action: 'archive', to: '' })],
+        }),
+      ),
+    );
+    renderOverlay();
+
+    await screen.findByText('light_001.xisf');
+    const approveBtn = screen.getByTestId('plan-review-approve-apply');
+    await waitFor(() =>
+      expect(approveBtn).toHaveAttribute('data-variant', 'destructive'),
+    );
+    expect(approveBtn).not.toHaveAttribute('data-variant', 'primary');
+    // The row itself must read danger too, not just the footer button.
+    const actionPill = within(
+      screen.getByTestId('plan-review-item-0'),
+    ).getByText('archive');
+    expect(actionPill).toHaveAttribute('data-variant', 'danger');
+  });
+
+  it('blocks Approve & apply on a trash-destination archive plan until destructive-confirm succeeds', async () => {
+    mockProtectionCheck.mockResolvedValue(
+      ok(protectionCheck({ hasProtectedItems: false, protectedItems: [] })),
+    );
+    mockPlansGet.mockResolvedValue(
+      ok(
+        plan({
+          destructiveDestination: 'os_trash',
+          items: [item({ action: 'archive', to: '' })],
+        }),
+      ),
+    );
+    renderOverlay();
+
+    const approveBtn = await screen.findByTestId('plan-review-approve-apply');
+    const confirmBox = await screen.findByTestId(
+      'plan-review-confirm-destructive',
+    );
+    await waitFor(() => expect(approveBtn).toBeDisabled());
+    expect(confirmBox).not.toBeChecked();
+
+    fireEvent.click(confirmBox);
+    await waitFor(() =>
+      expect(mockPlansConfirmDestructive).toHaveBeenCalledWith('plan-1'),
+    );
+    await waitFor(() => expect(approveBtn).not.toBeDisabled());
+  });
+
+  it('keeps an archive-destination plan of archive items non-destructive and gate-free', async () => {
+    mockProtectionCheck.mockResolvedValue(
+      ok(protectionCheck({ hasProtectedItems: false, protectedItems: [] })),
+    );
+    mockPlansGet.mockResolvedValue(
+      ok(
+        plan({
+          destructiveDestination: 'archive',
+          items: [
+            item({ action: 'archive', to: '.astro-plan-archive/a.xisf' }),
+          ],
+        }),
+      ),
+    );
+    renderOverlay();
+
+    await screen.findByText('light_001.xisf');
+    const approveBtn = screen.getByTestId('plan-review-approve-apply');
+    await waitFor(() =>
+      expect(approveBtn).toHaveAttribute('data-variant', 'primary'),
+    );
+    expect(
+      screen.queryByTestId('plan-review-confirm-destructive'),
+    ).not.toBeInTheDocument();
+    await waitFor(() => expect(approveBtn).not.toBeDisabled());
+    const actionPill = within(
+      screen.getByTestId('plan-review-item-0'),
+    ).getByText('archive');
+    expect(actionPill).toHaveAttribute('data-variant', 'info');
   });
 
   it('offers Cancel apply during a running apply and calls plan.cancel (US3/FR-009, issue #743)', async () => {

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
@@ -70,8 +70,24 @@ export interface PlanReviewOverlayProps {
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function actionPillVariant(action: PlanItemDetail_Serialize['action']) {
-  return action === 'delete' ? ('danger' as const) : ('info' as const);
+/**
+ * Whether applying this item removes the user's file from where it lives now.
+ *
+ * Both `cleanup_generator` and `archive_generator` always store
+ * `action = "archive"` for a destructive-but-reversible item; the reroute to
+ * the OS bin is a plan-level choice honoured only at apply time
+ * (`plan_apply::paths::item_row_to_executor_item`). So a plan that WILL send
+ * files to the OS bin carries zero `delete` items, and action alone cannot
+ * decide destructiveness.
+ */
+function isDestructiveItem(
+  item: PlanItemDetail_Serialize,
+  plan: PlanDetail_Serialize | undefined,
+): boolean {
+  if (item.action === 'delete') return true;
+  return (
+    item.action === 'archive' && plan?.destructiveDestination === 'os_trash'
+  );
 }
 
 /**
@@ -194,12 +210,12 @@ export function PlanReviewOverlay({
     reset: resetApply,
   } = usePlanApplyProgress();
 
-  // Destructive-confirm gate (FR-003, D9, issue #741): `delete` items are
+  // Destructive-confirm gate (FR-003, D9, issue #741): destructive items are
   // permanently refused at apply time until `destructive_confirmed` is set.
   // Plan-level (not per-item — `PlanItemDetail` carries no such flag; the
   // gate mirrors the existing plan-wide protection gate above it).
-  const hasDestructiveItems = (plan?.items ?? []).some(
-    (item) => item.action === 'delete',
+  const hasDestructiveItems = (plan?.items ?? []).some((item) =>
+    isDestructiveItem(item, plan),
   );
   const [destructiveConfirmed, setDestructiveConfirmed] = useState(false);
   const [confirmingDestructive, setConfirmingDestructive] = useState(false);
@@ -426,7 +442,11 @@ export function PlanReviewOverlay({
         ? 'pv-plan-review__row--protected'
         : undefined,
     name: item.name,
-    action: <Pill variant={actionPillVariant(item.action)}>{item.action}</Pill>,
+    action: (
+      <Pill variant={isDestructiveItem(item, plan) ? 'danger' : 'info'}>
+        {item.action}
+      </Pill>
+    ),
     from: <span className="pv-mono">{item.from}</span>,
     to:
       item.action === 'delete' ? (

--- a/crates/app/core/src/plan_apply/lifecycle.rs
+++ b/crates/app/core/src/plan_apply/lifecycle.rs
@@ -753,8 +753,12 @@ pub async fn retry_plan_item(
 
 // ── confirm_plan_destructive_items ────────────────────────────────────────────
 
-/// Confirm every destructive (delete/trash) item in a plan, persisting
+/// Confirm every destructive item in a plan, persisting
 /// `plan_items.destructive_confirmed = 1` (FR-003, D9, issue #741).
+///
+/// "Destructive" covers a `delete` action and an `archive` action whose plan
+/// carries `destructive_destination = 'trash'`: the latter is rerouted to the
+/// OS trash at apply time, so the stored action alone understates it.
 ///
 /// This is the write half of the executor's destructive-confirm gate
 /// (`fs_executor::run::execute_plan`'s `destructive_unconfirmed` refusal,

--- a/crates/app/core/src/plan_apply/paths.rs
+++ b/crates/app/core/src/plan_apply/paths.rs
@@ -294,10 +294,16 @@ pub(super) fn item_row_to_executor_item(
 
     let is_protected = row.protection == "protected";
 
-    // T020: `requires_destructive_confirm` is derived from action type,
-    // independent of `is_protected`. Replaces the old `confirm_required = is_protected` inversion.
-    let requires_destructive_confirm = matches!(row.action.as_str(), "delete" | "trash")
-        || row.requires_destructive_confirm.unwrap_or(0) != 0;
+    // T020: `requires_destructive_confirm` is derived from the EFFECTIVE
+    // executor action, independent of `is_protected`. Reading `row.action`
+    // instead would miss an `action = "archive"` item that the plan-level
+    // `destructive_destination = "trash"` reroute above turned into a real
+    // OS-trash removal, letting it past the executor's confirm gate
+    // unconfirmed. `persistence_plans::repositories::plans::confirm_plan_destructive_items`
+    // is the write half and MUST stay at least as wide as this predicate.
+    let requires_destructive_confirm =
+        matches!(action, ExecutorItemAction::Delete | ExecutorItemAction::Trash { .. })
+            || row.requires_destructive_confirm.unwrap_or(0) != 0;
 
     // T023a: `destructive_confirmed` is now a real DB column (migration 0033).
     let destructive_confirmed = row.destructive_confirmed != 0;

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -1142,6 +1142,11 @@ async fn archive_action_item_with_trash_destination_really_trashes() {
     .await
     .unwrap();
 
+    // The trash reroute makes this item destructive, so it now has to clear the
+    // executor's confirm gate like any other trash item.
+    let confirmed = confirm_plan_destructive_items(db.pool(), "p-trash-e2e").await.unwrap();
+    assert_eq!(confirmed, 1, "the archive-on-trash item must be confirmable");
+
     repo::update_plan_state(db.pool(), "p-trash-e2e", "ready_for_review").await.unwrap();
     repo::set_approved(db.pool(), "p-trash-e2e", "2026-06-01T00:00:00Z", "test-token")
         .await
@@ -1238,6 +1243,224 @@ async fn archive_action_item_with_archive_destination_stays_archived() {
     assert_eq!(plan.state, "applied");
     let items = repo::list_plan_items(db.pool(), "p-archive-e2e").await.unwrap();
     assert_eq!(items[0].item_state, "succeeded");
+}
+
+/// Builds an `action = "archive"` row, the only shape a generator ever stores
+/// for a destructive-but-reversible item.
+fn archive_row(id: &str) -> plans_repo::PlanItemRow {
+    plans_repo::PlanItemRow {
+        id: id.to_owned(),
+        plan_id: "plan-confirm-derivation".to_owned(),
+        item_index: 1,
+        name: "intermediate.fits".to_owned(),
+        action: "archive".to_owned(),
+        from_root_id: None,
+        from_relative_path: "raw/intermediate.fits".to_owned(),
+        to_root_id: None,
+        to_relative_path: String::new(),
+        reason: "test".to_owned(),
+        protection: "normal".to_owned(),
+        linked_entity: None,
+        item_state: "pending".to_owned(),
+        failure_reason: None,
+        provenance: None,
+        approved_mtime: None,
+        approved_size_bytes: None,
+        archive_path: None,
+        created_at: "2026-08-23T00:00:00Z".to_owned(),
+        source_id: None,
+        category: None,
+        requires_destructive_confirm: None,
+        resolved_pattern: None,
+        destructive_confirmed: 0,
+    }
+}
+
+/// The confirm-gate half of the trash-reroute fix: `requires_destructive_confirm`
+/// must follow the EFFECTIVE executor action, so an `action = "archive"` item on
+/// a `destructive_destination = "trash"` plan is gated, while the same row on an
+/// `"archive"` plan is not (the archive arm is a real move, not a removal).
+#[test]
+fn archive_item_requires_confirm_only_under_a_trash_destination() {
+    let root_map: HashMap<String, Utf8PathBuf> = HashMap::new();
+
+    let trashed = item_row_to_executor_item(&archive_row("item-trash"), &root_map, "trash", None);
+    assert!(
+        matches!(trashed.action, ExecutorItemAction::Trash { .. }),
+        "sanity: a trash-destination plan reroutes the archive item to Trash"
+    );
+    assert!(
+        trashed.requires_destructive_confirm,
+        "an archive item rerouted to OS trash removes the file and must be gated on confirmation"
+    );
+
+    let archived =
+        item_row_to_executor_item(&archive_row("item-archive"), &root_map, "archive", None);
+    assert!(
+        matches!(archived.action, ExecutorItemAction::Archive { .. }),
+        "sanity: an archive-destination plan keeps the archive action"
+    );
+    assert!(
+        !archived.requires_destructive_confirm,
+        "archiving is a reversible move — gating it would demand confirmation for every archive \
+         plan"
+    );
+}
+
+/// The writer half, which must stay at least as wide as the refuser above: a
+/// user who confirms a trash plan has to actually clear the gate for its
+/// archive-action items, and confirming an archive plan must still flip nothing.
+#[tokio::test]
+async fn confirm_covers_archive_items_only_under_a_trash_destination() {
+    let (db, _bus) = setup().await;
+
+    for (plan_id, destination) in [("p-cw-trash", "trash"), ("p-cw-archive", "archive")] {
+        repo::insert_plan(
+            db.pool(),
+            &repo::InsertPlan {
+                id: plan_id,
+                title: "Test",
+                origin: "cleanup",
+                origin_path: None,
+                plan_type: "cleanup",
+                destructive_destination: destination,
+                parent_plan_id: None,
+                total_bytes_required: 0,
+            },
+        )
+        .await
+        .unwrap();
+        repo::insert_plan_item(
+            db.pool(),
+            &repo::InsertPlanItem {
+                id: &format!("{plan_id}-item-0"),
+                plan_id,
+                item_index: 1,
+                name: "intermediate.fits",
+                action: "archive",
+                from_root_id: None,
+                from_relative_path: &format!("{plan_id}/raw/intermediate.fits"),
+                to_root_id: None,
+                to_relative_path: &format!("{plan_id}/archive/intermediate.fits"),
+                reason: "test",
+                protection: "normal",
+                linked_entity: None,
+                provenance_json: None,
+                archive_path: None,
+                source_id: None,
+                category: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let trash_confirmed = confirm_plan_destructive_items(db.pool(), "p-cw-trash").await.unwrap();
+    assert_eq!(
+        trash_confirmed, 1,
+        "the confirm writer must cover every item the executor gates, or a confirmed trash plan \
+         refuses all of its items"
+    );
+    let trash_items = repo::list_plan_items(db.pool(), "p-cw-trash").await.unwrap();
+    assert_eq!(trash_items[0].destructive_confirmed, 1);
+
+    let archive_confirmed =
+        confirm_plan_destructive_items(db.pool(), "p-cw-archive").await.unwrap();
+    assert_eq!(
+        archive_confirmed, 0,
+        "an archive-destination plan has nothing destructive to confirm"
+    );
+    let archive_items = repo::list_plan_items(db.pool(), "p-cw-archive").await.unwrap();
+    assert_eq!(archive_items[0].destructive_confirmed, 0);
+
+    // Idempotent: the widened predicate must not re-count a confirmed item.
+    let again = confirm_plan_destructive_items(db.pool(), "p-cw-trash").await.unwrap();
+    assert_eq!(again, 0);
+}
+
+/// End-to-end sibling of `archive_action_item_with_trash_destination_really_trashes`:
+/// the same plan shape WITHOUT a confirm call must be refused before
+/// `trash::delete` is reached, so the file is still on disk afterwards. The fake
+/// trash guard turns a leaked removal into a deleted file rather than a real
+/// OS-Trash move, keeping the assertion observable in a headless run.
+#[tokio::test]
+async fn unconfirmed_archive_item_under_trash_destination_is_refused_before_trashing() {
+    let _fake_trash = fs_executor::ops::trash_op::fake::FakeTrashGuard::new();
+
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("intermediate.fits");
+    std::fs::write(&file_path, b"data").unwrap();
+    let abs = file_path.to_str().unwrap();
+
+    let (db, bus) = setup().await;
+    repo::insert_plan(
+        db.pool(),
+        &repo::InsertPlan {
+            id: "p-trash-unconfirmed",
+            title: "Test",
+            origin: "cleanup",
+            origin_path: None,
+            plan_type: "cleanup",
+            destructive_destination: "trash",
+            parent_plan_id: None,
+            total_bytes_required: 0,
+        },
+    )
+    .await
+    .unwrap();
+    repo::insert_plan_item(
+        db.pool(),
+        &repo::InsertPlanItem {
+            id: "p-trash-unconfirmed-item-0",
+            plan_id: "p-trash-unconfirmed",
+            item_index: 1,
+            name: "intermediate.fits",
+            action: "archive",
+            from_root_id: None,
+            from_relative_path: abs,
+            to_root_id: None,
+            to_relative_path: "",
+            reason: "test",
+            protection: "normal",
+            linked_entity: None,
+            provenance_json: None,
+            archive_path: None,
+            source_id: None,
+            category: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    repo::update_plan_state(db.pool(), "p-trash-unconfirmed", "ready_for_review").await.unwrap();
+    repo::set_approved(db.pool(), "p-trash-unconfirmed", "2026-06-01T00:00:00Z", "test-token")
+        .await
+        .unwrap();
+
+    apply_plan(db.pool(), &bus, "p-trash-unconfirmed", "test-token", None).await.unwrap();
+    tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+
+    assert!(
+        file_path.exists(),
+        "an unconfirmed archive-on-trash item must never reach trash::delete"
+    );
+
+    let failure_code: Option<String> = sqlx::query_scalar(
+        "SELECT failure_code FROM plan_apply_events \
+         WHERE plan_id = ? AND item_id = ? AND failure_code IS NOT NULL \
+         ORDER BY rowid DESC LIMIT 1",
+    )
+    .bind("p-trash-unconfirmed")
+    .bind("p-trash-unconfirmed-item-0")
+    .fetch_optional(db.pool())
+    .await
+    .unwrap()
+    .flatten();
+    assert_eq!(
+        failure_code.as_deref(),
+        Some(FailureCode::DestructiveUnconfirmed.as_str()),
+        "the refusal must be recorded as destructive_unconfirmed"
+    );
 }
 
 /// #766: one durable `audit_log_entry` row per succeeded plan_item

--- a/crates/persistence/plans/src/repositories/plans.rs
+++ b/crates/persistence/plans/src/repositories/plans.rs
@@ -334,9 +334,14 @@ pub async fn list_plan_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Vec<P
 }
 
 /// Set `destructive_confirmed = 1` on every item in `plan_id` that requires
-/// destructive confirmation (`action IN ('delete','trash')`, or the explicit
-/// `requires_destructive_confirm` override column — mirrors the derivation in
-/// `app_core::plan_apply::item_row_to_executor_item`).
+/// destructive confirmation: `action IN ('delete','trash')`, an
+/// `action = 'archive'` item whose plan carries
+/// `destructive_destination = 'trash'` (that reroute makes it a real OS-trash
+/// removal), or the explicit `requires_destructive_confirm` override column.
+/// Mirrors the derivation in
+/// `app_core::plan_apply::item_row_to_executor_item`, and MUST stay at least as
+/// wide as it: a narrower writer leaves items the executor refuses with
+/// `destructive_unconfirmed` even after the user confirmed the plan.
 ///
 /// This is the write half of the FR-003/D9 confirm gate: the executor
 /// (`fs_executor::run::execute_plan`) refuses any destructive item where
@@ -351,7 +356,11 @@ pub async fn confirm_plan_destructive_items(pool: &SqlitePool, plan_id: &str) ->
     let result = sqlx::query(
         "UPDATE plan_items SET destructive_confirmed = 1 \
          WHERE plan_id = ? AND destructive_confirmed = 0 \
-         AND (action IN ('delete', 'trash') OR requires_destructive_confirm = 1)",
+         AND (action IN ('delete', 'trash') OR requires_destructive_confirm = 1 \
+              OR (action = 'archive' AND EXISTS ( \
+                  SELECT 1 FROM plans p \
+                  WHERE p.id = plan_items.plan_id \
+                  AND p.destructive_destination = 'trash')))",
     )
     .bind(plan_id)
     .execute(pool)


### PR DESCRIPTION
## Summary

- A cleanup plan set to send files to the system Recycle Bin / Trash now shows up in review as destructive, and cannot be applied until you tick the confirmation box. Previously such a plan looked like a harmless move and applied without asking, even though it removed your files.

## What was wrong

A cleanup plan whose `destructive_destination` is `trash` sends the user's files to the OS bin. Every generator stores `action = "archive"` for such items (`crates/app/core/src/cleanup_generator/generate.rs:56` maps `CleanupAction::Archive` to `"archive"` regardless of destination), and the reroute to `ExecutorItemAction::Trash` happens only at apply time in `crates/app/core/src/plan_apply/paths.rs:217-219`.

Three independent derivations of "is this item destructive" each read the stored action alone and never the destination:

1. `apps/desktop/src/features/plans/PlanReviewOverlay.tsx:201-202` — `items.some(i => i.action === 'delete')`, driving both the red destructive styling and the confirm gate.
2. `crates/app/core/src/plan_apply/paths.rs:299` — `requires_destructive_confirm`, the input to the executor refusal at `crates/fs/executor/src/run/loop_.rs:398`.
3. `crates/persistence/plans/src/repositories/plans.rs:352-354` — the confirm *writer* `UPDATE`.

Net effect: a plan that deletes files rendered neutral, offered no confirm checkbox, and was never refused for being unconfirmed. Constitution II makes reviewable filesystem mutation the product's core promise, so the review surface told the user the opposite of what would happen.

## Fix shape chosen, and the one rejected

**Chosen: derive destructiveness from the effective destination at all three sites.**

**Rejected: store `action = "trash"` at generation time.** That is the more correct shape — it makes the stored record honest for every present and future consumer at once — but it is blocked by hard constraints rather than merely being invasive:

- `crates/persistence/core/migrations/0001_initial_schema.sql:1735-1738` — the `plan_items.action` CHECK admits `move, archive, delete, link, write, mkdir, write_manifest, catalogue` and not `trash`. The repo has a single consolidated 216 KB initial migration, so widening it means a SQLite table rebuild.
- `crates/contracts/core/src/plans.rs:123-129` — `PlanItemAction` has no `Trash` variant, so this also becomes a contract + regenerated-bindings change.
- `crates/app/core/src/plans/mod.rs:141-142` — `parse_item_action` would silently map an unknown `"trash"` to `Move`, i.e. a stored-but-unparsed action fails *open* into a plain move.
- `crates/app/inbox/src/confirm.rs:832` documents "`plan_items.action` CHECK never admits the literal `'trash'`" as a deliberate existing invariant.

The contained shape turned out cheaper than expected because no contract change is needed at all: `PlanDetail.destructiveDestination` is already on the DTO the overlay consumes (`apps/desktop/src/bindings/index.ts:7501`, already read by `destinationLabel` at `PlanReviewOverlay.tsx:114`).

## The styling and the confirm gate now agree

Both are driven by one predicate per layer, and the two layers were checked against each other:

- **Frontend** — one shared `isDestructiveItem(item, plan)` (`PlanReviewOverlay.tsx:83-91`): `action === 'delete'`, or `action === 'archive' && plan?.destructiveDestination === 'os_trash'`. Used by `hasDestructiveItems` (`:217`, which gates the checkbox at `:644` and the approve button at `:541`) and by the per-row action pill (`:446`). The old `actionPillVariant` helper was deleted rather than having `plan` threaded through it, so a second near-duplicate predicate cannot drift again. Note the TS enum value is `os_trash` (`bindings/index.ts:3623`) while the DB spelling is `trash`.
- **Backend refuser** — `paths.rs` now derives `requires_destructive_confirm` from the already-computed `ExecutorItemAction` rather than from `row.action`, so the reroute decision and the confirm requirement are the same decision and cannot disagree.
- **Backend writer** — `plans.rs` widens the confirm `UPDATE` to cover an `action='archive'` row whose plan has `destructive_destination='trash'`.

The load-bearing invariant, which the brief did not name and which a partial fix would have broken: **the writer must confirm at least every item the refuser requires confirmation for.** A widened refuser with an unwidened writer means a user who ticks the box gets every trash item refused with `DestructiveUnconfirmed`. This was verified term-by-term across the full action vocabulary and empirically — reverting only the writer reproduces exactly that failure.

## Verification

Independently re-run by a second agent that did not make the changes, rather than trusting the implementers' own greens. Every claimed result reproduced.

| Check | Result |
| --- | --- |
| `cargo test -p app_core -p persistence_plans` | exit 0 — 650 passed, 0 failed, 0 ignored, across 40 test binaries |
| `cargo clippy -p app_core -p persistence_plans --all-targets` | exit 0, no warnings |
| `cargo fmt -p app_core -p persistence_plans -- --check` | exit 0, no diff |
| `npx vitest run src/features/plans` | exit 0 — 44 passed |
| `npx tsc --noEmit` | exit 0 |
| `npx biome check` (2 changed .tsx files) | exit 0 |
| `npx eslint` (2 changed .tsx files) | exit 0 |
| `bash scripts/check-db-boundary.sh` | exit 0 — 0 production query sites across 427 files |

Gates that actually ran: cargo test/clippy/fmt, vitest 4.1.10, tsc 5.9.3, biome, eslint 10.7.0, the db-boundary script, and `pre-commit run typos`. A bare `pre-commit` exit 0 was not treated as evidence.

`pre-commit run typos --all-files` exits 1 with 5 hits, all on the pre-existing `appliable` in `crates/app/inbox/src/confirm.rs` (tracked as `astro-plan-8vxx1`), which is not a file this branch touches. No changed file introduces a new typo hit.

### Per-test revert results

Each new test was re-run with the fix reverted. Rust (all 5 filters matched exactly 1 test each, so none silently matched zero):

- `archive_item_requires_confirm_only_under_a_trash_destination` — with fix PASS, reverted **FAIL**
- `confirm_covers_archive_items_only_under_a_trash_destination` — with fix PASS, reverted **FAIL**
- `unconfirmed_archive_item_under_trash_destination_is_refused_before_trashing` — with fix PASS, reverted **FAIL**
- `confirm_plan_destructive_items_confirms_only_destructive_actions` — with fix PASS, reverted **FAIL**
- `archive_action_item_with_trash_destination_really_trashes` — pre-existing test, amended because the behaviour it asserts legitimately changed: the item it trashes must now be confirmed first.

Frontend:

- `renders a trash-destination plan as destructive though every item action is archive` — with fix PASS, reverted **FAIL**
- `blocks Approve & apply on a trash-destination archive plan until destructive-confirm succeeds` — with fix PASS, reverted **FAIL**
- `keeps an archive-destination plan of archive items non-destructive and gate-free` — with fix PASS, reverted **PASS**. **Disclosed as a control arm that cannot fail on revert by construction**: it asserts the pre-fix behaviour (neutral) is preserved. It is not vacuous — mutating the predicate to the over-broad `action === 'archive'` alone makes it **FAIL**, which is the over-widening regression it exists to catch.

## Deliberately not fixed

**None of the three related beads is resolved or worsened — do not close any of them on the strength of this PR.** All three live in the archive-management path (`crates/app/core/src/plans/archive.rs`), which never renders through `PlanReviewOverlay` and writes no plan items, so a destination-aware plan-item predicate cannot reach them:

- `astro-plan-8zz72` (Archive hint promises reversibility policy-Delete items lack) — **not touched.** It concerns the *Archive*-destination hint versus policy-`Delete` items, whose action is already `"delete"` at `cleanup_generator/generate.rs:53` and is unaffected.
- `astro-plan-vuubi` (Restore stays enabled after trash/delete, then fails with `source.missing`) — **not touched.**
- `astro-plan-mlcyq` (partially failed trash/delete reports success) — **not touched.**

Also left alone, filed as `astro-plan-5jfcc`: for a trash-destination plan the `to` column still renders the `.astro-plan-archive/...` path that apply never uses, and `plans_review_confirm_destructive_label` still says "deleted" for files recoverable from the bin. Both need `PlanItemDetail`/`PlanDetail` to carry the effective destination, which is a contract change outside this fix. The sibling branch at `PlanReviewOverlay.tsx:452` was deliberately **not** widened for this reason: it renders "Deleted, not moved", which would be a false statement for a trash item, since such an item *is* moved into the bin.

No migration, no contract or `bindings/index.ts` change, no i18n edit, no `specs/*/tasks.md` edit, and `scripts/check-db-boundary.sh` untouched.

## Journey amendments needed (not made here)

J06 documents the current buggy behaviour as expected, so this fix makes parts of it factually wrong. Not edited here, per instruction — routing to a journey amendment: `docs/journeys/J06-cleanup-scan-review-apply/journey.md` S3 (`:86-89`, `:95-97`), S3 Trace (`:110-111`), S4 (`:119-123`), SC6 (`:188-190`), SC7 (`:191-193`), and gap G6 (`:201-205`, this bead) which the fix dissolves; G9 (`:212-214`) survives as a coverage gap but its rationale changes. In `docs/journeys/J07-archive-delete/journey.md`, S3 (`:77-81`) and Δ4 (`:270-276`) reach the right conclusion for archive plans but state the old predicate as the mechanism.

Merge-Bead: astro-plan-hjfmc
Tracks-Bead: astro-plan-cricc
Closes-Bead: astro-plan-cricc
