### PR TITLE
fix: an archive destination can no longer write outside the library root

### DIFF
--- a/crates/fs/executor/src/ops/archive_op.rs
+++ b/crates/fs/executor/src/ops/archive_op.rs
@@ -16,9 +16,11 @@ use crate::ops::move_op::{move_file, MoveResult};
 
 /// Archive a file by moving it to `archive_destination`.
 ///
-/// `archive_destination` is the absolute resolved path under the app-managed
-/// archive root (e.g. `<library_root>/.astro-plan-archive/<planId>/...`).
-/// Pre-computed at plan generation; passed in from the item's `archive_path`.
+/// `archive_destination` is the path already resolved and proven contained by
+/// `run::loop_::resolve_item_paths` (e.g.
+/// `<library_root>/.astro-plan-archive/<planId>/...`). Its stored form comes
+/// from the item's `archive_path` and may be root-relative, so passing the
+/// stored value straight in bypasses the containment rule (astro-plan-zboex).
 ///
 /// # Errors
 ///

--- a/crates/fs/executor/src/run/dispatch.rs
+++ b/crates/fs/executor/src/run/dispatch.rs
@@ -30,6 +30,12 @@ pub(super) type OpError = (PlanItemFailure, bool, RollbackOutcome, Option<String
 pub(super) struct ResolvedItemPaths {
     pub(super) source: Option<Utf8PathBuf>,
     pub(super) destination: Option<Utf8PathBuf>,
+    /// The archive destination carried by `Archive`/`Trash`, resolved against
+    /// the same root as the source.
+    ///
+    /// A third destination field reached `move_file` unresolved and ungated
+    /// while only the two named sides were gated (astro-plan-zboex).
+    pub(super) archive_destination: Option<Utf8PathBuf>,
 }
 
 pub(super) fn execute_item(item: &ExecutorItem, paths: &ResolvedItemPaths) -> Result<(), OpError> {
@@ -46,16 +52,17 @@ pub(super) fn execute_item(item: &ExecutorItem, paths: &ResolvedItemPaths) -> Re
                 .map_err(|(f, r)| (f, r.rollback_attempted, r.rollback_outcome, r.rollback_message))
         }
 
-        ExecutorItemAction::Archive { archive_destination } => {
+        ExecutorItemAction::Archive { .. } => {
             let src = require_resolved_path(resolved_src, "source")?;
-            // archive_destination is already absolute (pre-computed at plan generation).
-            archive_op::archive_file(src, archive_destination)
+            let dst =
+                require_resolved_path(paths.archive_destination.as_deref(), "archive destination")?;
+            archive_op::archive_file(src, dst)
                 .map_err(|(f, r)| (f, r.rollback_attempted, r.rollback_outcome, r.rollback_message))
         }
 
-        ExecutorItemAction::Trash { fallback_archive_destination } => {
+        ExecutorItemAction::Trash { .. } => {
             let src = require_resolved_path(resolved_src, "source")?;
-            trash_op::trash_file(src, fallback_archive_destination.as_deref())
+            trash_op::trash_file(src, paths.archive_destination.as_deref())
                 .map(|_| ()) // discard TrashResult (audit_reason recorded by caller)
                 .map_err(|(f, r)| (f, r.rollback_attempted, r.rollback_outcome, r.rollback_message))
         }

--- a/crates/fs/executor/src/run/loop_.rs
+++ b/crates/fs/executor/src/run/loop_.rs
@@ -160,13 +160,30 @@ async fn drive_plan<C: ExecutorCallbacks>(
 /// A side with no root is refused unless it carries an absolute, already-normal
 /// path, which is the legacy mode for items storing a pre-resolved destination
 /// (`fs_pathsafe::contain::resolve_unrooted`).
+///
+/// The archive destination carried inside the `Archive`/`Trash` action is a
+/// third side and is resolved here too: gating only the two named sides let it
+/// reach `move_file` unresolved (astro-plan-zboex). It is governed by the
+/// SOURCE root, because both generators derive it as a sibling of the source
+/// (`app_projects::prepared_views::compute_archive_destination`) and the
+/// archive-management side resolves the same stored column against
+/// `from_root_id` (`app_core::plans::archive::resolve_archive_abs_path`).
 fn resolve_item_paths(item: &ExecutorItem) -> Result<ResolvedItemPaths, PlanItemFailure> {
+    let archive_destination = match &item.action {
+        ExecutorItemAction::Archive { archive_destination } => Some(archive_destination.as_path()),
+        ExecutorItemAction::Trash { fallback_archive_destination } => {
+            fallback_archive_destination.as_deref()
+        }
+        _ => None,
+    };
+
     Ok(ResolvedItemPaths {
         source: resolve_side(item.source_path.as_deref(), item.library_root.as_deref())?,
         destination: resolve_side(
             item.destination_path.as_deref(),
             item.destination_root.as_deref().or(item.library_root.as_deref()),
         )?,
+        archive_destination: resolve_side(archive_destination, item.library_root.as_deref())?,
     })
 }
 

--- a/crates/fs/executor/src/run/tests.rs
+++ b/crates/fs/executor/src/run/tests.rs
@@ -170,6 +170,113 @@ async fn destination_under_destination_root_is_allowed() {
     assert!(view_root.join("lights/frame.fits").exists());
 }
 
+fn make_archive_item(id: &str, src: &Utf8Path, archive_destination: &Utf8Path) -> ExecutorItem {
+    ExecutorItem {
+        id: id.to_owned(),
+        plan_id: "p1".to_owned(),
+        action: ExecutorItemAction::Archive {
+            archive_destination: archive_destination.to_path_buf(),
+        },
+        source_path: Some(src.to_path_buf()),
+        destination_path: None,
+        library_root: None,
+        destination_root: None,
+        cas_snapshot: CasSnapshot { approved_mtime: None, approved_size_bytes: None },
+        is_protected: false,
+        requires_destructive_confirm: false,
+        destructive_confirmed: false,
+        current_state: "pending".to_owned(),
+    }
+}
+
+/// astro-plan-zboex: the archive destination is a third destination field and
+/// was neither resolved nor gated, so it reached `move_file` and wrote outside
+/// the library root the user granted.
+#[tokio::test]
+async fn archive_destination_outside_the_library_root_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    let outer = utf8(dir.path());
+    let root = outer.join("library");
+    std::fs::create_dir_all(&root).unwrap();
+    let src = root.join("frame.fits");
+    std::fs::write(&src, b"data").unwrap();
+
+    let mut item = make_archive_item(
+        "item-1",
+        Utf8Path::new("frame.fits"),
+        Utf8Path::new("../escaped/frame.fits"),
+    );
+    item.library_root = Some(root.clone());
+
+    let callbacks = FakeCallbacks::default();
+    let outcome = execute_plan(
+        vec![item],
+        &callbacks,
+        &CancellationToken::new(),
+        &SkipSet::new(),
+        &RetryQueue::new(),
+    )
+    .await;
+
+    let events = callbacks.events.lock().await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].new_state, "refused", "failure: {:?}", events[0].failure);
+    assert_eq!(
+        events[0].failure.as_ref().map(|f| f.code),
+        Some(crate::failure::FailureCode::RootEscape)
+    );
+    drop(events);
+
+    match outcome {
+        ApplyOutcome::Completed(counts) => assert_eq!(counts.failed, 1),
+        other => panic!("expected Completed, got {other:?}"),
+    }
+    assert!(src.exists(), "the source must be untouched");
+    assert!(
+        !outer.join("escaped/frame.fits").exists(),
+        "the archive must not have escaped the library root"
+    );
+}
+
+/// The companion direction: gating the third field must not refuse the ordinary
+/// root-relative archive destination both generators write.
+#[tokio::test]
+async fn archive_destination_under_the_library_root_is_applied() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = utf8(dir.path());
+    let src = root.join("frame.fits");
+    std::fs::write(&src, b"data").unwrap();
+
+    let mut item = make_archive_item(
+        "item-1",
+        Utf8Path::new("frame.fits"),
+        Utf8Path::new(".astro-plan-archive/p1/item-1-frame.fits"),
+    );
+    item.library_root = Some(root.clone());
+
+    let callbacks = FakeCallbacks::default();
+    let outcome = execute_plan(
+        vec![item],
+        &callbacks,
+        &CancellationToken::new(),
+        &SkipSet::new(),
+        &RetryQueue::new(),
+    )
+    .await;
+
+    let events = callbacks.events.lock().await;
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].new_state, "succeeded", "failure: {:?}", events[0].failure);
+    drop(events);
+
+    match outcome {
+        ApplyOutcome::Completed(counts) => assert_eq!(counts.succeeded, 1),
+        other => panic!("expected Completed, got {other:?}"),
+    }
+    assert!(!src.exists(), "the source must have moved");
+    assert!(root.join(".astro-plan-archive/p1/item-1-frame.fits").exists());
+}
+
 #[tokio::test]
 async fn item_in_failed_state_is_skipped_by_executor() {
     let item = ExecutorItem {


### PR DESCRIPTION
## The defect

`ExecutorItemAction::Archive { archive_destination }` was a third destination
field that no gate ever saw.

- `crates/fs/executor/src/run/loop_.rs:171` `resolve_item_paths` resolved
  `source_path` and `destination_path` only.
- `crates/fs/executor/src/run/dispatch.rs:55` (before this change) passed the
  stored `archive_destination` straight into
  `crates/fs/executor/src/ops/archive_op.rs:26` `archive_file`, which calls
  `move_op::move_file` with no root join and no containment verdict.

The stored value is root-relative whenever the item carries a `from_root_id`:
`crates/app/core/src/plan_apply/paths.rs:220-226` reads `plan_items.archive_path`,
and `crates/app/projects/src/prepared_views.rs:67-72`
`compute_archive_destination` derives it from `from_relative_path`. A relative
value therefore resolved against the process working directory; an absolute one
was never compared to any root. Either wrote outside every library root and was
recorded as succeeded, against constitution I (roots modelled separately from
relative paths) and II (a reviewable, contained mutation).

This was measured, not inferred. Running the two new tests with the fix reverted
left `crates/fs/escaped/frame.fits` and
`crates/fs/executor/.astro-plan-archive/p1/item-1-frame.fits` in the checkout —
files written relative to the test process's working directory, entirely outside
the test's library root.

## The fix

`resolve_item_paths` now resolves the third field through the same `resolve_side`
the other two sides use (`crates/fs/executor/src/run/loop_.rs:171-186`), so it
passes `fs_pathsafe::contain` and the `path_gate` per-component symlink walk.
Dispatch consumes the resolved value
(`crates/fs/executor/src/run/dispatch.rs:33-38, 55-66`).

No new normalizer. The single lexical normalizer in
`crates/fs/pathsafe/src/contain.rs` is reused via `path_gate::resolve_and_validate`
and `contain::resolve_unrooted_utf8`. `git diff -U0 | grep -E '^\+' | grep -E
'clean|normalize|components|starts_with|is_absolute|canonicalize'` returns
nothing.

### Root policy: the source root, and why no new decision was needed

`specs/tiny/root-relative-path-containment.md:129-131` deferred this bead on the
grounds that closing it "requires an archive-root policy decision, since an
archive destination on another drive is a supported user configuration".
Measured against the tree, that premise does not hold: `rg -n
'archive_root|astro-plan-archive'` finds no archive-root setting, column, or
config anywhere — only the hardcoded `.astro-plan-archive` convention. Both
generators write the destination as a sibling of the source, and
`crates/app/core/src/plans/archive.rs:47-60` `resolve_archive_abs_path` already
resolves the same stored column against `from_root_id`. The executor now matches
that, so one policy governs the column rather than two.

The spec file is not amended in this PR; its deferral note is now stale and that
is called out here rather than silently.

### Fail-closed consequence

An item with no `from_root_id` and a relative `archive_path` is now refused
`path.invalid` instead of writing relative to the process working directory. No
generator produces that shape; every producer sets `from_root_id` or stores an
absolute path.

### Trash reroute interaction

Asked and answered: a rerouted item does **not** carry an archive destination.
`crates/app/core/src/plan_apply/paths.rs:215-219` turns an `action = "archive"`
item into `Trash { fallback_archive_destination: None }` when the plan-level
`destructive_destination` is `"trash"`, discarding `archive_path` entirely. So PR
#1735's reroute cannot leak an ungated archive destination, and there is no
interaction to fix. The side effect — a rerouted item has no archive fallback, so
an unavailable OS trash fails the item rather than archiving it — is pre-existing
and fail-safe (the file survives); not changed here.

`fallback_archive_destination` is gated the same way for completeness. It has no
production producer: every construction site passes `None`, and the only `Some`
is `crates/fs/executor/tests/us1_safety.rs:830`. Gating both sides is fewer lines
than gating one, since dispatch would otherwise still read the raw field for
`Trash`.

## Tests

Two new tests in `crates/fs/executor/src/run/tests.rs`, both confirmed failing
with the fix reverted (both halves reverted — reverting dispatch alone leaves the
`loop_` gate in place and the refusal test passes vacuously, which is how the
first revert attempt misled me):

| Test | With fix | Fix reverted |
|---|---|---|
| `archive_destination_outside_the_library_root_is_refused` | PASS | FAIL — item succeeded, `failure: None`; wrote `crates/fs/escaped/frame.fits` |
| `archive_destination_under_the_library_root_is_applied` | PASS | FAIL — `assertion failed: root.join(".astro-plan-archive/p1/item-1-frame.fits").exists()` |

Neither is vacuous. The second is the working-direction companion the brief
required: gating the field must not refuse the ordinary root-relative
destination both generators write.

Windows: the tests build their roots from `tempfile::tempdir()`, which is
platform-absolute, so no `is_absolute` fixture is needed. `fs_pathsafe::test_support::abs`
is unused here.

## Verification

All run in a dedicated worktree with `CARGO_TARGET_DIR=/Users/sjors/tmp/cargo-target/zboex`.

| Command | Result |
|---|---|
| `cargo nextest run -p fs_executor` | 135 passed, 0 skipped |
| `cargo nextest run -p app_core` | 568 passed, 0 skipped |
| `cargo clippy -p fs_executor --all-targets` | exit 0, no warnings |
| `cargo fmt -p fs_executor -- --check` | exit 0 |
| `bash scripts/precommit-verify.sh <4 changed files>` | exit 0, **6 hooks actually ran** (added-large-files, detect-private-key, end-of-files, trailing-whitespace, gitleaks, typos) |
| `bash scripts/check-db-boundary.sh` | exit 0, 0 sites / 427 files |
| `just dead-callers` | exit 0, no new dead pub fns / 528 files |
| `just test-targets` | exit 0 |

`git merge origin/main` — already up to date, no conflicts.

Not run: `cargo nextest run -p e2e_tests` reports `0 tests run, 30 skipped` —
every e2e journey is `#[ignore]` and needs a WebDriver plus a feature-built
desktop binary, which this worktree cannot provide. `crates/e2e-tests/tests/archive_journeys.rs`
exercises a real `.astro-plan-archive` apply and is the test most likely to
notice a regression here; it goes through `item_row_to_executor_item` with
`from_root_id` set and a root-relative `archive_path`, which is exactly the shape
`archive_destination_under_the_library_root_is_applied` proves still succeeds.

## Not resolved by this PR

- `astro-plan-91bzn` — a fourth destination-blind derivation of the destructive
  predicate. Untouched: this PR does not change that predicate.
- `astro-plan-ta7kn` — the third-party lexical normalizer census. Untouched.
- `astro-plan-8vxx1` — pre-existing `typos` failure on `appliable` in
  `crates/app/inbox/src/confirm.rs`. Not in scope; `typos` passed on my four
  files because it was scoped to them.
- `astro-plan-xthfd` — filed by this unit, not fixed: `crates/fs/executor/Cargo.toml:24`
  declares `path-clean` but `rg -n path_clean crates/fs/executor/` finds no use
  in any target, left over from PR #1711 deleting `path_gate::lexical_normalize`.
  Deleting it is a manifest change this unit does not make.

No schema change; `crates/persistence/core/migrations/0001_initial_schema.sql` is
untouched, so no database recreate is needed.

Tracks-Bead: astro-plan-zboex
Closes-Bead: astro-plan-zboex
Merge-Bead: astro-plan-w6ccd
