### PR TITLE
fix: raw frame cleanup no longer plans against a session whose frame list is unreadable

### DIFF
--- a/crates/app/core/src/cleanup_generator/raw_frames.rs
+++ b/crates/app/core/src/cleanup_generator/raw_frames.rs
@@ -12,6 +12,7 @@ use contracts_core::inventory_frame::{
 };
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use domain_core::ids::new_id;
+use persistence_core::repositories::q_core;
 use persistence_plans::repositories::source_protection as prot_repo;
 use sqlx::SqlitePool;
 
@@ -41,6 +42,58 @@ fn raw_frame_protection_category(frame_type: RawFrameType) -> &'static str {
         RawFrameType::Flat => "flats",
         RawFrameType::Bias => "bias",
     }
+}
+
+/// Refuse raw-frame cleanup while any session's `frame_ids` is unreadable.
+///
+/// The `CASE WHEN json_valid(frame_ids)` guards substitute an empty array, so a
+/// corrupt session contributes zero frames and its frames resolve to no owning
+/// session — indistinguishable from a frame that is genuinely unattributed, and
+/// an unattributed frame is a cleanup candidate whose protection resolves under
+/// its root instead of its session. Constitution II forbids letting a
+/// destructive plan be built on that, and Constitution V makes
+/// frame-to-session attribution Tier 1, so the failure is raised rather than
+/// degraded (the same choice as
+/// `persistence_plans::repositories::projects::find_blockable_missing_sources`).
+///
+/// The check is deliberately not narrowed to the requested scope: deciding
+/// whether a corrupt session owns a selected frame requires reading the
+/// membership that is precisely what cannot be read.
+///
+/// A malformed `aliases` list is logged but does not refuse — equipment naming
+/// is not attribution and cannot misdirect a plan item.
+async fn refuse_unreadable_frame_attribution(pool: &SqlitePool) -> Result<(), ContractError> {
+    let malformed = q_core::list_malformed_json_columns(pool).await.map_err(db_err)?;
+    for row in &malformed {
+        tracing::warn!(
+            table = %row.table_name,
+            column = %row.column_name,
+            row_id = %row.row_id,
+            "stored JSON column is not valid JSON; queries over it read as empty"
+        );
+    }
+
+    let unreadable: Vec<&str> = malformed
+        .iter()
+        .filter(|row| row.column_name == q_core::FRAME_IDS_COLUMN)
+        .map(|row| row.row_id.as_str())
+        .collect();
+    if unreadable.is_empty() {
+        return Ok(());
+    }
+
+    Err(ContractError::new(
+        ErrorCode::InternalData,
+        format!(
+            "frame-to-session attribution is unreadable for {} session(s) ({}), \
+             so raw sub-frame cleanup cannot tell an unattributed frame from one \
+             of theirs. Repair or re-import those sessions first.",
+            unreadable.len(),
+            unreadable.join(", ")
+        ),
+        ErrorSeverity::Blocking,
+        false,
+    ))
 }
 
 /// Pick the protection source id for a raw frame (issue #563): the owning
