### PR TITLE
fix: applying an Inbox plan now requires your approval

### DIFF
--- a/apps/desktop/src-tauri/src/commands/inbox.rs
+++ b/apps/desktop/src-tauri/src/commands/inbox.rs
@@ -684,15 +684,16 @@ pub async fn inbox_plan(
     get_inbox_plan(state.repo.pool(), &inbox_item_id).await.map_err(|e| e.message)
 }
 
-/// `inbox.plan.apply` — approve + apply the plan for a single inbox item.
+/// `inbox.plan.apply` — apply the approved plan for a single inbox item.
 ///
-/// The use-case auto-approves the plan (which `inbox.confirm` leaves at
-/// `ready_for_review`) before calling `apply_plan`.  The plan listener
-/// transitions the inbox item state once the executor completes.
+/// `inbox.confirm` leaves the plan at `ready_for_review`; the caller must record
+/// the user's approval with `plans.approve` first. The plan listener transitions
+/// the inbox item state once the executor completes.
 ///
 /// # Errors
-/// Returns a string error on failure, including `plan.stale` when per-item
-/// CAS detects a file changed since the plan was created.
+/// Returns a string error on failure, including `plan.approval_required` when the
+/// plan carries no approval and `plan.stale` when per-item CAS detects a file
+/// changed since the plan was created.
 #[tauri::command]
 #[specta::specta]
 pub async fn inbox_plan_apply(

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1612,15 +1612,16 @@ export const commands = {
 	 */
 	inboxPlan: (inboxItemId: string) => typedError<InboxPlanView_Serialize, string>(__TAURI_INVOKE("inbox_plan", { inboxItemId })),
 	/**
-	 *  `inbox.plan.apply` — approve + apply the plan for a single inbox item.
+	 *  `inbox.plan.apply` — apply the approved plan for a single inbox item.
 	 * 
-	 *  The use-case auto-approves the plan (which `inbox.confirm` leaves at
-	 *  `ready_for_review`) before calling `apply_plan`.  The plan listener
-	 *  transitions the inbox item state once the executor completes.
+	 *  `inbox.confirm` leaves the plan at `ready_for_review`; the caller must record
+	 *  the user's approval with `plans.approve` first. The plan listener transitions
+	 *  the inbox item state once the executor completes.
 	 * 
 	 *  # Errors
-	 *  Returns a string error on failure, including `plan.stale` when per-item
-	 *  CAS detects a file changed since the plan was created.
+	 *  Returns a string error on failure, including `plan.approval_required` when the
+	 *  plan carries no approval and `plan.stale` when per-item CAS detects a file
+	 *  changed since the plan was created.
 	 */
 	inboxPlanApply: (inboxItemId: string) => typedError<PlanApplyResponse, string>(__TAURI_INVOKE("inbox_plan_apply", { inboxItemId })),
 	/**

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -214,7 +214,7 @@ export function InboxPage() {
     applyProgress,
     progressPlanId,
     planBusy,
-  } = useInboxPlanApplyFlow(refreshAll, viewResultAction);
+  } = useInboxPlanApplyFlow(refreshAll, viewResultAction, openPlans);
 
   // Stage B: plan review overlay open/close state.
   const [planOverlayOpen, setPlanOverlayOpen] = useState(false);

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.applyBatch.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.applyBatch.test.tsx
@@ -1,0 +1,171 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * astro-plan-tykek — the batch Apply gestures must record the user's approval
+ * before the plans are applied.
+ *
+ * `inbox.plan.apply_all` / `inbox.plan.apply_selected` used to reach a backend
+ * that minted its own approval (`approve_plan(actor = "inbox.apply")`), so the
+ * approval-token gate could never fail on the path the Inbox UI actually
+ * traverses. The backend now refuses an unapproved plan, which makes these two
+ * handlers responsible for approving what the user reviewed — the same shape
+ * `handleApplyOne` has carried since #769/#609.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  render as rtlRender,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PageStatusProvider } from '@/app/PageStatusContext';
+import type { InboxOpenPlan } from '@/bindings/index';
+
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>
+      <PageStatusProvider>{ui}</PageStatusProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const {
+  mockRootsList,
+  mockInboxList,
+  mockInboxPlanListOpen,
+  mockPlansApprove,
+  mockInboxPlanApplyAll,
+  mockInboxPlanApplySelected,
+  mockAddToast,
+  mockNavigate,
+} = vi.hoisted(() => ({
+  mockRootsList: vi.fn(),
+  mockInboxList: vi.fn(),
+  mockInboxPlanListOpen: vi.fn(),
+  mockPlansApprove: vi.fn(),
+  mockInboxPlanApplyAll: vi.fn(),
+  mockInboxPlanApplySelected: vi.fn(),
+  mockAddToast: vi.fn(),
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    rootsList: mockRootsList,
+    inboxList: mockInboxList,
+    inboxPlanListOpen: mockInboxPlanListOpen,
+    plansApprove: mockPlansApprove,
+    inboxPlanApplyAll: mockInboxPlanApplyAll,
+    inboxPlanApplySelected: mockInboxPlanApplySelected,
+  },
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useSearch: () => ({ selected: undefined, type: undefined }),
+}));
+
+vi.mock('@/shared/toast', () => ({
+  addToast: mockAddToast,
+  useToasts: () => ({ toasts: [], dismiss: vi.fn() }),
+}));
+
+const ok = <T,>(data: T) => ({ status: 'ok' as const, data });
+
+function makePlan(n: number): InboxOpenPlan {
+  return {
+    inboxItemId: `item-plan-00${n}`,
+    itemName: `lights/NGC700${n}`,
+    planId: `plan-00${n}`,
+    state: 'ready_for_review',
+    stale: false,
+    actions: [
+      {
+        index: 1,
+        action: 'move',
+        fromPath: `lights/NGC700${n}/frame_001.fits`,
+        toPath: `M31/light/frame_00${n}.fits`,
+        destinationPreview: `M31/light/frame_00${n}.fits`,
+        requiresDestructiveConfirm: false,
+      },
+    ],
+  };
+}
+
+const planA = makePlan(1);
+const planB = makePlan(2);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRootsList.mockResolvedValue(ok([]));
+  mockInboxList.mockResolvedValue(ok({ items: [], capped: false, limit: 500 }));
+  mockInboxPlanListOpen.mockResolvedValue(
+    ok({ plans: [planA, planB], totalActions: 2 }),
+  );
+  mockPlansApprove.mockImplementation((planId: string) =>
+    Promise.resolve(
+      ok({
+        planId,
+        newState: 'approved',
+        approvalToken: `tok-${planId}`,
+        approvedAt: '2026-08-24T00:00:00Z',
+      }),
+    ),
+  );
+  mockInboxPlanApplyAll.mockResolvedValue(ok({ results: [] }));
+  mockInboxPlanApplySelected.mockResolvedValue(ok({ results: [] }));
+});
+
+import { InboxPage } from '../InboxPage';
+
+async function openOverlay() {
+  render(<InboxPage />);
+  fireEvent.click(await screen.findByTestId('inbox-review-plans-btn'));
+}
+
+/** Assert every `plans.approve` call landed before the batch apply IPC. */
+function expectApprovedBefore(applyMock: {
+  mock: { invocationCallOrder: number[] };
+}) {
+  const applyOrder = applyMock.mock.invocationCallOrder[0];
+  for (const order of mockPlansApprove.mock.invocationCallOrder) {
+    expect(order).toBeLessThan(applyOrder);
+  }
+}
+
+describe('InboxPage batch apply — approve before apply (astro-plan-tykek)', () => {
+  it('approves every displayed plan before inbox.plan.apply_all', async () => {
+    await openOverlay();
+
+    fireEvent.click(await screen.findByTestId('plan-apply-all'));
+
+    await waitFor(() => expect(mockInboxPlanApplyAll).toHaveBeenCalled());
+    expect(mockPlansApprove.mock.calls.map((c) => c[0]).sort()).toEqual([
+      planA.planId,
+      planB.planId,
+    ]);
+    expectApprovedBefore(mockInboxPlanApplyAll);
+  });
+
+  it('approves the selected plans before inbox.plan.apply_selected', async () => {
+    await openOverlay();
+
+    fireEvent.click(await screen.findByTestId('plan-select-all'));
+    fireEvent.click(await screen.findByTestId('plan-apply-selected'));
+
+    await waitFor(() => expect(mockInboxPlanApplySelected).toHaveBeenCalled());
+    expect(mockPlansApprove.mock.calls.map((c) => c[0]).sort()).toEqual([
+      planA.planId,
+      planB.planId,
+    ]);
+    expectApprovedBefore(mockInboxPlanApplySelected);
+  });
+});

--- a/apps/desktop/src/features/inbox/store/index.ts
+++ b/apps/desktop/src/features/inbox/store/index.ts
@@ -49,7 +49,6 @@ export type {
 
 export {
   useInboxPlan,
-  useInboxPlanApply,
   useInboxPlanApplyAll,
   useInboxPlanCancel,
   useOpenInboxPlans,

--- a/apps/desktop/src/features/inbox/store/plans.ts
+++ b/apps/desktop/src/features/inbox/store/plans.ts
@@ -86,31 +86,6 @@ interface PlanApplyState {
   error: string | null;
 }
 
-/** Apply the open plan for a single inbox item. */
-export function useInboxPlanApply() {
-  const [state, setState] = useState<PlanApplyState>({
-    loading: false,
-    error: null,
-  });
-
-  const apply = useCallback(
-    async (inboxItemId: string): Promise<PlanApplyResponse | null> => {
-      setState({ loading: true, error: null });
-      try {
-        const result = unwrap(await commands.inboxPlanApply(inboxItemId));
-        setState({ loading: false, error: null });
-        return result;
-      } catch (e: unknown) {
-        setState({ loading: false, error: String(e) });
-        return null;
-      }
-    },
-    [],
-  );
-
-  return { ...state, apply };
-}
-
 /** Apply all plans currently in `plan_open` state. */
 export function useInboxPlanApplyAll() {
   const [state, setState] = useState<PlanApplyState>({

--- a/apps/desktop/src/features/inbox/useInboxPlanApplyFlow.ts
+++ b/apps/desktop/src/features/inbox/useInboxPlanApplyFlow.ts
@@ -17,6 +17,19 @@ import {
   useInboxPlanApplyAll,
   useInboxPlanCancel,
 } from './store';
+import type { InboxOpenPlan } from './store';
+
+/**
+ * Record the user's approval for every plan in a batch gesture before any of
+ * them is applied (Constitution II, `astro-plan-tykek`).
+ *
+ * Individual failures are swallowed: a plan already in `approved` state rejects
+ * a second `plans.approve` yet still carries a usable approval, and the backend
+ * refuses any plan that ends up without one, reporting it per plan.
+ */
+async function approvePlans(planIds: string[]): Promise<void> {
+  await Promise.allSettled(planIds.map((id) => commands.plansApprove(id)));
+}
 
 export interface PlanApplyFlowResult {
   handleApplyOne: (planId: string) => Promise<void>;
@@ -32,6 +45,7 @@ export interface PlanApplyFlowResult {
 export function useInboxPlanApplyFlow(
   refreshAll: () => void,
   viewResultAction: () => { label: string; onClick: () => void },
+  openPlans: InboxOpenPlan[],
 ): PlanApplyFlowResult {
   const { applyAll, loading: applyAllLoading } = useInboxPlanApplyAll();
   const { applySelected, loading: applySelectedLoading } =
@@ -79,6 +93,12 @@ export function useInboxPlanApplyFlow(
   const handleApplySelected = useCallback(
     async (inboxItemIds: string[]) => {
       if (inboxItemIds.length === 0) return;
+      const selectedSet = new Set(inboxItemIds);
+      await approvePlans(
+        openPlans
+          .filter((p) => selectedSet.has(p.inboxItemId))
+          .map((p) => p.planId),
+      );
       const result = await applySelected(inboxItemIds);
       if (result) {
         const failed = result.results.filter((r) => r.error != null).length;
@@ -104,10 +124,13 @@ export function useInboxPlanApplyFlow(
         addToast({ message: m.inbox_toast_apply_failed(), variant: 'error' });
       }
     },
-    [applySelected, refreshAll, viewResultAction],
+    [applySelected, openPlans, refreshAll, viewResultAction],
   );
 
   const handleApplyAll = useCallback(async () => {
+    // Only the plans the user was shown get an approval; anything that appeared
+    // since this render is refused by the backend rather than applied unseen.
+    await approvePlans(openPlans.map((p) => p.planId));
     const result = await applyAll();
     if (result) {
       const failed = result.results.filter((r) => r.error != null).length;
@@ -130,7 +153,7 @@ export function useInboxPlanApplyFlow(
       }
       refreshAll();
     }
-  }, [applyAll, refreshAll, viewResultAction]);
+  }, [applyAll, openPlans, refreshAll, viewResultAction]);
 
   const handleCancel = useCallback(
     async (inboxItemId: string) => {

--- a/crates/app/core/src/inbox_plan.rs
+++ b/crates/app/core/src/inbox_plan.rs
@@ -5,7 +5,7 @@
 //!
 //! Entry points:
 //! - `get_inbox_plan`       — fetch the plan linked to an inbox item as `InboxPlanView`.
-//! - `apply_inbox_plan`     — auto-approve then apply the linked plan; on
+//! - `apply_inbox_plan`     — apply the plan the caller has already approved; on
 //!   success marks the inbox item `resolved`.
 //! - `apply_all_inbox_plans`— apply every `plan_open` item's plan; per-plan results.
 //! - `cancel_inbox_plan`    — discard the linked plan; item returns to `classified`.
@@ -48,6 +48,16 @@ fn no_plan_err(inbox_item_id: &str) -> ContractError {
     ContractError::new(
         ErrorCode::InboxItemNoPlan,
         format!("no linked plan found for inbox item {inbox_item_id}"),
+        ErrorSeverity::Blocking,
+        false,
+    )
+}
+
+/// Refusal for an inbox apply whose plan carries no approval (Constitution II).
+fn approval_required_err(plan_id: &str) -> ContractError {
+    ContractError::new(
+        ErrorCode::PlanApprovalRequired,
+        format!("plan {plan_id} is not approved; approve it before applying"),
         ErrorSeverity::Blocking,
         false,
     )
@@ -140,25 +150,34 @@ pub async fn get_inbox_plan(
 
 // ── apply_inbox_plan ──────────────────────────────────────────────────────────
 
-/// `inbox.plan.apply` — auto-approve and apply the plan linked to this inbox item.
+/// `inbox.plan.apply` — apply the already-approved plan linked to this inbox item.
 ///
 /// Pipeline:
 /// 1. Resolve the linked plan.
-/// 2. Auto-approve (`ready_for_review` → `approved`) so the executor can run.
+/// 2. Read the approval the caller recorded via `plans.approve`; refuse when absent.
 /// 3. Call the existing `apply_plan` executor (CAS, staleness, audit).
 /// 4. The plan listener already handles `resolved` transition when the plan
 ///    reaches `applied` state — we don't set it here to avoid double-write.
+///
+/// Constitution II: this path must never approve on the user's behalf. It once
+/// called `approve_plan(actor = "inbox.apply")` itself, which both attributed
+/// the approval to the code rather than the person and made the approval-token
+/// gate in `apply_plan` unable to fail for every inbox apply
+/// (`astro-plan-tykek`). The mkdir-only auto-apply path
+/// (`crate::plans::auto_apply`) remains the one documented exception, and it
+/// does not route through here.
 ///
 /// Staleness (FR-007): the executor's CAS check fires per-item and transitions
 /// stale items to `stale` state, which surfaces as `plan.stale` error code.
 ///
 /// # Errors
 ///
-/// - `inbox.item.not_found` — item not found.
-/// - `inbox.item.no_plan`   — no linked plan.
-/// - `plan.invalid_state`   — plan not in approvable state.
-/// - `plan.stale`           — one or more source files changed since planning.
-/// - `internal.database`    — DB failure.
+/// - `inbox.item.not_found`     — item not found.
+/// - `inbox.item.no_plan`       — no linked plan.
+/// - `plan.approval_required`   — the plan carries no approval.
+/// - `plan.invalid_state`       — plan cannot be applied from its current state.
+/// - `plan.stale`               — one or more source files changed since planning.
+/// - `internal.database`        — DB failure.
 pub async fn apply_inbox_plan(
     pool: &SqlitePool,
     bus: &EventBus,
@@ -180,22 +199,12 @@ pub async fn apply_inbox_plan(
 
     let plan_id = link.plan_id;
 
-    // Auto-approve: transition ready_for_review → approved.
-    // This may fail if the plan is already approved (idempotent-ish) or in
-    // an incompatible state (e.g. already applied/discarded).
-    let approve_resp = crate::plans::approve_plan(pool, bus, &plan_id, "inbox.apply").await;
-
-    let approval_token = match approve_resp {
-        Ok(resp) => resp.approval_token,
-        // Already approved (idempotent-ish) — that's fine; the plan is in `approved`
-        // state, so fetch the stored token and carry through to apply_plan.
-        Err(e) if e.code == ErrorCode::PlanInvalidState => {
-            let plan_row =
-                plans_repo::get_plan(pool, &plan_id, false).await.map_err(db_err_internal)?;
-            plan_row.approval_token.unwrap_or_default()
-        }
-        Err(e) => return Err(e),
-    };
+    // Read the approval the caller recorded; never mint one here.
+    let plan_row = plans_repo::get_plan(pool, &plan_id, false).await.map_err(db_err_internal)?;
+    let approval_token = plan_row
+        .approval_token
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| approval_required_err(&plan_id))?;
 
     // Run the executor (CAS, audit, staleness).
     // The plan listener will catch `plan.applying.completed` and transition the
@@ -211,7 +220,8 @@ pub async fn apply_inbox_plan(
 ///
 /// Iterates items in `plan_open` state across roots, applies each plan
 /// sequentially. Returns per-plan results. Each action is individually audited
-/// by the executor.
+/// by the executor. A plan the caller has not approved is reported as a per-plan
+/// `plan.approval_required` error, not applied.
 ///
 /// # Errors
 ///
@@ -320,7 +330,8 @@ pub async fn list_open_inbox_plans(
 /// individual action. Iterates only the provided ids; ids that are not in
 /// `plan_open` state are reported as a per-item error (`plan.invalid_state`)
 /// rather than hard-failing the whole call, mirroring `apply_all_inbox_plans`'
-/// partial-failure semantics.
+/// partial-failure semantics. An id whose plan carries no approval is reported
+/// as `plan.approval_required`, not applied.
 ///
 /// # Errors
 /// Returns `internal.database` only if the membership query fails; per-plan
@@ -473,8 +484,13 @@ mod tests {
         f.write_all(&vec![b' '; pad]).unwrap();
     }
 
-    /// Set up a registered source + classified inbox item, returning (item_id, root_path).
-    async fn setup_classified_item(db: &Database) -> (String, PathBuf) {
+    /// Set up a registered source + classified inbox item, returning
+    /// `(item_id, root_path, tempdir)`.
+    ///
+    /// The `TempDir` is returned rather than dropped here: dropping it deletes
+    /// the fixture's files, so an apply test would run against a root that no
+    /// longer exists.
+    async fn setup_classified_item(db: &Database) -> (String, PathBuf, tempfile::TempDir) {
         let dir = tempdir().unwrap();
         let root_path = dir.path().to_path_buf();
         let item_dir = root_path.join("lights");
@@ -574,7 +590,7 @@ mod tests {
         .execute(db.pool())
         .await
         .unwrap();
-        (item_id.to_owned(), root_path)
+        (item_id.to_owned(), root_path, dir)
     }
 
     /// Confirm an item (creates the plan, sets state to plan_open).
@@ -598,7 +614,7 @@ mod tests {
     #[tokio::test]
     async fn confirm_creates_plan_link_and_plan_open_state() {
         let db = test_db().await;
-        let (item_id, root_path) = setup_classified_item(&db).await;
+        let (item_id, root_path, _dir) = setup_classified_item(&db).await;
 
         let plan_id = do_confirm(&db, &item_id, &root_path).await;
 
@@ -623,7 +639,7 @@ mod tests {
         let db = test_db().await;
         let bus = make_bus(db.pool());
         let _ = bus; // bus not needed for get
-        let (item_id, root_path) = setup_classified_item(&db).await;
+        let (item_id, root_path, _dir) = setup_classified_item(&db).await;
 
         let plan_id = do_confirm(&db, &item_id, &root_path).await;
 
@@ -638,7 +654,7 @@ mod tests {
     async fn cancel_inbox_plan_returns_to_classified() {
         let db = test_db().await;
         let bus = make_bus(db.pool());
-        let (item_id, root_path) = setup_classified_item(&db).await;
+        let (item_id, root_path, _dir) = setup_classified_item(&db).await;
 
         do_confirm(&db, &item_id, &root_path).await;
 
@@ -666,7 +682,7 @@ mod tests {
     async fn cancel_does_not_report_classified_without_a_frame_type_sc003() {
         let db = test_db().await;
         let bus = make_bus(db.pool());
-        let (item_id, root_path) = setup_classified_item(&db).await;
+        let (item_id, root_path, _dir) = setup_classified_item(&db).await;
 
         sqlx::query("UPDATE inbox_items SET frame_type = NULL WHERE id = ?")
             .bind(&item_id)
@@ -689,7 +705,7 @@ mod tests {
     #[tokio::test]
     async fn get_inbox_plan_errors_when_no_plan_linked() {
         let db = test_db().await;
-        let (item_id, _) = setup_classified_item(&db).await;
+        let (item_id, _, _dir) = setup_classified_item(&db).await;
 
         let err = get_inbox_plan(db.pool(), &item_id).await.unwrap_err();
         assert_eq!(err.code, ErrorCode::InboxItemNoPlan);
@@ -701,7 +717,7 @@ mod tests {
     async fn cancel_inbox_plan_errors_when_no_plan_linked() {
         let db = test_db().await;
         let bus = make_bus(db.pool());
-        let (item_id, _) = setup_classified_item(&db).await;
+        let (item_id, _, _dir) = setup_classified_item(&db).await;
 
         let err = cancel_inbox_plan(db.pool(), &bus, &item_id).await.unwrap_err();
         assert_eq!(err.code, ErrorCode::InboxItemNoPlan);
@@ -851,7 +867,7 @@ mod tests {
     #[tokio::test]
     async fn list_open_keeps_confirmed_placeholder_with_materialized_sub_item() {
         let db = test_db().await;
-        let (item_id, root_path) = setup_classified_item(&db).await;
+        let (item_id, root_path, _dir) = setup_classified_item(&db).await;
 
         // Give the placeholder a source group and materialize the single-type
         // sub-item classify would have written for it.
@@ -917,7 +933,7 @@ mod tests {
     #[tokio::test]
     async fn list_open_reaches_a_confirmed_sub_item_of_a_split_folder() {
         let db = test_db().await;
-        let (placeholder_id, root_path) = setup_classified_item(&db).await;
+        let (placeholder_id, root_path, _dir) = setup_classified_item(&db).await;
         let root_id = "root-plan-test";
 
         inbox_repo::upsert_inbox_source_group(
@@ -1010,8 +1026,12 @@ mod tests {
 
         let (id_a, root_a) = setup_classified_item_suffixed(&db, "a").await;
         let (id_b, root_b) = setup_classified_item_suffixed(&db, "b").await;
-        do_confirm(&db, &id_a, &root_a).await;
+        let plan_a = do_confirm(&db, &id_a, &root_a).await;
         do_confirm(&db, &id_b, &root_b).await;
+
+        // The production sequence: the user's Apply gesture records the approval
+        // (`plans.approve`) before the batch apply runs.
+        crate::plans::approve_plan(db.pool(), &bus, &plan_a, "user").await.unwrap();
 
         let resp =
             apply_selected_inbox_plans(db.pool(), &bus, std::slice::from_ref(&id_a)).await.unwrap();
@@ -1053,5 +1073,68 @@ mod tests {
         assert_eq!(r.inbox_item_id, item_id);
         assert!(r.error.is_some(), "non-plan_open id should yield a per-item error");
         assert_eq!(r.error.as_deref(), Some("plan.invalid_state"));
+    }
+
+    // ── Constitution II: application is explicit (astro-plan-tykek) ──────────
+
+    /// The production inbox apply must refuse a plan the user never approved.
+    ///
+    /// `inbox.confirm` leaves the plan at `ready_for_review`. Before the fix this
+    /// path minted its own approval, so no inbox apply could ever be refused.
+    #[tokio::test]
+    async fn apply_inbox_plan_refuses_a_plan_the_user_never_approved() {
+        let db = test_db().await;
+        let bus = make_bus(db.pool());
+        let (item_id, root_path, _dir) = setup_classified_item(&db).await;
+
+        let plan_id = do_confirm(&db, &item_id, &root_path).await;
+
+        let err = apply_inbox_plan(db.pool(), &bus, &item_id)
+            .await
+            .expect_err("an unapproved plan must not apply");
+        assert_eq!(err.code, ErrorCode::PlanApprovalRequired);
+
+        let row = plans_repo::get_plan(db.pool(), &plan_id, false).await.unwrap();
+        assert_eq!(
+            row.state, "ready_for_review",
+            "the refused plan must stay reviewable, not advance to applying"
+        );
+        assert!(row.approval_token.is_none(), "the refusal must not record an approval");
+    }
+
+    /// The same call succeeds once the user's approval is on record, so the
+    /// refusal above gates on the approval rather than on the inbox path itself.
+    #[tokio::test]
+    async fn apply_inbox_plan_applies_after_an_explicit_approval() {
+        let db = test_db().await;
+        let bus = make_bus(db.pool());
+        let (item_id, root_path, _dir) = setup_classified_item(&db).await;
+
+        let plan_id = do_confirm(&db, &item_id, &root_path).await;
+        crate::plans::approve_plan(db.pool(), &bus, &plan_id, "user").await.unwrap();
+
+        let resp =
+            apply_inbox_plan(db.pool(), &bus, &item_id).await.expect("an approved plan must apply");
+        assert_eq!(resp.plan_id, plan_id);
+        assert_ne!(
+            resp.new_state, "ready_for_review",
+            "the approved plan must leave the review state"
+        );
+    }
+
+    /// The batch path the Inbox UI actually calls inherits the same refusal.
+    #[tokio::test]
+    async fn apply_selected_refuses_a_plan_the_user_never_approved() {
+        let db = test_db().await;
+        let bus = make_bus(db.pool());
+        let (item_id, root_path) = setup_classified_item_suffixed(&db, "unapproved").await;
+        do_confirm(&db, &item_id, &root_path).await;
+
+        let resp = apply_selected_inbox_plans(db.pool(), &bus, std::slice::from_ref(&item_id))
+            .await
+            .unwrap();
+
+        assert_eq!(resp.results.len(), 1);
+        assert_eq!(resp.results[0].error.as_deref(), Some("plan.approval_required"));
     }
 }

--- a/crates/app/core/src/plans/auto_apply.rs
+++ b/crates/app/core/src/plans/auto_apply.rs
@@ -49,10 +49,12 @@ where
 /// Auto-approve and start applying a freshly persisted plan when (and only
 /// when) it qualifies under [`plan_qualifies_for_mkdir_auto_apply`].
 ///
+/// This is the ONLY path permitted to approve without a user gesture; the Inbox
+/// apply pipeline used to do the same and no longer does (`astro-plan-tykek`).
+///
 /// Returns `Ok(None)` when the plan does not qualify — the normal review flow
 /// is untouched. When it qualifies, this drives the SAME [`super::approve_plan`] and
-/// [`crate::plan_apply::apply_plan`] use-cases as the manual path (mirroring
-/// the Inbox pipeline in `crate::inbox_plan::apply_inbox_plan`), so the plan
+/// [`crate::plan_apply::apply_plan`] use-cases as the manual path, so the plan
 /// row, the `plan.approved` audit event (actor [`AUTO_APPLY_MKDIR_ACTOR`]),
 /// the per-item apply audit records, and the failure handling are identical
 /// to a user-clicked apply. A failed auto-apply surfaces exactly like a

--- a/crates/app/core/tests/confirm_master_integration.rs
+++ b/crates/app/core/tests/confirm_master_integration.rs
@@ -23,7 +23,8 @@ use std::path::Path;
 
 use app_core::calibration::masters_list;
 use app_core::inbox::confirm::{confirm, ConfirmRequest};
-use app_core::inbox_plan::apply_inbox_plan;
+use app_core::inbox_plan::{apply_inbox_plan, get_inbox_plan};
+use app_core::plans::approve_plan;
 use audit::bus::EventBus;
 use persistence_core::Database;
 use persistence_inbox::repositories::inbox::{
@@ -181,6 +182,11 @@ async fn insert_master_inbox_item(
 /// Drive apply to completion. The plan listener (started by the caller before
 /// apply) consumes `plan.applying.completed` and registers the master.
 async fn apply_and_register(db: &Database, bus: &EventBus, item_id: &str) {
+    // Constitution II (astro-plan-tykek): the apply path refuses a plan the user
+    // has not approved, so record the approval the UI's Apply gesture records.
+    let plan_id = get_inbox_plan(db.pool(), item_id).await.unwrap().plan_id;
+    approve_plan(db.pool(), bus, &plan_id, "user").await.unwrap();
+
     let resp = apply_inbox_plan(db.pool(), bus, item_id).await.unwrap();
     // The executor finishes, publishes TOPIC_PLAN_APPLYING_COMPLETED, then the
     // plan listener runs its registration callback asynchronously. Poll for the

--- a/crates/e2e-tests/tests/inventory_journeys.rs
+++ b/crates/e2e-tests/tests/inventory_journeys.rs
@@ -147,7 +147,7 @@ async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow
         .ok_or_else(|| anyhow::anyhow!("inbox.classify returned no contentSignature: {classify}"))?
         .to_owned();
 
-    let _confirm: serde_json::Value = app
+    let confirm: serde_json::Value = app
         .invoke(
             "inbox_confirm",
             json!({
@@ -162,6 +162,10 @@ async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow
         )
         .await?;
 
+    // Constitution II (astro-plan-tykek): `inbox.plan.apply` refuses a plan the
+    // caller has not approved, mirroring the UI's approve-then-apply gesture.
+    let _: serde_json::Value =
+        app.invoke("plans_approve", json!({ "id": confirm["planId"] })).await?;
     let _apply: serde_json::Value =
         app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
     anyhow::ensure!(

--- a/crates/e2e-tests/tests/journeys.rs
+++ b/crates/e2e-tests/tests/journeys.rs
@@ -144,13 +144,14 @@ async fn first_run_resolve_create_project() -> anyhow::Result<()> {
 /// Filesystem plan review → apply → durable-record assertion.
 ///
 /// Backend REAL: `roots.register`, `sources.set_organization_state`,
-/// `inbox.scan.folder`, `inbox.classify`, `inbox.confirm`,
+/// `inbox.scan.folder`, `inbox.classify`, `inbox.confirm`, `plans.approve`,
 /// `inbox.plan.apply`, `plans.apply.status`.
 ///
-/// `inbox.plan.apply` (not `plans.apply_real`) is the mutating step: it
-/// auto-approves the confirmed plan and calls the SAME `apply_plan` core
-/// function `plans.apply_real` uses, just without a progress `Channel` — the
-/// exact real, channel-free equivalent this journey needs (see module docs).
+/// `inbox.plan.apply` (not `plans.apply_real`) is the mutating step: it calls the
+/// SAME `apply_plan` core function `plans.apply_real` uses, just without a
+/// progress `Channel` — the exact real, channel-free equivalent this journey
+/// needs (see module docs). It refuses a plan that carries no approval, so the
+/// journey approves first, as the UI does.
 #[tokio::test]
 #[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
 async fn plan_review_apply_with_audit() -> anyhow::Result<()> {
@@ -250,6 +251,10 @@ async fn plan_review_apply_with_audit() -> anyhow::Result<()> {
     anyhow::ensure!(!plan_id.is_empty(), "expected a real (non-empty) plan id: {confirm}");
 
     // 3. Apply — the real filesystem mutation (FR-009).
+    // Constitution II (astro-plan-tykek): `inbox.plan.apply` refuses a plan the
+    // caller has not approved, mirroring the UI's approve-then-apply gesture.
+    let _: serde_json::Value =
+        app.invoke("plans_approve", json!({ "id": confirm["planId"] })).await?;
     let apply: serde_json::Value =
         app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
     anyhow::ensure!(
@@ -369,7 +374,7 @@ async fn ingestion_sessions_search() -> anyhow::Result<()> {
         .ok_or_else(|| anyhow::anyhow!("inbox.classify returned no contentSignature: {classify}"))?
         .to_owned();
 
-    let _: serde_json::Value = app
+    let confirm: serde_json::Value = app
         .invoke(
             "inbox_confirm",
             json!({
@@ -384,6 +389,10 @@ async fn ingestion_sessions_search() -> anyhow::Result<()> {
         )
         .await?;
 
+    // Constitution II (astro-plan-tykek): `inbox.plan.apply` refuses a plan the
+    // caller has not approved, mirroring the UI's approve-then-apply gesture.
+    let _: serde_json::Value =
+        app.invoke("plans_approve", json!({ "id": confirm["planId"] })).await?;
     let _: serde_json::Value =
         app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
 

--- a/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
+++ b/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
@@ -106,7 +106,7 @@ async fn setup_project_library_and_one_session(app: &E2eApp) -> anyhow::Result<s
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("inbox.classify returned no contentSignature: {classify}"))?
         .to_owned();
-    let _: serde_json::Value = app
+    let confirm: serde_json::Value = app
         .invoke(
             "inbox_confirm",
             json!({
@@ -120,6 +120,10 @@ async fn setup_project_library_and_one_session(app: &E2eApp) -> anyhow::Result<s
             }),
         )
         .await?;
+    // Constitution II (astro-plan-tykek): `inbox.plan.apply` refuses a plan the
+    // caller has not approved, mirroring the UI's approve-then-apply gesture.
+    let _: serde_json::Value =
+        app.invoke("plans_approve", json!({ "id": confirm["planId"] })).await?;
     let _: serde_json::Value =
         app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
 

--- a/crates/e2e-tests/tests/sessions_journeys.rs
+++ b/crates/e2e-tests/tests/sessions_journeys.rs
@@ -163,7 +163,7 @@ async fn sessions_ui_derived_view_invariants() -> anyhow::Result<()> {
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("inbox.classify returned no contentSignature: {classify}"))?
         .to_owned();
-    let _: serde_json::Value = app
+    let confirm: serde_json::Value = app
         .invoke(
             "inbox_confirm",
             json!({
@@ -177,6 +177,10 @@ async fn sessions_ui_derived_view_invariants() -> anyhow::Result<()> {
             }),
         )
         .await?;
+    // Constitution II (astro-plan-tykek): `inbox.plan.apply` refuses a plan the
+    // caller has not approved, mirroring the UI's approve-then-apply gesture.
+    let _: serde_json::Value =
+        app.invoke("plans_approve", json!({ "id": confirm["planId"] })).await?;
     let _: serde_json::Value =
         app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
 

--- a/crates/e2e-tests/tests/source_view_journeys.rs
+++ b/crates/e2e-tests/tests/source_view_journeys.rs
@@ -184,6 +184,10 @@ async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<(
         "expected a real (non-empty) plan id from inbox.confirm: {confirm}"
     );
 
+    // Constitution II (astro-plan-tykek): `inbox.plan.apply` refuses a plan the
+    // caller has not approved, mirroring the UI's approve-then-apply gesture.
+    let _: serde_json::Value =
+        app.invoke("plans_approve", json!({ "id": confirm["planId"] })).await?;
     let _apply: serde_json::Value =
         app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
     anyhow::ensure!(

--- a/e2e-agentic-test/025-filesystem-plan-application/plan-overlap-guard/scenario.md
+++ b/e2e-agentic-test/025-filesystem-plan-application/plan-overlap-guard/scenario.md
@@ -39,6 +39,10 @@ merged: report BLOCKED, do not improvise.
    longer — wait for the detail to resolve).
 5. Confirm all three items (each produces one plan; single root →
    auto-selected). Verify `inbox_plan_list_open` shows 3 plans.
+6. Approve each of the three plans via `plans_approve` (`{ id: PLAN_ID }`).
+   `inbox_plan_apply` refuses a plan that carries no approval with
+   `plan.approval_required` (astro-plan-tykek), so this stands in for the
+   Apply gesture the UI performs.
 
 ## Stage 1 — Agent validation via Tauri MCP
 
@@ -74,7 +78,8 @@ merged: report BLOCKED, do not improvise.
    step 1 completes, re-read `inbox_plan_list_open`.
    - Expected: B's plan still open/approved (not stale, not errored, not
      half-applied); now `invoke('inbox_plan_apply', {…B_ID…})` alone
-     SUCCEEDS; B's 2 files land under
+     SUCCEEDS (re-`plans_approve` B first if the rejection cleared its
+     approval); B's 2 files land under
      `test-data\library-lights\NGC 7000\Ha\...\light\` (WSL `find`), and no
      duplicate/partial artifacts exist.
    - FAIL if: B is stuck (registry leak — the guard didn't clean up), or


### PR DESCRIPTION
## Summary

- Applying an Inbox plan no longer proceeds without the user's approval on
  record. The Inbox apply path approved the plan on the user's behalf, so the
  approval check could never refuse, and the audit trail credited the approval to
  the code rather than to the person.
- The Apply gesture is unchanged: still one click, and the recorded approver is
  now `user`.

## What changed

`apply_inbox_plan` called `approve_plan(actor = "inbox.apply")` and passed the
token it had just created to `apply_plan`, so `verify_approval_token` could not
fail for any of the three commands the Inbox UI reaches: `inbox.plan.apply`,
`inbox.plan.apply_all`, `inbox.plan.apply_selected`. Filesystem mutation
therefore ran without the explicit approval Constitution II requires.

`apply_inbox_plan` now reads the approval the caller recorded and refuses with
`plan.approval_required` when the plan carries none
(`crates/app/core/src/inbox_plan.rs:186-191`). The batch handlers record the
user's approval for the plans they displayed before calling the batch command
(`apps/desktop/src/features/inbox/useInboxPlanApplyFlow.ts:30-32`, `:96-102`,
`:131-133`), the same approve-then-apply shape `handleApplyOne` has used since
&#35;769 / &#35;609. A plan that appeared after the render the user reviewed is
refused rather than applied unseen.

The mkdir-only auto-apply path (`crates/app/core/src/plans/auto_apply.rs`, user
decision 2026-07-04) is untouched and remains the one documented exception.

Resolves `astro-plan-tykek`. Merge bead: `astro-plan-9uhth`.

## The finding was real, and wider than filed

The bead named `apps/desktop/src/features/inbox/store/plans.ts:100` as the
production path. That call site is `useInboxPlanApply`, and it had no component
consumer — the single-plan Apply button already went through `plans.approve` plus
`plans_apply_real` (`useInboxPlanApplyFlow.ts:57-73` at base) and was explicit.
The live defect is on the two batch buttons in `PlanPanel`
(`plan-apply-selected`, `plan-apply-all`), which do reach the self-minted
approval. Command run here: `rg -n 'useInboxPlanApply\b' apps/desktop` returned
only the definition and the barrel export.

## Also in this change

- `setup_classified_item` returns its `TempDir` rather than dropping it at
  return, which deleted the fixture's files before any test used them
  (`crates/app/core/src/inbox_plan.rs:493`).
- `useInboxPlanApply` is deleted along with its barrel export: no consumer, and
  it would now always fail.
- Six e2e journey call sites and `confirm_master_integration`'s
  `apply_and_register` helper approve before applying, as the UI does.
  Enumerated with
  `rg -n 'inbox_plan_apply' --glob '!**/node_modules/**' --glob '!**/bindings/**' .`
  — 30 hits, of which six are Rust `app.invoke` sites: `journeys.rs:254`,
  `journeys.rs:388`, `sessions_journeys.rs:181`, `lifecycle_ui_journeys.rs:128`,
  `inventory_journeys.rs:170`, `source_view_journeys.rs:192` (pre-edit line
  numbers).
- `e2e-agentic-test/025-filesystem-plan-application/plan-overlap-guard/scenario.md`
  gains an approval step; without it the scenario now fails before it reaches the
  overlap guard.
- Regenerated `apps/desktop/src/bindings/index.ts` for the changed command doc.

## Tests, each confirmed failing with the fix reverted

Rust, `crates/app/core/src/inbox_plan.rs`:

- `apply_inbox_plan_refuses_a_plan_the_user_never_approved` — with the mint
  restored: FAILS, `PlanApplyResponse { new_state: "applying" }`.
- `apply_selected_refuses_a_plan_the_user_never_approved` — with the mint
  restored: FAILS, `left: None, right: Some("plan.approval_required")`.
- `apply_inbox_plan_applies_after_an_explicit_approval` — cannot fail at base,
  because the base auto-approves. Discrimination was proved instead against a
  WRONG implementation that always refuses: FAILS with `PlanApprovalRequired`.
  `apply_selected_applies_only_named_items` (pre-existing, now approves first)
  also fails against that wrong implementation.

TypeScript, `apps/desktop/src/features/inbox/__tests__/InboxPage.applyBatch.test.tsx`:

- `approves every displayed plan before inbox.plan.apply_all` and
  `approves the selected plans before inbox.plan.apply_selected` — with the two
  `approvePlans` calls removed: both FAIL,
  `expected ["plan-001","plan-002"] received []`.

## Verification, in this worktree at 9b7a19f5

| Command | Result |
| --- | --- |
| `cargo test -p app_core -p app_core_inbox` | exit 0 |
| `cargo test -p app_core --lib inbox_plan` | 14 passed, exit 0 |
| `cargo clippy -p app_core -p app_core_inbox --all-targets` | exit 0, no warnings |
| `cargo fmt --all -- --check` | exit 0 |
| `cargo check -p e2e_tests --tests` | exit 0 |
| `pnpm vitest run src/features/inbox` | 41 files, 276 tests passed |
| `pnpm tsc --noEmit` | exit 0 |
| `pnpm biome check` on the 5 edited TS files | exit 0 |
| `bash scripts/precommit-verify.sh` on the 16 changed files | exit 0 |
| `bash scripts/check-db-boundary.sh` | exit 0, 0 sites across 427 files |
| `bash scripts/check-generated-drift.sh` | exit 0 after the bindings commit |
| `git merge origin/main` | already up to date, no conflicted file |

The precommit hooks that actually RAN: added-large-files, detect-private-key,
end-of-files, trailing-whitespace, gitleaks, typos. The json, toml and yaml hooks
reported no matching files. The typos hook caught one word I had introduced and
it is fixed; the pre-existing `appliable` failure in
`crates/app/inbox/src/confirm.rs` (`astro-plan-8vxx1`) is untouched.

Not executed: the e2e journeys are `#[ignore]`d Layer-2 tests needing
tauri-webdriver and a served frontend, so they were compile-checked only. The
`plan-overlap-guard` agentic scenario was not run.

Merge-Bead: astro-plan-9uhth
Tracks-Bead: astro-plan-tykek
Closes-Bead: astro-plan-tykek
