### PR TITLE
fix!: one corrupt session no longer breaks calibration master and session lists (recreate your development database)

### DIFF
--- a/crates/persistence/calibration/src/repositories/equipment.rs
+++ b/crates/persistence/calibration/src/repositories/equipment.rs
@@ -255,7 +255,10 @@ pub async fn find_camera_by_alias(pool: &SqlitePool, alias: &str) -> DbResult<Op
         "SELECT id, name, aliases, auto_detected, sensor_type, passband, \
          pixel_size_um, sensor_width_px, sensor_height_px \
          FROM cameras \
-         WHERE EXISTS (SELECT 1 FROM json_each(cameras.aliases) j WHERE j.value = ?) \
+         WHERE EXISTS (SELECT 1 FROM json_each( \
+                           CASE WHEN json_valid(cameras.aliases) \
+                                THEN cameras.aliases ELSE '[]' END) j \
+                       WHERE j.value = ?) \
          LIMIT 1",
     )
     .bind(alias)
@@ -378,7 +381,9 @@ pub async fn find_telescope_by_alias(
 ) -> DbResult<Option<Telescope>> {
     let row: Option<(String, String, String, Option<i32>, i32)> = sqlx::query_as(
         "SELECT t.id, t.name, t.aliases, t.focal_length_mm, t.auto_detected \
-         FROM telescopes t, json_each(t.aliases) j \
+         FROM telescopes t, json_each( \
+                  CASE WHEN json_valid(t.aliases) \
+                       THEN t.aliases ELSE '[]' END) j \
          WHERE j.value = ? \
          LIMIT 1",
     )
@@ -755,6 +760,53 @@ mod tests {
         assert!(not_found.is_none());
     }
 
+    /// Writes a row whose JSON `aliases` column holds a non-JSON string, which
+    /// the schema permits: `aliases` is `TEXT NOT NULL DEFAULT '[]'` with no
+    /// `json_valid` CHECK. `cameras` and `telescopes` share the four columns
+    /// touched here.
+    ///
+    /// Called before the intact row so the corrupt one takes the lower rowid: a
+    /// full table scan then reaches it first and the by-alias probes' `LIMIT 1`
+    /// cannot skip past it.
+    async fn insert_malformed_aliases_row(pool: &SqlitePool, table: &str, id: &str) {
+        sqlx::query(sqlx::AssertSqlSafe(format!(
+            "INSERT INTO {table} (id, name, aliases, created_at) \
+             VALUES (?, 'corrupt', 'oops', '2026-01-01T00:00:00Z')"
+        )))
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn camera_find_by_alias_survives_a_malformed_aliases_row() {
+        let pool = setup_db().await;
+        insert_malformed_aliases_row(&pool, "cameras", "cam-corrupt").await;
+
+        create_camera(
+            &pool,
+            &CreateCamera {
+                name: "ASI2600MM".to_owned(),
+                aliases: vec!["ZWO 2600".to_owned()],
+                sensor_type: None,
+                passband: None,
+                pixel_size_um: None,
+                sensor_width_px: None,
+                sensor_height_px: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let found = find_camera_by_alias(&pool, "ZWO 2600")
+            .await
+            .expect("a malformed aliases row must not fail the whole query")
+            .expect("the intact camera is still matched");
+        assert_eq!(found.name, "ASI2600MM");
+        assert_eq!(found.aliases, vec!["ZWO 2600".to_owned()]);
+    }
+
     #[tokio::test]
     async fn camera_delete_nonexistent() {
         let pool = setup_db().await;
@@ -838,6 +890,31 @@ mod tests {
 
         let not_found = find_telescope_by_alias(&pool, "missing").await.unwrap();
         assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    async fn telescope_find_by_alias_survives_a_malformed_aliases_row() {
+        let pool = setup_db().await;
+        insert_malformed_aliases_row(&pool, "telescopes", "tel-corrupt").await;
+
+        create_telescope(
+            &pool,
+            &CreateTelescope {
+                name: "Esprit 100ED".to_owned(),
+                aliases: vec!["SW Esprit".to_owned()],
+                focal_length_mm: Some(550),
+            },
+        )
+        .await
+        .unwrap();
+
+        let found = find_telescope_by_alias(&pool, "SW Esprit")
+            .await
+            .expect("a malformed aliases row must not fail the whole query")
+            .expect("the intact telescope is still matched");
+        assert_eq!(found.name, "Esprit 100ED");
+        assert_eq!(found.aliases, vec!["SW Esprit".to_owned()]);
+        assert_eq!(found.focal_length_mm, Some(550));
     }
 
     // ── Optical Train tests ─────────────────────────────────────────────────

--- a/crates/persistence/core/migrations/0001_initial_schema.sql
+++ b/crates/persistence/core/migrations/0001_initial_schema.sql
@@ -3198,7 +3198,12 @@ SELECT
     cs.archived_via_plan_id                             AS archived_via_plan_id
 FROM calibration_session cs
 LEFT JOIN calibration_fingerprint cf ON cf.id = cs.id
-LEFT JOIN file_record fr ON fr.id = json_extract(cs.frame_ids, '$[0]')
+-- calibration_session.frame_ids carries no json_valid CHECK, and an unguarded
+-- json_extract raises on a malformed value, failing every SELECT against this
+-- view rather than the one corrupt row. The CASE substitutes an empty array so
+-- the row survives with a NULL frame_relative_path.
+LEFT JOIN file_record fr ON fr.id = json_extract(
+    CASE WHEN json_valid(cs.frame_ids) THEN cs.frame_ids ELSE '[]' END, '$[0]')
 WHERE cs.kind IN ('dark', 'flat', 'bias');
 
 CREATE VIEW ledger_view AS

--- a/crates/persistence/core/tests/calibration_master_view_json_guard.rs
+++ b/crates/persistence/core/tests/calibration_master_view_json_guard.rs
@@ -1,0 +1,98 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `calibration_master_view` degrades a malformed `calibration_session.frame_ids`
+//! to a NULL path instead of failing every read of the view.
+//!
+//! `frame_ids` is `TEXT NOT NULL DEFAULT '[]'` with no `json_valid` CHECK, so a
+//! non-JSON value is storable. An unguarded `json_extract` in the view's
+//! `LEFT JOIN file_record` raises "malformed JSON" and aborts the whole SELECT,
+//! taking down `calibration.masters.list` and `.get`.
+
+use sqlx::{Row, SqlitePool};
+
+use persistence_core::Database;
+
+/// The projection of `persistence_calibration::repositories::q_calibration`'s
+/// `list_calibration_masters`. Reproduced rather than called because
+/// `persistence_calibration` depends on this crate, not the reverse.
+///
+/// The column set is load-bearing: selecting `id` alone lets SQLite prune the
+/// guarded `LEFT JOIN file_record` away, and the test then passes against an
+/// unguarded view. `frame_relative_path` is the column that forces the join —
+/// and with it the `json_extract` — to evaluate.
+const MASTER_VIEW_COLUMNS: &str = "id, kind, created_at, size_bytes, \
+     fp_gain, fp_exposure_s, fp_temp_c, fp_filter_name, fp_binning, \
+     fp_optic_train, source_session_id, root_id, frame_relative_path, \
+     archived_at, archived_via_plan_id";
+
+async fn migrated() -> Database {
+    let db = Database::in_memory().await.expect("in-memory database");
+    db.migrate().await.expect("baseline applies cleanly");
+    db
+}
+
+/// Seeds the frame the intact master resolves to. The view's `LEFT JOIN` scans
+/// `calibration_session` either way, so this proves the intact row keeps its
+/// real path rather than merely surviving.
+async fn seed_frame(pool: &SqlitePool) {
+    sqlx::query(
+        "INSERT INTO library_root (id, label, current_path, kind, state, created_at)
+         VALUES ('root-1', 'Main', '/lib', 'local', 'active', '2026-06-01T00:00:00Z')",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO file_record
+            (id, root_id, relative_path, size_bytes, mtime, state, first_seen_at, last_seen_at)
+         VALUES ('file-1', 'root-1', 'darks/dark_001.fits', 2048, '2026-06-01T00:00:00Z',
+                 'observed', '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z')",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// `kind` must be one of `dark`/`flat`/`bias`; the view's `WHERE` clause drops
+/// anything else and the test would assert over an empty result.
+async fn seed_master(pool: &SqlitePool, id: &str, frame_ids: &str) {
+    sqlx::query(
+        "INSERT INTO calibration_session (id, session_key, frame_ids, kind, root_id, created_at)
+         VALUES (?, ?, ?, 'dark', 'root-1', '2026-06-01T00:00:00Z')",
+    )
+    .bind(id)
+    .bind(id)
+    .bind(frame_ids)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn master_view_reads_survive_a_malformed_frame_ids_row() {
+    let db = migrated().await;
+    let pool = db.pool();
+    seed_frame(pool).await;
+    seed_master(pool, "master-corrupt", "oops").await;
+    seed_master(pool, "master-ok", r#"["file-1"]"#).await;
+
+    let rows = sqlx::query(sqlx::AssertSqlSafe(format!(
+        "SELECT {MASTER_VIEW_COLUMNS} FROM calibration_master_view \
+         WHERE archived_at IS NULL ORDER BY id ASC"
+    )))
+    .fetch_all(pool)
+    .await
+    .expect("a malformed frame_ids row must not fail the whole view");
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0].get::<String, _>("id"), "master-corrupt");
+    assert_eq!(rows[0].get::<String, _>("kind"), "dark");
+    assert_eq!(rows[0].get::<Option<String>, _>("frame_relative_path"), None);
+    assert_eq!(rows[1].get::<String, _>("id"), "master-ok");
+    assert_eq!(rows[1].get::<String, _>("kind"), "dark");
+    assert_eq!(
+        rows[1].get::<Option<String>, _>("frame_relative_path"),
+        Some("darks/dark_001.fits".to_owned())
+    );
+}

--- a/crates/persistence/plans/src/repositories/projects/sources.rs
+++ b/crates/persistence/plans/src/repositories/projects/sources.rs
@@ -53,7 +53,9 @@ pub async fn find_blockable_missing_sources(pool: &SqlitePool) -> DbResult<Vec<(
          FROM project_sources ps
          JOIN projects p ON p.id = ps.project_id
          JOIN acquisition_session s ON s.id = ps.inventory_session_id
-         JOIN json_each(s.frame_ids) je
+         JOIN json_each(
+                  CASE WHEN json_valid(s.frame_ids)
+                       THEN s.frame_ids ELSE '[]' END) je
          JOIN file_record fr ON fr.id = je.value
          WHERE fr.state = 'missing'
            AND p.lifecycle IN ('setup_incomplete', 'ready', 'prepared', 'processing')

--- a/crates/persistence/plans/src/repositories/projects/sources.rs
+++ b/crates/persistence/plans/src/repositories/projects/sources.rs
@@ -44,6 +44,15 @@ pub async fn list_project_ids_for_session(
 /// The explicit lifecycle list mirrors the canonical `ProjectState -> Blocked`
 /// edges. In particular, `completed` remains terminal for automatic blocking.
 ///
+/// `json_each(s.frame_ids)` is deliberately NOT wrapped in the
+/// `CASE WHEN json_valid(...)` guard applied to every other `frame_ids` query.
+/// Raising on a malformed value is the contract here: the caller treats the
+/// failure as an incomplete health check and leaves a durable retry marker, so
+/// a corrupt session is retried rather than silently reported as having no
+/// missing sources. Guarding it makes the project unblockable and writes no
+/// marker; `crates/app/core/tests/project_source_missing_block.rs:216` sets
+/// `frame_ids` to `'{'` on purpose and asserts both halves of that contract.
+///
 /// # Errors
 ///
 /// Returns `persistence_core::DbError::Database` on query failure.
@@ -53,9 +62,7 @@ pub async fn find_blockable_missing_sources(pool: &SqlitePool) -> DbResult<Vec<(
          FROM project_sources ps
          JOIN projects p ON p.id = ps.project_id
          JOIN acquisition_session s ON s.id = ps.inventory_session_id
-         JOIN json_each(
-                  CASE WHEN json_valid(s.frame_ids)
-                       THEN s.frame_ids ELSE '[]' END) je
+         JOIN json_each(s.frame_ids) je
          JOIN file_record fr ON fr.id = je.value
          WHERE fr.state = 'missing'
            AND p.lifecycle IN ('setup_incomplete', 'ready', 'prepared', 'processing')

--- a/crates/persistence/plans/src/repositories/projects/tests.rs
+++ b/crates/persistence/plans/src/repositories/projects/tests.rs
@@ -215,8 +215,13 @@ async fn seed_acquisition_session(pool: &SqlitePool, id: &str, frame_ids: &str) 
     .unwrap();
 }
 
+/// The one `frame_ids` site that MUST keep raising on malformed JSON. The caller
+/// reads the failure as an incomplete health check and leaves a durable retry
+/// marker; guarding it reports the corrupt session as having no missing sources,
+/// which leaves the project unblockable and writes no marker. Pins the raise so
+/// a later guard sweep cannot remove the signal without failing here.
 #[tokio::test]
-async fn find_blockable_missing_sources_survives_a_malformed_frame_ids_session() {
+async fn find_blockable_missing_sources_raises_on_a_malformed_frame_ids_session() {
     let db = setup().await;
     seed_missing_frame(db.pool()).await;
     // `acquisition_session.frame_ids` is `TEXT NOT NULL DEFAULT '[]'` with no
@@ -244,10 +249,13 @@ async fn find_blockable_missing_sources_survives_a_malformed_frame_ids_session()
         .unwrap();
     }
 
-    let rows = find_blockable_missing_sources(db.pool())
+    let err = find_blockable_missing_sources(db.pool())
         .await
-        .expect("a malformed frame_ids row must not fail the whole query");
-    assert_eq!(rows, vec![("p1".to_owned(), "sess-ok".to_owned())]);
+        .expect_err("a malformed frame_ids row must fail the health check loudly");
+    assert!(
+        err.to_string().contains("malformed JSON"),
+        "expected a malformed-JSON raise, got: {err}"
+    );
 }
 
 // ── has_archived_raw_frames_for_project (F-Framing-6, Q25 warning) ────────

--- a/crates/persistence/plans/src/repositories/projects/tests.rs
+++ b/crates/persistence/plans/src/repositories/projects/tests.rs
@@ -178,6 +178,78 @@ async fn duplicate_source_link_rejected() {
     assert!(result.is_err());
 }
 
+// ── find_blockable_missing_sources (R-17/FR-052) ──────────────────────────
+
+/// Seeds a root plus one `file_record` in state `missing`. The query joins
+/// `json_each` and `file_record` with INNER joins, so an empty `file_record`
+/// lets SQLite return no rows without ever evaluating the JSON function.
+async fn seed_missing_frame(pool: &SqlitePool) {
+    sqlx::query(
+        "INSERT INTO library_root (id, label, current_path, kind, state, created_at)
+         VALUES ('root-1', 'Main', '/lib', 'local', 'active', '2026-06-01T00:00:00Z')",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO file_record
+            (id, root_id, relative_path, size_bytes, mtime, state, first_seen_at, last_seen_at)
+         VALUES ('file-1', 'root-1', 'lights/light_001.fits', 1024, '2026-06-01T00:00:00Z',
+                 'missing', '2026-06-01T00:00:00Z', '2026-06-01T00:00:00Z')",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn seed_acquisition_session(pool: &SqlitePool, id: &str, frame_ids: &str) {
+    sqlx::query(
+        "INSERT INTO acquisition_session (id, session_key, frame_ids, root_id, created_at)
+         VALUES (?, ?, ?, 'root-1', '2026-06-01T00:00:00Z')",
+    )
+    .bind(id)
+    .bind(id)
+    .bind(frame_ids)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn find_blockable_missing_sources_survives_a_malformed_frame_ids_session() {
+    let db = setup().await;
+    seed_missing_frame(db.pool()).await;
+    // `acquisition_session.frame_ids` is `TEXT NOT NULL DEFAULT '[]'` with no
+    // `json_valid` CHECK, so a non-JSON value is storable.
+    seed_acquisition_session(db.pool(), "sess-corrupt", "oops").await;
+    seed_acquisition_session(db.pool(), "sess-ok", r#"["file-1"]"#).await;
+    insert_project(db.pool(), &InsertProject { lifecycle: "ready", ..project_a("p1") })
+        .await
+        .unwrap();
+    for (row_id, session_id) in [("src-1", "sess-corrupt"), ("src-2", "sess-ok")] {
+        insert_project_source(
+            db.pool(),
+            &InsertProjectSource {
+                id: row_id,
+                project_id: "p1",
+                inventory_session_id: session_id,
+                name_snapshot: "NGC7000 Ha",
+                frames_snapshot: 1,
+                filter_snapshot: "Ha",
+                exposure_snapshot: "60s",
+                linked_at: "2026-06-01T00:00:00Z",
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    let rows = find_blockable_missing_sources(db.pool())
+        .await
+        .expect("a malformed frame_ids row must not fail the whole query");
+    assert_eq!(rows, vec![("p1".to_owned(), "sess-ok".to_owned())]);
+}
+
 // ── has_archived_raw_frames_for_project (F-Framing-6, Q25 warning) ────────
 
 async fn insert_applied_raw_frame_archive_item(pool: &SqlitePool, plan_id: &str, source_id: &str) {

--- a/crates/persistence/targets/src/repositories/inventory.rs
+++ b/crates/persistence/targets/src/repositories/inventory.rs
@@ -158,11 +158,16 @@ pub async fn list_sessions_for_root(
             'acquisition'                               AS session_kind,
             'light'                                     AS frame_type,
             (SELECT COUNT(*)
-               FROM json_each(acs.frame_ids) je
+               FROM json_each(
+                        CASE WHEN json_valid(acs.frame_ids)
+                             THEN acs.frame_ids ELSE '[]' END) je
                LEFT JOIN file_record fr ON fr.id = je.value
               WHERE fr.state IS NULL OR fr.state != 'missing')
                                                         AS frame_count,
-            json_extract(acs.frame_ids, '$[0]')         AS first_frame_id,
+            json_extract(
+                CASE WHEN json_valid(acs.frame_ids)
+                     THEN acs.frame_ids ELSE '[]' END, '$[0]')
+                                                        AS first_frame_id,
             acs.target_id                               AS target_id,
             NULL                                        AS target_name,
             acs.created_at                              AS created_at,
@@ -189,11 +194,16 @@ pub async fn list_sessions_for_root(
             'calibration'                               AS session_kind,
             cs.kind                                     AS frame_type,
             (SELECT COUNT(*)
-               FROM json_each(cs.frame_ids) je
+               FROM json_each(
+                        CASE WHEN json_valid(cs.frame_ids)
+                             THEN cs.frame_ids ELSE '[]' END) je
                LEFT JOIN file_record fr ON fr.id = je.value
               WHERE fr.state IS NULL OR fr.state != 'missing')
                                                         AS frame_count,
-            json_extract(cs.frame_ids, '$[0]')          AS first_frame_id,
+            json_extract(
+                CASE WHEN json_valid(cs.frame_ids)
+                     THEN cs.frame_ids ELSE '[]' END, '$[0]')
+                                                        AS first_frame_id,
             NULL                                        AS target_id,
             NULL                                        AS target_name,
             cs.created_at                               AS created_at,
@@ -346,7 +356,9 @@ pub async fn get_session_context_by_ids(
              af.filter_name                                      AS filter,
              af.observing_night_date                             AS acquisition_night,
              (SELECT COUNT(*)
-                FROM json_each(acs.frame_ids) je
+                FROM json_each(
+                         CASE WHEN json_valid(acs.frame_ids)
+                              THEN acs.frame_ids ELSE '[]' END) je
                 LEFT JOIN file_record fr ON fr.id = je.value
                WHERE fr.state IS NULL OR fr.state != 'missing')  AS frame_count
          FROM acquisition_session acs
@@ -418,7 +430,9 @@ pub async fn list_session_cameras(
                  UNION ALL
                  SELECT id, frame_ids FROM calibration_session WHERE id IN ({placeholders})
              ) s
-             JOIN json_each(s.frame_ids) je
+             JOIN json_each(
+                      CASE WHEN json_valid(s.frame_ids)
+                           THEN s.frame_ids ELSE '[]' END) je
              JOIN file_record fr ON fr.id = je.value AND fr.state != 'missing'
              LEFT JOIN inbox_items ii ON ii.root_id = fr.root_id
              LEFT JOIN inbox_file_metadata ifm
@@ -1169,5 +1183,219 @@ mod tests {
             rows.iter().any(|r| r.id == "cal-ob-0"),
             "real cal row must be present (old bug: pop() dropped it)"
         );
+    }
+
+    // ── malformed `frame_ids` tolerance ───────────────────────────────────────
+    //
+    // `frame_ids` is `TEXT NOT NULL DEFAULT '[]'` with no `json_valid` CHECK, so
+    // a corrupt value is storable. An unguarded SQLite JSON function over it
+    // raises "malformed JSON", which fails the whole SELECT rather than the one
+    // bad row. Each test below keeps `file_record` populated and asserts the
+    // intact row's projected values, so the query planner cannot prune the
+    // `json_each` join away and leave the assertion vacuous.
+
+    const MALFORMED: &str = "oops";
+
+    async fn insert_root(pool: &SqlitePool, root_id: &str) {
+        sqlx::query(
+            "INSERT INTO library_root (id, label, kind, current_path, state, created_at) \
+             VALUES (?, 'Lib', 'local', ?, 'active', '2026-01-01T00:00:00Z')",
+        )
+        .bind(root_id)
+        .bind(format!("/lib/{root_id}"))
+        .execute(pool)
+        .await
+        .expect("insert library_root");
+    }
+
+    async fn insert_file_record(pool: &SqlitePool, id: &str, root_id: &str, relative_path: &str) {
+        sqlx::query(
+            "INSERT INTO file_record \
+                (id, root_id, relative_path, size_bytes, mtime, state, first_seen_at, last_seen_at) \
+             VALUES (?, ?, ?, 100, 't0', 'classified', 't0', 't0')",
+        )
+        .bind(id)
+        .bind(root_id)
+        .bind(relative_path)
+        .execute(pool)
+        .await
+        .expect("insert file_record");
+    }
+
+    #[tokio::test]
+    async fn list_sessions_for_root_acquisition_tolerates_malformed_frame_ids() {
+        let db = setup_db().await;
+        insert_root(db.pool(), "root-amj").await;
+        insert_file_record(db.pool(), "amj-1", "root-amj", "amj-1.fits").await;
+
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, root_id, frame_ids, created_at) \
+             VALUES ('acq-amj-ok', 'k', 'root-amj', '[\"amj-1\"]', '2026-01-02T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, root_id, frame_ids, created_at) \
+             VALUES ('acq-amj-bad', 'k', 'root-amj', ?, '2026-01-01T00:00:00Z')",
+        )
+        .bind(MALFORMED)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let (rows, _) = list_sessions_for_root(db.pool(), "root-amj", &InventoryFilters::default())
+            .await
+            .expect("malformed frame_ids must not fail the acquisition projection");
+
+        assert_eq!(rows.len(), 2, "the corrupt row is projected, not dropped");
+
+        let ok = rows.iter().find(|r| r.id == "acq-amj-ok").expect("intact row missing");
+        assert_eq!(ok.frame_count, 1, "intact row still counts its live frame");
+        assert_eq!(ok.first_frame_id.as_deref(), Some("amj-1"));
+
+        let bad = rows.iter().find(|r| r.id == "acq-amj-bad").expect("corrupt row missing");
+        assert_eq!(bad.frame_count, 0, "corrupt frame_ids reads as an empty array");
+        assert!(bad.first_frame_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_sessions_for_root_calibration_tolerates_malformed_frame_ids() {
+        let db = setup_db().await;
+        insert_root(db.pool(), "root-cmj").await;
+        insert_file_record(db.pool(), "cmj-1", "root-cmj", "cmj-1.fits").await;
+
+        // No acquisition session under this root, so the acquisition branch of
+        // `list_sessions_for_root` never evaluates its own JSON expressions —
+        // a failure here can only come from the calibration branch.
+        sqlx::query(
+            "INSERT INTO calibration_session \
+                (id, session_key, root_id, frame_ids, kind, created_at) \
+             VALUES ('cal-cmj-ok', 'k', 'root-cmj', '[\"cmj-1\"]', 'dark', '2026-01-02T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO calibration_session \
+                (id, session_key, root_id, frame_ids, kind, created_at) \
+             VALUES ('cal-cmj-bad', 'k', 'root-cmj', ?, 'flat', '2026-01-01T00:00:00Z')",
+        )
+        .bind(MALFORMED)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let (rows, _) = list_sessions_for_root(db.pool(), "root-cmj", &InventoryFilters::default())
+            .await
+            .expect("malformed frame_ids must not fail the calibration projection");
+
+        assert_eq!(rows.len(), 2, "the corrupt row is projected, not dropped");
+
+        let ok = rows.iter().find(|r| r.id == "cal-cmj-ok").expect("intact row missing");
+        assert_eq!(ok.frame_count, 1, "intact row still counts its live frame");
+        assert_eq!(ok.first_frame_id.as_deref(), Some("cmj-1"));
+        assert_eq!(ok.frame_type, "dark");
+
+        let bad = rows.iter().find(|r| r.id == "cal-cmj-bad").expect("corrupt row missing");
+        assert_eq!(bad.frame_count, 0, "corrupt frame_ids reads as an empty array");
+        assert!(bad.first_frame_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn session_context_tolerates_malformed_frame_ids() {
+        let db = setup_db().await;
+        insert_root(db.pool(), "root-smj").await;
+        insert_file_record(db.pool(), "smj-1", "root-smj", "smj-1.fits").await;
+        insert_file_record(db.pool(), "smj-2", "root-smj", "smj-2.fits").await;
+
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, root_id, frame_ids, created_at) \
+             VALUES ('acq-smj-ok', 'k', 'root-smj', '[\"smj-1\",\"smj-2\"]', '2026-01-02T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, root_id, frame_ids, created_at) \
+             VALUES ('acq-smj-bad', 'k', 'root-smj', ?, '2026-01-01T00:00:00Z')",
+        )
+        .bind(MALFORMED)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let ids = vec!["acq-smj-ok".to_owned(), "acq-smj-bad".to_owned()];
+        let mut rows = get_session_context_by_ids(db.pool(), &ids)
+            .await
+            .expect("malformed frame_ids must not fail the context batch");
+        rows.sort_by(|a, b| a.id.cmp(&b.id));
+
+        assert_eq!(rows.len(), 2, "the corrupt row is returned, not dropped");
+        assert_eq!(rows[0].id, "acq-smj-bad");
+        assert_eq!(rows[0].frame_count, 0, "corrupt frame_ids reads as an empty array");
+        assert_eq!(rows[1].id, "acq-smj-ok");
+        assert_eq!(rows[1].frame_count, 2, "intact row still counts both live frames");
+    }
+
+    #[tokio::test]
+    async fn session_cameras_tolerate_malformed_frame_ids() {
+        let db = setup_db().await;
+        insert_root(db.pool(), "root-kmj").await;
+        insert_file_record(db.pool(), "kmj-1", "root-kmj", "M31/Ha/kmj-1.fits").await;
+        insert_file_record(db.pool(), "kmj-2", "root-kmj", "M31/Ha/kmj-2.fits").await;
+
+        sqlx::query(
+            "INSERT INTO inbox_items \
+                (id, root_id, relative_path, file_count, discovered_at, last_scanned_at, state) \
+             VALUES ('ii-kmj', 'root-kmj', 'M31/Ha', 2, \
+                     '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', 'resolved')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        for id in ["kmj-1", "kmj-2"] {
+            sqlx::query(
+                "INSERT INTO inbox_file_metadata \
+                    (id, inbox_item_id, relative_file_path, instrume) \
+                 VALUES (?, 'ii-kmj', ?, 'ASI2600MM Pro')",
+            )
+            .bind(format!("ifm-{id}"))
+            .bind(format!("M31/Ha/{id}.fits"))
+            .execute(db.pool())
+            .await
+            .unwrap();
+        }
+
+        // Intact rows go in the acquisition branch of the UNION and the corrupt
+        // row in the calibration branch, so both branches are evaluated.
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, root_id, frame_ids, created_at) \
+             VALUES ('acq-kmj-ok', 'k', 'root-kmj', '[\"kmj-1\",\"kmj-2\"]', '2026-01-02T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO calibration_session \
+                (id, session_key, root_id, frame_ids, kind, created_at) \
+             VALUES ('cal-kmj-bad', 'k', 'root-kmj', ?, 'dark', '2026-01-01T00:00:00Z')",
+        )
+        .bind(MALFORMED)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let ids = vec!["acq-kmj-ok".to_owned(), "cal-kmj-bad".to_owned()];
+        let rows = list_session_cameras(db.pool(), &ids)
+            .await
+            .expect("malformed frame_ids must not fail the camera rollup");
+
+        // `json_each` is INNER-joined here, so the corrupt session contributes
+        // no frames and therefore no camera row at all.
+        assert_eq!(rows.len(), 1, "only the intact session resolves a camera: {rows:?}");
+        assert_eq!(rows[0].session_id, "acq-kmj-ok");
+        assert_eq!(rows[0].camera, "ASI2600MM Pro");
+        assert_eq!(rows[0].frame_count, 2, "both live frames vote for the camera");
     }
 }

--- a/crates/persistence/targets/src/repositories/targets.rs
+++ b/crates/persistence/targets/src/repositories/targets.rs
@@ -43,7 +43,10 @@ pub struct TargetProjectRow {
 /// List acquisition sessions whose `canonical_target_id` matches `target_id`,
 /// ordered by `created_at DESC` (newest first).
 ///
-/// `json_array_length(frame_ids)` gives a zero-allocation frame count.
+/// `json_array_length` gives a zero-allocation frame count. `frame_ids` carries
+/// no `json_valid` CHECK and the function raises on a malformed value, failing
+/// the whole SELECT; the `CASE` substitutes an empty array so a corrupt session
+/// reports `frame_count` 0 instead of losing every other session's row.
 ///
 /// # Errors
 ///
@@ -56,7 +59,9 @@ pub async fn list_sessions_for_target(
         "SELECT id,
                 session_key,
                 created_at,
-                json_array_length(frame_ids) AS frame_count
+                json_array_length(
+                    CASE WHEN json_valid(frame_ids)
+                         THEN frame_ids ELSE '[]' END) AS frame_count
          FROM acquisition_session
          WHERE canonical_target_id = ?
          ORDER BY created_at DESC",
@@ -196,6 +201,36 @@ mod tests {
         assert_eq!(rows[0].id, "s-001", "newest first");
         assert_eq!(rows[1].id, "s-002");
         assert_eq!(rows[0].frame_count, 3, "frame_count from json_array_length");
+    }
+
+    /// `acquisition_session.frame_ids` is `TEXT NOT NULL DEFAULT '[]'` with no
+    /// `json_valid` CHECK, so a corrupt value is storable. An unguarded
+    /// `json_array_length` over it raises "malformed JSON" and fails the whole
+    /// SELECT rather than the one bad row.
+    #[tokio::test]
+    async fn sessions_for_target_tolerate_malformed_frame_ids() {
+        let db = setup_db().await;
+        insert_target(db.pool(), "t-mj").await;
+
+        insert_linked_session(db.pool(), "s-mj-ok", "t-mj", "2026-01-02T00:00:00Z").await;
+        sqlx::query(
+            "INSERT INTO acquisition_session \
+                (id, session_key, frame_ids, created_at, canonical_target_id) \
+             VALUES ('s-mj-bad', 'k', 'oops', '2026-01-01T00:00:00Z', 't-mj')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let rows = list_sessions_for_target(db.pool(), "t-mj")
+            .await
+            .expect("malformed frame_ids must not fail the target session history");
+
+        assert_eq!(rows.len(), 2, "the corrupt row is listed, not dropped");
+        assert_eq!(rows[0].id, "s-mj-ok", "newest first");
+        assert_eq!(rows[0].frame_count, 3, "intact row keeps its real count");
+        assert_eq!(rows[1].id, "s-mj-bad");
+        assert_eq!(rows[1].frame_count, 0, "corrupt frame_ids reads as an empty array");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

A single session row holding a corrupt frame list used to break entire lists rather than just itself. Opening the calibration masters list, the session inventory for a library root, or a target's session list would fail outright and show nothing. Those lists now load, and the corrupt row is either skipped or shown with a zero frame count while every intact row appears normally.

The same problem affected camera and telescope alias lookups, where one equipment row with a corrupt alias list broke matching for all equipment.

## What's new

- Calibration master lists (all, single, and archived) load even when one calibration session has a corrupt frame list.
- Session inventory for a library root loads, showing a corrupt session with a frame count of 0.
- A target's session list loads, showing a corrupt session with a frame count of 0.
- Camera and telescope lookup by alias works when another equipment row has a corrupt alias list.
- Project source-missing health checks still fail loudly on a corrupt session, and that is deliberate: the failure is the signal that a project's sources could not be verified, and the caller records a durable retry marker. This is the one site left unguarded on purpose (see below).

## Breaking changes

**Your existing development database will FAIL TO OPEN. Delete it and let the app recreate it.**

`calibration_master_view` is defined in `crates/persistence/core/migrations/0001_initial_schema.sql`, the single editable baseline at version 1. Editing it changes the file's checksum, and `crates/persistence/core/src/lib.rs:401-413` shows sqlx treats a changed v1 checksum as a divergent migration history: `migrate()` returns an error rather than proceeding. So an existing development database does not merely keep the old unguarded view — it fails migration at startup and the app will not open it at all.

There is no released version and no user data migration involved; the fix is only reachable on a database created fresh. This matches how #1729 handled the same consequence, including the recreate instruction in the title.

## Behaviour detail

`frame_ids` and `aliases` are `TEXT NOT NULL DEFAULT '[]'` with no `json_valid` CHECK, so a malformed value is storable. An unguarded `json_each`, `json_extract` or `json_array_length` over such a column raises `malformed JSON` and fails the whole query.

The fix wraps the column argument at 10 of the 11 remaining expressions across 9 query sites:

    CASE WHEN json_valid(<col>) THEN <col> ELSE '[]' END

The guard is an argument to the JSON function rather than a `WHERE json_valid(...) AND ...` term, because SQLite does not guarantee AND-term evaluation order and the bare predicate form can still raise.

No query errors any more, and no intact row is lost. The outcome for the corrupt row depends on join shape — measured in sqlite3 3.51.0 and asserted per site:

| Shape | Site | Corrupt row becomes |
|---|---|---|
| `json_each` under INNER JOIN | `inventory.rs::list_session_cameras` | skipped entirely, absent from results |
| `json_each` under INNER JOIN, **deliberately unguarded** | `sources.rs::find_blockable_missing_sources` | **still raises** — see the exception section below |
| `json_each` in a `COUNT(*)` subquery with LEFT JOIN | `inventory.rs::list_sessions_for_root` (both branches), `get_session_context_by_ids` | row survives, `frame_count` 0 |
| `json_each` in `EXISTS` / cross join | `equipment.rs::find_camera_by_alias`, `find_telescope_by_alias` | row never matches an alias |
| `json_extract` | `inventory.rs` `first_frame_id`, `calibration_master_view` | row survives, column NULL |
| `json_array_length` | `targets.rs::list_sessions_for_target` | row survives, `frame_count` 0 |

So at the 10 guarded expressions: not an error and not an empty result set — either a skipped row, or a surviving row with a zeroed or NULL derived column. The eleventh expression, `sources.rs:65`, is left unguarded on purpose and still raises.

## Site census, independently re-run

9 sites / 11 expressions, matching the prior census. No tenth site. The round-1 reviewer independently reproduced this with a different, column-driven method and reached the same answer. Search actually run, tree-wide, no extension filter:

    rg -i -n --no-heading -g '!.git' -e json_each -e json_extract -e json_array_length \
      -e json_type -e json_tree -e json_valid -e json_quote -e json_insert -e 'json_set\b' \
      -e json_remove -e json_patch -e json_replace -e json_object -e json_array \
      -e json_group_array -e json_group_object -e json_error_position -e jsonb_ .

48 matching lines across 15 files. Re-running with `-uu` added only third-party skill docs, so nothing is hidden by `.gitignore`. `->` and `->>` return 0 hits in `.sql`. Twelve of the eighteen function names appear nowhere.

Post-fix verification: the guarded-expression count per file is 6 / 1 / 2 / 0 / 1 = 10, plus one deliberate unguarded exception at `sources.rs:65` documented at `sources.rs:47-54`.

The `calibration_master_view` site is the one previously recorded as not fixable in place. It was blocked by an exact-text plus checksum assertion in `crates/persistence/core/tests/baseline_invariants.rs`; that assertion no longer exists, so the in-place edit is correct and the previously planned `0004_*.sql` is not needed.

Two corrections to the recorded census, both material to test design:

1. `inventory.rs:161` and `:197` are not inner joins. Both are correlated `(SELECT COUNT(*) FROM json_each(col) je LEFT JOIN file_record fr ...)` subqueries, so `json_each` is the outer table under a LEFT JOIN and the empty-`file_record` trap does not apply. `:359` is the same shape. The genuine inner-join sites are `inventory.rs:433` and `sources.rs:65`. Line numbers are as of this branch head.
2. `inventory.rs:433` takes `frame_ids` from an inline `UNION ALL` derived table, not a table alias.

## The one site deliberately left unguarded

`crates/persistence/plans/src/repositories/projects/sources.rs:65`, `find_blockable_missing_sources`, keeps raising. Its job is to notice missing project sources, and raising is the contract: the caller reads the failure as an incomplete health check and leaves a durable retry marker, so a corrupt session is retried rather than silently reported as clean. `crates/app/core/tests/project_source_missing_block.rs:216` sets `frame_ids` to `'{'` on purpose, then asserts at `:231` that the project stays `ready` and at `:239` that the marker is written.

Guarding it broke that safety property, which round-1 review caught. Both candidate fixes were measured rather than argued:

| Option | Result |
|---|---|
| Guard the site | `project_source_missing_block.rs:239` fails, marker `0 != 1`. The project becomes unblockable and no marker is written. |
| Guard plus a `NOT json_valid` blockable arm | `:231` fails, `blocked != ready`. The corrupt session then blocks the project. |

The second is the more attractive design and it still breaks the safety test. That test is the property, not an obstacle to accommodate, so the site reverts to unguarded, with the contract documented at `sources.rs:47-54` and pinned by a test that asserts the raise. Adding the guard back makes that test fail at exit 101, so it is non-vacuous in the inverse direction.

## Tests: 9 added, each confirmed red with only its own guard reverted

This defect class has produced vacuous tests here four times: an empty joined table lets the planner skip `json_each`, and selecting a single column lets it prune the join away. Either passes with or without the guard. Every test therefore populates the joined table and asserts intact-row values, not `is_ok()` alone.

| Test | Result with its guard reverted |
|---|---|
| `list_sessions_for_root_acquisition_tolerates_malformed_frame_ids` | red, `malformed JSON` |
| `list_sessions_for_root_calibration_tolerates_malformed_frame_ids` | red, `malformed JSON` |
| `session_context_tolerates_malformed_frame_ids` | red, `malformed JSON` |
| `session_cameras_tolerate_malformed_frame_ids` | red, `malformed JSON` |
| `sessions_for_target_tolerate_malformed_frame_ids` | red, `malformed JSON` |
| `camera_find_by_alias_survives_a_malformed_aliases_row` | red, `malformed JSON` |
| `telescope_find_by_alias_survives_a_malformed_aliases_row` | red, `malformed JSON` |
| `find_blockable_missing_sources_raises_on_a_malformed_frame_ids_session` | red at exit 101 when the guard is ADDED (inverse direction: it pins the raise) |
| `master_view_reads_survive_a_malformed_frame_ids_row` | red, `malformed JSON` |

Each guard was reverted one at a time, so the two `list_sessions_for_root` tests are confirmed to fail for their own branch rather than each other's. Two of the nine were re-verified independently rather than only self-reported: `master_view_reads_survive_a_malformed_frame_ids_row` (the view site, strongest pruning trap) and `session_cameras_tolerate_malformed_frame_ids` (a real inner-join site).

The view test selects `frame_relative_path`, the column fed by the guarded `LEFT JOIN`, because selecting `id` alone prunes the join and passes against unguarded code.

## Gates run locally

Round 2, `CARGO_TARGET_DIR=/Users/sjors/tmp/cargo-target/p3vor-r2`, scoped to 5 crates (never the workspace):

| Gate | Result |
|---|---|
| `cargo fmt --all -- --check` | exit 0 |
| `cargo clippy` on 5 crates, `--all-targets -- -D warnings` | exit 0 |
| `cargo test` on `persistence_targets`, `persistence_calibration`, `persistence_plans`, `persistence_core`, `app_core` | exit 0, **817 passed, 0 failed** |
| `crates/app/core/tests/project_source_missing_block.rs` | all 5 tests pass, including `failed_health_check_retries_after_committed_reconcile`, which failed at exit 101 before this round |
| `scripts/check-db-boundary.sh` | exit 0, 0 production query sites outside `crates/persistence/`, 427 files scanned |
| `cargo test -p persistence_core --test baseline_invariants` | exit 0, the 309-object `sqlite_master` count is unchanged by the view edit |
| `pre-commit run --files <changed files>` | exit 0. Hooks that actually ran: added-large-files, detect-private-key, end-of-files, trailing-whitespace, hardcoded-secrets, typos. Skipped as no-files: check-json, check-toml, check-yaml, rustfmt-include |

`origin/main` had advanced by one commit to `3326320ba`; merged with the `ort` strategy, exit 0, **no conflicted files**.

## Not resolved here

- `astro-plan-l2s06`, filed by this change at P1: the guard trades a loud failure for silent degradation. A corrupt session now contributes zero frames, so its frames read as unattributed, which is indistinguishable from genuinely unattributed frames and can feed a cleanup plan. Frame-to-session attribution is a Tier-1 record under constitution principle V. Nothing yet logs, audits, or integrity-scans a malformed value. Deliberately out of scope: it needs a product decision between an integrity report, an audit event, and a `json_valid` CHECK constraint.
- `astro-plan-c6xjn`, stale migration paths: read for context only, not touched.
- `astro-plan-8vxx1`: the pre-existing `typos` failure on `appliable` in `crates/app/inbox/src/confirm.rs` is untouched and outside this diff.

## Spec Context

The bead's `scope` metadata named `crates/persistence/targets` and `crates/persistence/calibration`. The census sites also reach `crates/persistence/plans` (`sources.rs`) and `crates/persistence/core` (the baseline view), both named explicitly in the bead body, so this change claims those two as well.

That extension was unbriefed, and it is the `persistence/plans` site that produced the deleted-safety-signal defect found in round-1 review. Widening scope on the strength of the bead body was still the right call — the alternative was leaving a reachable crash unguarded and unreported — but the outcome shows an unbriefed widening carries risk in proportion to how little the widening was reviewed, and the site it added is exactly the one that needed a judgement the census could not supply. `crates/persistence/plans` remains in the claimed scope because this change now modifies that file deliberately, to document and test the exception.

Merge-Bead: astro-plan-1hket
Tracks-Bead: astro-plan-p3vor
Closes-Bead: astro-plan-p3vor


