### PR TITLE
fix: a corrupt FITS file is no longer detected as a calibration master

### DIFF
--- a/crates/app/inbox/src/scan.rs
+++ b/crates/app/inbox/src/scan.rs
@@ -215,10 +215,10 @@ fn is_xisf_extension(ext: &str) -> bool {
 /// Returns `None` when not a master or metadata is unreadable.
 fn try_detect_master(abs_path: &Path, rel_path: &str, ext: &str) -> Option<ScannedMasterFile> {
     // Cached extract (F0): memoized by (path, mtime, size). Unsupported
-    // extensions surface as `Err` here. A corrupt FITS header does not: the
-    // parser is lenient and reports no keywords, so such a file reaches
-    // `detect_master` below with every header field `None` and is classified
-    // from its path alone (astro-plan-z7997).
+    // extensions and headers in which no keyword is readable surface as `Err`
+    // here, so such a file is declined outright rather than path-inferred. A
+    // readable header that merely lacks `IMAGETYP` still reaches
+    // `detect_master` below and may be classified from its path.
     let bundle = cached_extract(abs_path).ok()?;
 
     let image_typ_raw = bundle.image_typ.as_deref();
@@ -893,6 +893,40 @@ mod tests {
         let items = scan_root(tmp.path(), &ScanOptions::default()).unwrap().items;
         assert_eq!(items.len(), 1);
         assert!(items[0].masters.is_empty(), "dummy file cannot be a master");
+    }
+
+    /// A master-shaped file name never outranks an unreadable header: the
+    /// extractor rejects a header with no recognisable keyword, so no
+    /// path-only inference runs (astro-plan-z7997).
+    #[test]
+    fn corrupt_master_named_fits_is_not_detected_as_a_master() {
+        let tmp = tmpdir();
+        let folder = tmp.path().join("calibration");
+        fs::create_dir_all(&folder).unwrap();
+        write_file(&folder, "masterDark.fits", &[0xffu8; 2880]);
+
+        let items = scan_root(tmp.path(), &ScanOptions::default()).unwrap().items;
+        assert_eq!(items.len(), 1);
+        assert!(
+            items[0].masters.is_empty(),
+            "a corrupt header carries no evidence for master detection"
+        );
+    }
+
+    /// The neighbouring case the z7997 rejection must not swallow: a valid
+    /// header without `IMAGETYP` still reaches path inference.
+    #[test]
+    fn keywordless_imagetyp_master_still_infers_frame_type_from_path() {
+        let tmp = tmpdir();
+        let folder = tmp.path().join("calibration");
+        fs::create_dir_all(&folder).unwrap();
+        write_realistic_fits(&folder, "masterDark.fits", None, None);
+
+        let items = scan_root(tmp.path(), &ScanOptions::default()).unwrap().items;
+        assert_eq!(items.len(), 1);
+        let master = items[0].masters.first().expect("path inference must still detect a master");
+        assert_eq!(master.detection.frame_type, FrameType::Dark);
+        assert!(!master.detection.stack_count_evidence, "no header integration count present");
     }
 
     /// Constitution §I regression: a symlinked subdirectory reachable from the

--- a/crates/metadata/fits/src/lib.rs
+++ b/crates/metadata/fits/src/lib.rs
@@ -14,10 +14,11 @@
 //! `GAIN`, `XBINNING`, `YBINNING`, `NAXIS1`, `NAXIS2`, `INSTRUME`, `TELESCOP`,
 //! `DATE-OBS`.
 //!
-//! No cfitsio or heavy C dependencies — `fits-header` is pure Rust. A missing
-//! keyword yields `None` rather than an error. A header the parser cannot
-//! handle at all — including one that panics inside `fits-header` — yields
-//! [`MetadataExtractError::Parse`]; [`FitsExtractor::extract`] never panics.
+//! No cfitsio or heavy C dependencies — `fits-header` is pure Rust. A header
+//! missing individual keywords still yields `Ok`, with `None` for each absent
+//! field. A header in which the parser recognises no keyword at all yields
+//! [`MetadataExtractError::Parse`], as does one that panics inside
+//! `fits-header`; [`FitsExtractor::extract`] never panics.
 //!
 //! This adapter does not validate that the header block is ASCII. `fits-header`
 //! slices each field from the raw 80 bytes of its card and lossy-decodes the
@@ -94,6 +95,16 @@ impl MetadataExtractor for FitsExtractor {
             msg: e.to_string(),
         })?;
 
+        // A header whose every card is opaque to the parser carries no evidence
+        // at all. Returning it as `Ok` would let callers fall back to path-based
+        // inference and report a filename guess as header-backed fact.
+        if header.iter().all(|r| r.keyword().is_none()) {
+            return Err(MetadataExtractError::Parse {
+                path: path.display().to_string(),
+                msg: "the FITS header carries no readable keyword".to_owned(),
+            });
+        }
+
         Ok(Some(parse_header(&header)))
     }
 