@@ -83,11 +136,17 @@ async fn frame_protection_source(
 ///
 /// # Errors
 ///
-/// Returns `ContractError` on database failure or an invalid/empty scope.
+/// Returns `ContractError` on database failure, an invalid/empty scope, or
+/// `internal.data` when any session's `frame_ids` is unreadable (see
+/// [`refuse_unreadable_frame_attribution`]) — the preview refuses on the same
+/// condition as the plan so a frame cannot be absent from one surface and
+/// present as a candidate in the other.
 pub async fn scan_raw_frames(
     pool: &SqlitePool,
     req: &RawFrameCleanupScanRequest,
 ) -> Result<RawFrameCleanupScanResponse, ContractError> {
+    refuse_unreadable_frame_attribution(pool).await?;
+
     let listed = frame_inventory::list_frames(
         pool,
         &InventoryFrameListRequest {
@@ -159,12 +218,16 @@ pub async fn scan_raw_frames(
 ///
 /// # Errors
 ///
-/// Returns `ContractError` on database failure or when no selected frame id
-/// resolves to a present `file_record` row.
+/// Returns `ContractError` on database failure, when no selected frame id
+/// resolves to a present `file_record` row, or `internal.data` when any
+/// session's `frame_ids` is unreadable (see
+/// [`refuse_unreadable_frame_attribution`]).
 pub async fn generate_raw_frame_plan(
     pool: &SqlitePool,
     req: &RawFrameCleanupGenerateRequest,
 ) -> Result<GenerateCleanupPlanResult, ContractError> {
+    refuse_unreadable_frame_attribution(pool).await?;
+
     let rows = frame_inventory::rows_by_ids(pool, &req.selected_frame_ids).await?;
 
     let plan_id = new_id();

--- a/crates/app/core/src/cleanup_generator/tests.rs
+++ b/crates/app/core/src/cleanup_generator/tests.rs
@@ -13,6 +13,7 @@ use contracts_core::cleanup::{
     CleanupAction, CleanupPolicy, CleanupPolicyEntry, RawFrameCleanupGenerateRequest,
     RawFrameCleanupScanRequest,
 };
+use contracts_core::error_code::ErrorCode;
 use contracts_core::protection::{
     PlanProtectionCheckRequest, ProtectionLevel, SourceProtectionSetRequest,
 };
@@ -745,4 +746,148 @@ async fn generate_raw_frame_plan_skips_missing_selected_frames() {
     .unwrap();
 
     assert_eq!(resp.item_count, 1, "the missing frame must not become a plan item (FR-022)");
+}
+
+// ── Unreadable frame attribution refuses cleanup (astro-plan-l2s06) ──────────
+
+/// Writes a `frame_ids` value the `json_valid` guards reject. The helper above
+/// serialises through `serde_json` and cannot produce one.
+async fn insert_session_with_raw_frame_ids(pool: &SqlitePool, id: &str, frame_ids: &str) {
+    sqlx::query(
+        "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at)
+         VALUES (?, '{}', ?, datetime('now'))",
+    )
+    .bind(id)
+    .bind(frame_ids)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+/// Seeds a root-scoped library where two present frames belong to an intact
+/// session, so the scan has real candidates to return. Without the refusal both
+/// tests below observe those candidates; the corrupt session is the only
+/// difference between them.
+async fn seed_two_attributed_frames(pool: &SqlitePool) -> Vec<String> {
+    use app_core_targets::frame_writer::upsert_frame_record;
+
+    insert_root(pool, "root-1", "/tmp/lib").await;
+    let f1 =
+        upsert_frame_record(pool, "root-1", "l1.fits", 1000, "t0", "classified").await.unwrap();
+    let f2 =
+        upsert_frame_record(pool, "root-1", "l2.fits", 2000, "t0", "classified").await.unwrap();
+    insert_acquisition_session(pool, "sess-intact", &[&f1, &f2]).await;
+    vec![f1, f2]
+}
+
+#[tokio::test]
+async fn scan_raw_frames_refuses_while_a_session_frame_ids_is_unreadable() {
+    let (db, _bus, _lock) = setup().await;
+    seed_two_attributed_frames(db.pool()).await;
+    insert_session_with_raw_frame_ids(db.pool(), "sess-corrupt", "{").await;
+
+    let err = scan_raw_frames(
+        db.pool(),
+        &RawFrameCleanupScanRequest {
+            scope: RawFrameCleanupScope { session_id: None, root_id: Some("root-1".to_owned()) },
+            kinds: None,
+        },
+    )
+    .await
+    .expect_err("a corrupt session reads as zero frames, so the scan must refuse");
+
+    assert_eq!(err.code, ErrorCode::InternalData);
+    assert!(
+        err.message.contains("sess-corrupt"),
+        "the refusal must name the unreadable session: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn generate_raw_frame_plan_refuses_while_a_session_frame_ids_is_unreadable() {
+    let (db, _bus, _lock) = setup().await;
+    let frames = seed_two_attributed_frames(db.pool()).await;
+    insert_session_with_raw_frame_ids(db.pool(), "sess-corrupt", "{").await;
+
+    let err = generate_raw_frame_plan(
+        db.pool(),
+        &RawFrameCleanupGenerateRequest {
+            selected_frame_ids: frames,
+            title: None,
+            destructive_destination: None,
+        },
+    )
+    .await
+    .expect_err("a destructive plan must not be built while attribution is unreadable");
+
+    assert_eq!(err.code, ErrorCode::InternalData);
+    assert!(
+        err.message.contains("sess-corrupt"),
+        "the refusal must name the unreadable session: {}",
+        err.message
+    );
+}
+
+/// The other half of the distinction: `[]` is a session with no frames, not a
+/// session whose frames cannot be read, and it must not refuse anything.
+#[tokio::test]
+async fn an_empty_frame_ids_still_reads_as_empty_and_refuses_nothing() {
+    let (db, _bus, _lock) = setup().await;
+    let frames = seed_two_attributed_frames(db.pool()).await;
+    insert_session_with_raw_frame_ids(db.pool(), "sess-empty", "[]").await;
+
+    let scan = scan_raw_frames(
+        db.pool(),
+        &RawFrameCleanupScanRequest {
+            scope: RawFrameCleanupScope { session_id: None, root_id: Some("root-1".to_owned()) },
+            kinds: None,
+        },
+    )
+    .await
+    .expect("an empty frame_ids is not a corrupt one");
+
+    assert_eq!(scan.candidates.len(), 2);
+    assert_eq!(scan.total_reclaimable_bytes, 3000);
+    assert!(scan.candidates.iter().all(|c| c.session_id.as_deref() == Some("sess-intact")));
+
+    let plan = generate_raw_frame_plan(
+        db.pool(),
+        &RawFrameCleanupGenerateRequest {
+            selected_frame_ids: frames,
+            title: None,
+            destructive_destination: None,
+        },
+    )
+    .await
+    .expect("an empty frame_ids must not block plan generation");
+
+    assert_eq!(plan.item_count, 2);
+}
+
+/// A malformed equipment alias list is reported by the scan but is not
+/// attribution, so it must not refuse a cleanup plan.
+#[tokio::test]
+async fn a_malformed_camera_alias_list_does_not_refuse_cleanup() {
+    let (db, _bus, _lock) = setup().await;
+    seed_two_attributed_frames(db.pool()).await;
+    sqlx::query(
+        "INSERT INTO cameras (id, name, aliases, created_at)
+         VALUES ('cam-corrupt', 'cam-corrupt', '[', datetime('now'))",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    let scan = scan_raw_frames(
+        db.pool(),
+        &RawFrameCleanupScanRequest {
+            scope: RawFrameCleanupScope { session_id: None, root_id: Some("root-1".to_owned()) },
+            kinds: None,
+        },
+    )
+    .await
+    .expect("an unreadable alias list cannot misdirect a plan item");
+
+    assert_eq!(scan.candidates.len(), 2);
 }

--- a/crates/persistence/core/src/repositories/q_core.rs
+++ b/crates/persistence/core/src/repositories/q_core.rs
@@ -153,6 +153,53 @@ pub async fn find_calibration_session_by_frame(
     Ok(row)
 }
 
+/// One stored JSON column whose value is not valid JSON.
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub struct MalformedJsonColumnRow {
+    pub table_name: String,
+    pub column_name: String,
+    pub row_id: String,
+}
+
+/// The `column_name` value carried by a session frame-attribution row, so
+/// callers can separate an unreadable Tier-1 attribution record from a merely
+/// unreadable equipment alias list.
+pub const FRAME_IDS_COLUMN: &str = "frame_ids";
+
+/// Every row whose JSON column is not valid JSON, across the four columns the
+/// `CASE WHEN json_valid(...)` guards read: `acquisition_session.frame_ids`,
+/// `calibration_session.frame_ids`, `cameras.aliases`, `telescopes.aliases`.
+///
+/// Those guards substitute an empty array, so a corrupt row reads as zero
+/// frames or zero aliases rather than failing its query. This is the only
+/// query that can tell the two apart, and callers whose result would otherwise
+/// be silently degraded must consult it.
+///
+/// `json_valid(NULL)` is `NULL`, so a NULL column is never reported malformed
+/// (all four columns are `NOT NULL` today).
+///
+/// # Errors
+/// Returns `persistence_core::DbError::Database` on query failure.
+pub async fn list_malformed_json_columns(
+    pool: &SqlitePool,
+) -> DbResult<Vec<MalformedJsonColumnRow>> {
+    let rows = sqlx::query_as::<_, MalformedJsonColumnRow>(
+        "SELECT 'acquisition_session' AS table_name, 'frame_ids' AS column_name, id AS row_id \
+           FROM acquisition_session WHERE NOT json_valid(frame_ids) \
+         UNION ALL \
+         SELECT 'calibration_session', 'frame_ids', id \
+           FROM calibration_session WHERE NOT json_valid(frame_ids) \
+         UNION ALL \
+         SELECT 'cameras', 'aliases', id FROM cameras WHERE NOT json_valid(aliases) \
+         UNION ALL \
+         SELECT 'telescopes', 'aliases', id FROM telescopes WHERE NOT json_valid(aliases) \
+         ORDER BY table_name ASC, row_id ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
 /// Mark a `file_record` row `missing`. Preserves the original call site's
 /// `last_seen_at = last_seen_at` no-op assignment (leaves the column
 /// untouched while still forming a valid `UPDATE`).

--- a/crates/persistence/core/tests/malformed_json_column_scan.rs
+++ b/crates/persistence/core/tests/malformed_json_column_scan.rs
@@ -1,0 +1,126 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `q_core::list_malformed_json_columns` separates an unreadable JSON column
+//! from an empty one.
+//!
+//! Every other query over these columns wraps them in
+//! `CASE WHEN json_valid(col) THEN col ELSE '[]' END`, which makes a corrupt
+//! row read exactly like a row holding `[]`. This scan is the only place the
+//! two are distinguishable, so it is asserted over all four guarded columns and
+//! over valid rows in the same database — a scan that reported every row, or
+//! none, would satisfy neither half.
+
+use sqlx::SqlitePool;
+
+use persistence_core::repositories::q_core::{list_malformed_json_columns, MalformedJsonColumnRow};
+use persistence_core::Database;
+
+async fn migrated() -> Database {
+    let db = Database::in_memory().await.expect("in-memory database");
+    db.migrate().await.expect("migrations apply");
+    db
+}
+
+async fn seed_acquisition(pool: &SqlitePool, id: &str, frame_ids: &str) {
+    sqlx::query(
+        "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at)
+         VALUES (?, ?, ?, '2026-06-01T00:00:00Z')",
+    )
+    .bind(id)
+    .bind(id)
+    .bind(frame_ids)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn seed_calibration(pool: &SqlitePool, id: &str, frame_ids: &str) {
+    sqlx::query(
+        "INSERT INTO calibration_session (id, session_key, frame_ids, kind, created_at)
+         VALUES (?, ?, ?, 'dark', '2026-06-01T00:00:00Z')",
+    )
+    .bind(id)
+    .bind(id)
+    .bind(frame_ids)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn seed_camera(pool: &SqlitePool, id: &str, aliases: &str) {
+    sqlx::query(
+        "INSERT INTO cameras (id, name, aliases, created_at)
+         VALUES (?, ?, ?, '2026-06-01T00:00:00Z')",
+    )
+    .bind(id)
+    .bind(id)
+    .bind(aliases)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn seed_telescope(pool: &SqlitePool, id: &str, aliases: &str) {
+    sqlx::query(
+        "INSERT INTO telescopes (id, name, aliases, created_at)
+         VALUES (?, ?, ?, '2026-06-01T00:00:00Z')",
+    )
+    .bind(id)
+    .bind(id)
+    .bind(aliases)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+fn located(rows: &[MalformedJsonColumnRow]) -> Vec<(&str, &str, &str)> {
+    rows.iter()
+        .map(|r| (r.table_name.as_str(), r.column_name.as_str(), r.row_id.as_str()))
+        .collect()
+}
+
+#[tokio::test]
+async fn the_scan_reports_a_corrupt_row_in_each_guarded_column_and_no_valid_row() {
+    let db = migrated().await;
+    let pool = db.pool();
+
+    seed_acquisition(pool, "acq-corrupt", "{").await;
+    seed_acquisition(pool, "acq-empty", "[]").await;
+    seed_acquisition(pool, "acq-populated", r#"["file-1"]"#).await;
+    seed_calibration(pool, "cal-corrupt", "not json").await;
+    seed_calibration(pool, "cal-empty", "[]").await;
+    seed_camera(pool, "cam-corrupt", "[").await;
+    seed_camera(pool, "cam-empty", "[]").await;
+    seed_telescope(pool, "tel-corrupt", r#"{"a":}"#).await;
+    seed_telescope(pool, "tel-empty", "[]").await;
+
+    let rows = list_malformed_json_columns(pool).await.unwrap();
+
+    assert_eq!(
+        located(&rows),
+        vec![
+            ("acquisition_session", "frame_ids", "acq-corrupt"),
+            ("calibration_session", "frame_ids", "cal-corrupt"),
+            ("cameras", "aliases", "cam-corrupt"),
+            ("telescopes", "aliases", "tel-corrupt"),
+        ],
+        "every guarded column reports its corrupt row, and no valid or empty row is reported"
+    );
+}
+
+#[tokio::test]
+async fn the_scan_is_empty_when_every_row_holds_valid_json() {
+    let db = migrated().await;
+    let pool = db.pool();
+
+    seed_acquisition(pool, "acq-empty", "[]").await;
+    seed_acquisition(pool, "acq-populated", r#"["file-1","file-2"]"#).await;
+    seed_calibration(pool, "cal-empty", "[]").await;
+    seed_camera(pool, "cam-ok", r#"["ASI2600"]"#).await;
+    seed_telescope(pool, "tel-ok", "[]").await;
+
+    let rows = list_malformed_json_columns(pool).await.unwrap();
+
+    assert_eq!(located(&rows), Vec::new(), "an empty array is not a corrupt value");
+}


### PR DESCRIPTION
## Summary

- A session whose stored frame list is corrupt used to look exactly like a
  session with no frames, so its frames read as belonging to nothing and could
  be offered for archive or deletion. Raw sub-frame cleanup now refuses, names
  the affected sessions, and logs them, instead of quietly planning against
  data it cannot read.

## The defect

PR #1736 (`da71a9c44`) wrapped every SQLite JSON function over `frame_ids` and
`aliases` in `CASE WHEN json_valid(col) THEN col ELSE '[]' END`. That stopped
one corrupt row failing a whole query, and its author filed
`astro-plan-l2s06` against their own work because it traded a loud failure for
silent degradation: a corrupt session now reads as having **zero frames**,
indistinguishable from a session whose frames are genuinely unattributed.

`app_core::cleanup_generator::raw_frames` treats an unattributed frame as a raw
sub-frame cleanup candidate and resolves its protection under its root instead
of its session, so a lost Tier-1 attribution record (Constitution V names
"frame-to-session attribution" verbatim) could reach a **destructive plan** with
nothing logged, audited, or shown.

## The fix

`persistence_core::repositories::q_core::list_malformed_json_columns` reports
every row failing `json_valid` across the four guarded columns
(`acquisition_session.frame_ids`, `calibration_session.frame_ids`,
`cameras.aliases`, `telescopes.aliases`). It is the only query that can tell a
corrupt value from an empty one, because every other query over those columns
makes them read identically.

`raw_frames::refuse_unreadable_frame_attribution` consults it at the head of
both `scan_raw_frames` and `generate_raw_frame_plan`, logs every malformed row
at `warn`, and returns `internal.data` (reusing the existing `ErrorCode`
variant, so no contract field and no TS binding change) naming the unreadable
session ids when any `frame_ids` is among them.

The user sees it through a surface that already exists:
`apps/desktop/src/features/sessions/RawFrameCleanupSection.tsx:181-182` and
`:221-222` already render `errMessage(...)` in a danger `Banner` for both the
scan and the generate error. No frontend change.

### Decisions, and why the other two candidates lose

The bead offered three designs.

- **Audit event on each guard substitution** — SQL cannot report that the `CASE`
  fired without adding a column to each of the 14 guarded expressions, it would
  put an `audit` dependency into the persistence crates the `audit-types` split
  exists to keep out, and Constitution V makes audit writes Tier-2 (batched or
  asynchronous), so it cannot gate a destructive plan. It records history it
  cannot act on.
- **Startup reconciliation check** — fires only at boot, so corruption arising
  later in a session is invisible until the next launch, and it likewise gates
  nothing. The constitution's unclean-shutdown reconciliation is about mutation
  intents, which a malformed `frame_ids` is not.
- **`json_valid` CHECK constraint** — a breaking edit to the single editable
  baseline, and it only stops *new* corrupt writes; it does nothing about a row
  already stored, which is the case in hand.
- **Chosen: the integrity scan**, wired at the one boundary where the
  consequence is destructive. It is one query, it needs no schema change, and it
  is the only option that answers the sharp question the bead poses.

Both surfaces refuse on one condition deliberately. Refusing only the plan
would leave the frame visible as a candidate in the preview and silently absent
from the plan, which is its own defect.

The check is **not** narrowed to the requested scope. Deciding whether the
corrupt session owns a selected frame requires reading the membership that is
precisely what cannot be read, so a per-root or per-session filter would be
scoping on unreadable data. A single corrupt session therefore refuses raw-frame
cleanup library-wide until it is repaired. Stated as a judgement call, not an
oversight.

A malformed `aliases` list is reported and logged but does **not** refuse:
equipment naming is not attribution and cannot misdirect a plan item.

## The out-of-scope site is untouched

`crates/persistence/plans/src/repositories/projects/sources.rs:65`
(`find_blockable_missing_sources`) is not modified. Its raise is its contract.
The tripwire test still passes:

```
test repositories::projects::tests::find_blockable_missing_sources_raises_on_a_malformed_frame_ids_session ... ok
```

## Sites, counted in this checkout

`git grep -c "CASE WHEN json_valid" origin/main -- ':!target'` reports 15
matches across 7 files. One of those (`sources.rs:48`) is a doc-comment
reference, not a guard, so **14 guarded expressions** exist on `main`: 13 in
Rust across 5 repository files, plus 1 in `calibration_master_view` in
`0001_initial_schema.sql`.

Of those 14, only the `q_core` pair (`:119`, `:145`) and the `inventory.rs` six
feed the raw sub-frame cleanup path, via `frame_inventory::list_frames` and
`owning_session_frame_type`. The gate covers every session row regardless, since
it queries the tables rather than the call sites.

Enumerated for the remaining consumers, so no coverage is claimed that is not
here:

- `calibration_assignment.rs:232`/`:266` feed reconcile and calibration master
  health, not a plan.
- `equipment.rs:259`/`:385` feed equipment alias matching.
- `targets.rs:63` and `inventory.rs:360`/`:434` feed target and session read
  projections.
- The `calibration_master_view` guard feeds `calibration_archive_generator`,
  which is a destructive path but **already** refuses loudly:
  `crates/app/core/src/calibration_archive_generator.rs:106-109` returns `Err`
  when `frame_relative_path` is `None`, which is exactly what the guarded view
  yields for a corrupt row. Left alone; no change was needed.

## No schema change

`0001_initial_schema.sql` is not edited, so no development database needs
recreating.

## Tests, each confirmed failing with the fix reverted

New, in `crates/app/core/src/cleanup_generator/tests.rs`:

| Test | With fix | Fix reverted |
|---|---|---|
| `scan_raw_frames_refuses_while_a_session_frame_ids_is_unreadable` | pass | **FAIL** — returned 2 candidates / 3000 bytes |
| `generate_raw_frame_plan_refuses_while_a_session_frame_ids_is_unreadable` | pass | **FAIL** — built a plan with `item_count: 2` |

Revert method: both `refuse_unreadable_frame_attribution(pool).await?;` call
sites commented out; result `25 passed; 2 failed`.

Two more tests assert the *other* direction and cannot fail at base, because at
base nothing refuses anything. They guard against over-correction, so per the
dispatch addendum each was proved to discriminate by substituting a wrong
implementation. **Disclosed as vacuous against the base tree.**

| Test | Wrong implementation | Result |
|---|---|---|
| `an_empty_frame_ids_still_reads_as_empty_and_refuses_nothing` | scan SQL extended to `NOT json_valid(frame_ids) OR frame_ids = '[]'` | **FAIL** — refused `sess-empty` |
| `a_malformed_camera_alias_list_does_not_refuse_cleanup` | the `FRAME_IDS_COLUMN` filter replaced with an always-true filter | **FAIL** — refused `cam-corrupt` |

New, in `crates/persistence/core/tests/malformed_json_column_scan.rs`: two tests
covering the query itself over all four columns (a corrupt row in each is
reported, and no valid or empty row is). Both are new-symbol tests and cannot
compile against the base tree.

The SQL vacuity traps were addressed: `seed_two_attributed_frames` populates
`file_record` and an intact `acquisition_session` so the scan has real
candidates to return, and the assertions read candidate counts, byte totals, and
`session_id` values rather than `is_ok()`. The reverted-fix output above shows
the refusal tests really did observe those candidates.

## Verification

All under `CARGO_TARGET_DIR=/Users/sjors/tmp/cargo-target/l2s06`, with
`RUSTUP_TOOLCHAIN` unset.

| Command | Result |
|---|---|
| `cargo test -p app_core -p persistence_targets -p persistence_calibration` | 671 passed (42 suites) |
| `cargo test -p persistence_core` | 69 passed (8 suites) |
| `cargo test -p persistence_plans` | 83 passed (2 suites), includes the `sources.rs` tripwire |
| `cargo clippy -p persistence_core -p app_core --all-targets` | no issues |
| `cargo fmt --all -- --check` | clean |
| `bash scripts/check-db-boundary.sh` | OK, 0 production query sites outside `crates/persistence/`, 427 files scanned |
| `bash scripts/precommit-verify.sh <4 touched files>` | exit 0, **6 hooks actually ran** |

`cargo test -p e2e_tests` exits 0 but reports `0 passed, 30 ignored` — every
journey there is `#[ignore]`, so it is **not** evidence for this change and is
reported as such rather than as a pass.

## Spec Context

Tracks-Bead: astro-plan-l2s06
Closes-Bead: astro-plan-l2s06

Merge-Bead: astro-plan-4thu5