@@ -139,8 +150,8 @@ fn read_header_bytes(mut reader: impl Read) -> io::Result<Vec<u8>> {
 
 /// Typed keyword read that never hard-errors: a duplicated keyword
 /// (`FitsError::AmbiguousKeyword`) falls back to its first occurrence instead
-/// of surfacing an error, preserving this extractor's "always `None`, never
-/// `Err`" contract for corrupt/odd files.
+/// of surfacing an error. Per-field reads are always `None`, never `Err`;
+/// rejecting a wholly unreadable header is [`FitsExtractor::extract`]'s job.
 fn get<T: FromCard>(header: &Header, key: &str) -> Option<T> {
     match header.get::<T>(key) {
         Ok(v) => v,
@@ -385,21 +396,39 @@ mod tests {
         assert!(parsed.is_ok(), "expected a lenient parse, got {parsed:?}");
     }
 
-    /// A block of non-ASCII bytes yields no recognised keywords rather than an
-    /// error: `fits-header` parsing is lenient by design.
+    /// `fits-header` parses a block of non-ASCII bytes leniently into opaque
+    /// cards; the adapter rejects it because no keyword is recognised.
     #[test]
-    fn malformed_header_bytes_yield_no_keywords() {
+    fn malformed_header_bytes_are_a_parse_error() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("corrupt.fits");
         std::fs::write(&path, [0xffu8; BLOCK_SIZE]).expect("write fixture");
 
+        let err = FitsExtractor
+            .extract(&path)
+            .expect_err("a header with no readable keyword must be an error");
+        assert!(matches!(err, MetadataExtractError::Parse { .. }), "got {err:?}");
+    }
+
+    /// A readable header that simply lacks `IMAGETYP` stays `Ok`: the
+    /// keywordless-header rejection must not swallow a valid header whose
+    /// individual keywords are absent.
+    #[test]
+    fn header_without_imagetyp_is_extracted() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("no_imagetyp.fits");
+        let block = build_fits_header(&[
+            "SIMPLE  =                    T",
+            "BITPIX  =                   16",
+            "NAXIS   =                    0",
+        ]);
+        std::fs::write(&path, &block).expect("write fixture");
+
         let meta = FitsExtractor
             .extract(&path)
-            .expect("a malformed header must not be an error")
+            .expect("a readable header must not be an error")
             .expect("a .fits extension must be supported");
         assert!(meta.image_typ.is_none());
-        assert!(meta.object.is_none());
-        assert!(meta.date_obs.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- A corrupt or unreadable FITS file could be detected as a calibration master purely from its filename, with no header evidence behind it. It is now declined and surfaced as unclassified instead.
- A valid FITS file that simply has no `IMAGETYP` keyword is unaffected: its frame type is still inferred from its path, exactly as before.

## The defect

`fits-header` 0.4.3 (#1733) is lenient where 0.4.2 errored. It parses arbitrary bytes into 36 `RecordKind::Opaque` records whose `keyword()` is `None`, so every keyword lookup returns `Ok(None)` and `FitsExtractor::extract` returned `Ok(Some(all-None RawFileMetadata))` where it previously returned `Parse`.

`crates/app/inbox/src/scan.rs:222` discards that `Err`, so a corrupt file reached `PixInsightDetector::detect` with `imagetyp: None` and fell into the path-only else-branch (`crates/calibration/master-detect/src/pixinsight.rs:75-83`) that infers `frame_type` from the filename. A corrupt file named `masterDark.fits` was reported as a calibration master backed by no header evidence at all.

This was ruled non-blocking for #1733 and that ruling is not overturned here: the mechanism pre-existed, `stack_count_evidence: false` marks the result as inference, and classification evidence is Tier 2. It is still worth fixing, because calibration attribution becomes Tier 1 the moment the user confirms it.

## The fix

`crates/metadata/fits/src/lib.rs:101` — `extract` rejects a header in which the parser recognised no keyword, returning `MetadataExtractError::Parse`.

The discrimination lives in the FITS adapter because card structure is its knowledge alone; neither the inbox scan nor the detector knows what a card is. It restores the contract #1719 established and every caller already handles, so all five extractor paths through `crates/app/targets/src/metadata_cache.rs` are fixed without touching them, and it restores parity with the XISF adapter, which still returns `Parse` for a structurally broken header (`crates/metadata/xisf/src/lib.rs:82`).

The predicate is exactly "no record carries a resolvable keyword". It does **not** conflate a corrupt header with a valid one that merely lacks `IMAGETYP` — the latter still carries `SIMPLE`/`BITPIX`/`NAXIS` and keeps reaching path inference. Two rejected alternatives, both of which do conflate them:

- "every `RawFileMetadata` field is `None`" — installing this predicate makes both neighbouring-case tests fail (measured).
- "the bytes begin with a `SIMPLE` card" — the FITS standard mandates that card, but the test corpus largely omits it, so the predicate is unenforceable here. Measured: `rg -o 'IMAGETYP= ' -g '*.rs' | wc -l` = 33 `IMAGETYP` card literals against `rg -o 'SIMPLE  =' -g '*.rs' | wc -l` = 10 `SIMPLE` card literals, and `rg -l 'SIMPLE  =' -g '*.rs'` lists only 7 Rust files writing a `SIMPLE` card while `rg -l IMAGETYP -g '*.rs'` matches 32. Filed as astro-plan-is352.

The 0.4.3 bump stands and the `catch_unwind` guard is retained: it was deliberately kept for parity with the XISF adapter and no surviving comment cites 0.4.2 as its reason.

## What the user sees

An unreadable header yields `EvidenceSource::None`, which lands the file in `unclassified_files` — already documented at `crates/contracts/core/src/inbox.rs:132` as covering an `IMAGETYP` that was "absent, unreadable, or unmapped", and already rendered. The file does not vanish; it appears as needing attention rather than as a false calibration master. No new contract field.

## `scan.rs` still discards the `Err`

Deliberate. With this change `.ok()?` yields the correct outcome — the file is declined rather than path-inferred — and distinguishing it there would mean changing `process_leaf`'s return type across the `thread::scope` workers to reach a `ScanWarning` sink that no UI component consumes. Filed as astro-plan-7rsk0. The doc comment at `scan.rs:216-221`, which documented the old behaviour and is now false, is corrected.

## Tests

| Test | Direction | With fix reverted |
|---|---|---|
| `malformed_header_bytes_are_a_parse_error` (metadata_fits) | corrupt rejected | FAILS |
| `corrupt_master_named_fits_is_not_detected_as_a_master` (app_core_inbox) | corrupt not a master | FAILS |
| `header_without_imagetyp_is_extracted` (metadata_fits) | valid keywordless still `Ok` | passes |
| `keywordless_imagetyp_master_still_infers_frame_type_from_path` (app_core_inbox) | valid keywordless still path-inferred | passes |

The two neighbouring-case tests pass with the fix reverted by design — they guard against over-reach, not against this bug. They are not vacuous: under the wrong `image_typ.is_none()` predicate **both fail** while both corrupt-case tests pass, so the pair discriminates the correct predicate from the tempting wrong one.

`parser_itself_does_not_panic_on_a_non_ascii_block` is untouched; it pins the panic regression against the parser directly, independent of the adapter's `catch_unwind`.

## Known residual gap

This closes the reproduced defect, not the whole class. A card with a blank keyword parses as `Commentary` carrying `Some("")` rather than `None` (`parse.rs:97-113`), so a header consisting entirely of blank-keyword junk still escapes this predicate and reaches path inference — the same shape from a different byte pattern. Confirmed reachable by the reviewer. The byte patterns exercised here (`[0xff; 2880]`, all-zero blocks) do become `Opaque` and are caught. Hardening is roughly one token, treating an empty keyword as absent, and is filed as astro-plan-69jw4.

## Verification

All run from inside the worktree with `CARGO_TARGET_DIR` scoped; the workspace was never built.

- `cargo test -p metadata_fits -p app_core_inbox -p calibration_master_detect` — exit 0, 325 passed, 1 ignored
- `cargo clippy -p metadata_fits -p app_core_inbox -p calibration_master_detect --all-targets -- -D warnings` — exit 0
- `cargo fmt -p metadata_fits -p app_core_inbox -p calibration_master_detect -- --check` — exit 0
- `bash scripts/check-db-boundary.sh` — exit 0, sealed at zero
- `pre-commit run --files <the two changed files>` — exit 0. Hooks that actually ran and passed: check-added-large-files, detect-private-key, end-of-file-fixer, trailing-whitespace, gitleaks, typos. Skipped for lack of matching file types: check-json, check-toml, check-yaml, rustfmt-include. The known pre-existing `appliable` typos failure is in `crates/app/inbox/src/confirm.rs`, outside this change set.

`origin/main` advanced to `3326320ba` (#1735) and was merged in with no conflicted files.

## Not done

- The 0.4.3 bump is not reverted and the `catch_unwind` guard is not removed.
- `astro-plan-7rsk0` (no UI renders `scan_warnings`), `astro-plan-is352` (the `fits_fixtures` migration never happened) and `astro-plan-69jw4` (blank-keyword `Commentary` cards escape the predicate) are filed, not fixed. None is resolved by this PR.
- No behaviour change outside FITS extraction and inbox master detection.

Merge-Bead: astro-plan-x6w08
Tracks-Bead: astro-plan-z7997
Closes-Bead: astro-plan-z7997
