### PR TITLE
test(e2e): cover the settings tool-enablement transition in mock mode

### DIFF
--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -46,6 +46,9 @@ import type {
   RegisterSourceBatchResponse_Serialize,
   RemapVerification,
   ToolPathValidation,
+  ToolProfileSummary,
+  ToolProfileListResponse,
+  ToolDiscoverResponse,
   IpcOperationHandle,
   OperationEvent,
   PlanApplyResponse,
@@ -454,6 +457,45 @@ function mockContractError(code: string, message: string): never {
 // live in ./mocks/inbox.ts and are imported above.
 
 let mockInboxOpenPlans: InboxOpenPlan[] = seedInboxOpenPlans();
+
+// ── Processing-tool profiles (spec 011) — stateful mock ───────────────────────
+//
+// Seeded UNCONFIGURED on purpose. The disabled "Open in {tool}" CTA and its
+// `Tool path not configured` hint are the default state every project spec
+// asserts, so a seed with a path would silently retire that coverage. The
+// Settings save path (`tools_update`) is what flips a profile to configured,
+// which is the transition spec 011 T018 covers.
+
+/** Path `tools_discover` reports per tool id; anything else gets `/mock/bin/<id>`. */
+const MOCK_DISCOVERED_TOOL_PATHS: Record<string, string> = {
+  pixinsight: '/Applications/PixInsight/PixInsight.app',
+  siril: '/usr/local/bin/siril',
+};
+
+let mockToolProfiles: ToolProfileSummary[] = [
+  {
+    id: 'pixinsight',
+    name: 'PixInsight',
+    configured: false,
+    available: false,
+    supportsOpenFolder: true,
+    enabled: true,
+    autoDetected: false,
+    executablePath: null,
+    watchExtensions: ['xisf', 'fit', 'fits', 'tif', 'tiff'],
+  },
+  {
+    id: 'siril',
+    name: 'Siril',
+    configured: false,
+    available: false,
+    supportsOpenFolder: true,
+    enabled: true,
+    autoDetected: false,
+    executablePath: null,
+    watchExtensions: ['fit', 'fits', 'tif', 'tiff'],
+  },
+];
 
 /**
 /**
@@ -1620,6 +1662,56 @@ const mockHandlers = {
       // existing directories).
       isDir: valid ? true : null,
     } satisfies ToolPathValidation;
+  },
+  tools_list: async () => {
+    return { tools: mockToolProfiles } satisfies ToolProfileListResponse;
+  },
+  tools_discover: async (_args) => {
+    // Discovery reports candidate paths and does NOT persist them: the
+    // ProcessingTools pane pre-fills empty inputs from this response and the
+    // user still has to save. Mutating state here would make the pane's
+    // "auto-detected, unsaved" state unreachable in mock mode, which is the
+    // state the save step exists to leave.
+    const req = (_args?.request as { toolId?: string | null }) ?? {};
+    const only = req.toolId ?? null;
+    return {
+      entries: mockToolProfiles
+        .filter((t) => only === null || t.id === only)
+        .map((t) => ({
+          toolId: t.id,
+          path: MOCK_DISCOVERED_TOOL_PATHS[t.id] ?? `/mock/bin/${t.id}`,
+          available: true,
+        })),
+    } satisfies ToolDiscoverResponse;
+  },
+  tools_update: async (_args) => {
+    const req =
+      (_args?.request as {
+        id?: string;
+        path?: string | null;
+        enabled?: boolean;
+      }) ?? {};
+    const id = req.id ?? '';
+    const index = mockToolProfiles.findIndex((t) => t.id === id);
+    if (index === -1) throw new Error(`mock tools_update: unknown tool ${id}`);
+    const path = req.path?.trim() ? req.path.trim() : null;
+    const updated: ToolProfileSummary = {
+      ...mockToolProfiles[index],
+      executablePath: path,
+      configured: path !== null,
+      // Mock mode has no filesystem, so a configured path is always present.
+      // `available` therefore tracks `configured`, which is what makes the
+      // project CTA flip from disabled to enabled after a save.
+      available: path !== null,
+      // A saved path is no longer a mere auto-detect suggestion, regardless of
+      // where the string came from.
+      autoDetected: false,
+      enabled: req.enabled ?? mockToolProfiles[index].enabled,
+    };
+    mockToolProfiles = mockToolProfiles.map((t, i) =>
+      i === index ? updated : t,
+    );
+    return updated satisfies ToolProfileSummary;
   },
   firstrun_complete: async () => {
     return {

--- a/scripts/mock-unmocked-baseline.txt
+++ b/scripts/mock-unmocked-baseline.txt
@@ -73,7 +73,4 @@ target_resolution_settings
 target_resolution_settings_update
 target_resolve_explicit
 target_sessions_list
-tools_discover
 tools_launch
-tools_list
-tools_update

--- a/tests/e2e/project_tool_launch_disabled.spec.ts
+++ b/tests/e2e/project_tool_launch_disabled.spec.ts
@@ -26,10 +26,10 @@
  * all — a layout defect tracked as astro-plan-ltlo, not something this spec
  * locks in.
  *
- * Mock wiring: `tools_list` has no mock handler, so `useToolProfiles()`
- * degrades to no profile and `toolLaunchDisabledReason()` returns
- * `not_configured` — the same path `project_lifecycle_surfaces.spec.ts`
- * documents.
+ * Mock wiring: `tools_list` seeds every profile unconfigured, so
+ * `toolLaunchDisabledReason()` returns `not_configured` — the same path
+ * `project_lifecycle_surfaces.spec.ts` documents. The save step that flips a
+ * profile to configured is covered by `settings_tool_enablement.spec.ts`.
  */
 import {
   test,

--- a/tests/e2e/settings_tool_enablement.spec.ts
+++ b/tests/e2e/settings_tool_enablement.spec.ts
@@ -1,0 +1,151 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Spec 011 T018 — Settings tool-enablement flow: auto-detect → save → the
+ * project CTA enables.
+ *
+ * The companion spec (`project_tool_launch_disabled.spec.ts`) pins the
+ * disabled end of this behaviour. This one drives the transition, so a
+ * regression in `ProcessingTools` wiring or in profile persistence fails a
+ * test instead of leaving every project spec on the never-configured path.
+ *
+ * What each step distinguishes:
+ *
+ *   1. Auto-detect fills the path input WITHOUT persisting. The pane marks the
+ *      row `Auto-detected` and the project CTA is still disabled, because a
+ *      discovery suggestion the user has not accepted must not enable a launch.
+ *   2. Saving the filled path (Enter) persists it. The `Auto-detected` pill
+ *      gives way to `Available`, which is the pane's own read of
+ *      `configured && available` coming back from the backend rather than
+ *      local input state.
+ *   3. Only then does the CTA on an unrelated route enable and its hint
+ *      disappear. Asserting this after a navigation is the point: it proves
+ *      the enablement came from the persisted profile, not from React state
+ *      left over in the Settings pane.
+ *
+ * Viewport: 1600x900, matching the companion spec — at the default 1280x820
+ * the CTA hint sits below the fold with no scrollable ancestor
+ * (astro-plan-ltlo).
+ */
+import {
+  test,
+  expect,
+  seedSetupComplete,
+  disableOnboarding,
+} from './support/harness';
+
+const DETECTED_PIXINSIGHT_PATH = '/Applications/PixInsight/PixInsight.app';
+
+test.beforeEach(async ({ page }) => {
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await disableOnboarding(page);
+  seedSetupComplete(page);
+});
+
+/** Open the project whose `tool` resolves to the `pixinsight` profile. */
+async function openNarrowbandProject(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  await page.goto('/#/projects');
+  const row = page
+    .locator('[data-kind="projects-table-row"]')
+    .filter({ hasText: 'NGC 7000 Narrowband' })
+    .first();
+  await expect(row).toBeVisible({ timeout: 8_000 });
+  await row.click();
+  await expect(page.getByTestId('tool-launch-btn')).toBeVisible({
+    timeout: 8_000,
+  });
+}
+
+test.describe('spec 011 · Settings tool enablement', () => {
+  test('auto-detect fills the path without enabling, and saving it enables the project CTA', async ({
+    page,
+  }) => {
+    // Baseline: no profile is configured, so the CTA is inert and says why.
+    await openNarrowbandProject(page);
+    await expect(page.getByTestId('tool-launch-btn')).toBeDisabled();
+    await expect(page.getByTestId('tool-launch-footer')).toContainText(
+      'Tool path not configured',
+    );
+
+    await page.goto('/#/settings/tools');
+    const pathInput = page.getByLabel('Executable path for PixInsight');
+    await expect(pathInput).toBeVisible({ timeout: 8_000 });
+    await expect(pathInput).toHaveValue('');
+
+    // Step 1 — discovery suggests a path but persists nothing.
+    await page.getByLabel('Re-run auto-detect for all tools').click();
+    await expect(pathInput).toHaveValue(DETECTED_PIXINSIGHT_PATH);
+    const pixinsightRow = page
+      .getByTestId('settings-row')
+      .filter({ hasText: 'PixInsight' })
+      .first();
+    await expect(pixinsightRow).toContainText('Auto-detected');
+    await expect(pixinsightRow).not.toContainText('Available');
+
+    // An unsaved suggestion must not enable a launch: navigate away and back
+    // so the CTA re-reads the persisted profile rather than any local state.
+    await openNarrowbandProject(page);
+    await expect(page.getByTestId('tool-launch-btn')).toBeDisabled();
+    await expect(page.getByTestId('tool-launch-footer')).toContainText(
+      'Tool path not configured',
+    );
+
+    // Step 2 — accept the suggestion. Enter commits, per ProcessingTools'
+    // onKeyDown save; the pill flipping to `Available` is the pane reading the
+    // saved profile back, not echoing the input.
+    await page.goto('/#/settings/tools');
+    const savedInput = page.getByLabel('Executable path for PixInsight');
+    await expect(savedInput).toBeVisible({ timeout: 8_000 });
+    await savedInput.fill(DETECTED_PIXINSIGHT_PATH);
+    await savedInput.press('Enter');
+    const savedRow = page
+      .getByTestId('settings-row')
+      .filter({ hasText: 'PixInsight' })
+      .first();
+    await expect(savedRow).toContainText('Available', { timeout: 8_000 });
+    await expect(savedRow).not.toContainText('Auto-detected');
+
+    // Step 3 — the CTA is now live and the explanatory hint is gone.
+    await openNarrowbandProject(page);
+    const btn = page.getByTestId('tool-launch-btn');
+    await expect(btn).toBeEnabled({ timeout: 8_000 });
+    await expect(btn).toHaveText('Open in PixInsight');
+    await expect(page.getByTestId('tool-launch-footer')).toHaveCount(0);
+  });
+
+  test('a tool the user disabled stays unlaunchable even with a saved path', async ({
+    page,
+  }) => {
+    // #656 in the browser: the toggle is authoritative over a configured path.
+    // `toolLaunchDisabledReason` checks `enabled` before `configured`, so the
+    // copy must fall back to `not configured` rather than claiming the
+    // executable is missing.
+    await page.goto('/#/settings/tools');
+    const pathInput = page.getByLabel('Executable path for PixInsight');
+    await expect(pathInput).toBeVisible({ timeout: 8_000 });
+    await pathInput.fill(DETECTED_PIXINSIGHT_PATH);
+    await pathInput.press('Enter');
+    const row = page
+      .getByTestId('settings-row')
+      .filter({ hasText: 'PixInsight' })
+      .first();
+    await expect(row).toContainText('Available', { timeout: 8_000 });
+
+    // Click the toggle's label, not its input: `Toggle` hides the checkbox
+    // behind a styled track, so the input is never visible and a click on it
+    // is not the gesture a user makes.
+    const toggle = row.getByTestId('toggle');
+    await expect(toggle.getByLabel('Enable PixInsight')).toBeChecked();
+    await toggle.click();
+    await expect(toggle.getByLabel('Enable PixInsight')).not.toBeChecked();
+
+    await openNarrowbandProject(page);
+    await expect(page.getByTestId('tool-launch-btn')).toBeDisabled();
+    await expect(page.getByTestId('tool-launch-footer')).toContainText(
+      'Tool path not configured',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Recovers uncommitted work from the reclaimed checkout `test/4kbt-tool-workflow-smoke` (`astro-plan-2cy4e`). PR #1675 landed only `tests/e2e/project_tool_launch_disabled.spec.ts`; the mock wiring and the transition spec below never reached a commit and existed only as working-tree changes.

- `tests/e2e/settings_tool_enablement.spec.ts` (new, 2 tests): drives auto-detect → save → the project CTA enables, and asserts a user-disabled tool stays unlaunchable even with a saved path. `project_tool_launch_disabled.spec.ts` pins the disabled end; nothing drove the transition, so a regression in `ProcessingTools` wiring or in profile persistence left every project spec on the never-configured path and failed no test.
- `apps/desktop/src/api/mocks.ts` (+92): stateful mock for `tools_list`, `tools_discover`, `tools_update`. Seeded UNCONFIGURED on purpose — the disabled CTA and its `Tool path not configured` hint are the default state the other project specs assert, and a seeded path would silently retire that coverage. `tools_discover` reports candidate paths without persisting, which keeps the pane's auto-detected-but-unsaved state reachable.
- `scripts/mock-unmocked-baseline.txt` (-3): drops `tools_discover`, `tools_list`, `tools_update` now that they are mocked.
- `tests/e2e/project_tool_launch_disabled.spec.ts` (4+/4-): its comment claimed `tools_list` has no mock handler. That is no longer true, so the comment is corrected.

No production code changes. No schema change.

## Verification

Worktree at `origin/main` = `c0f7e10ea`. All exit codes 0.

- `pnpm exec playwright test settings_tool_enablement` — 2 passed.
- Revert check, per test: with `apps/desktop/src/api/mocks.ts` reverted to `main` and both tests kept, **2 failed** (`Executable path for PixInsight` label never becomes visible). Both new tests discriminate; neither is vacuous.
- `pnpm exec playwright test project_tool_launch_disabled` — 3 passed (the companion spec still holds after the mock stopped being absent).
- `node scripts/check-mock-baseline.mjs` — OK, 202 commands, 135 mocked, 67 unmocked and baselined.
- `bash scripts/check-pv-selector-ratchet.sh` — OK, zero `.pv-*` class selectors in e2e test files.
- `bash scripts/precommit-verify.sh <the 4 changed paths>` — 6 hooks actually ran and passed: check for added large files, detect private key, fix end of files, trim trailing whitespace, Detect hardcoded secrets, typos. json/toml/yaml/rustfmt hooks reported no files to check.
- `pnpm -r --if-present typecheck` — `tsc --noEmit` and `tsc -p tsconfig.e2e.json --noEmit` both clean.
- `pnpm -r --if-present lint` and `pnpm run lint:tests` (`biome check tests`, 39 files) — clean.

Not run: `cargo` gates. No Rust file is touched.

## Beads

Merge bead: `astro-plan-igf4g`. Work bead: `astro-plan-2cy4e`.

`astro-plan-2cy4e` is NOT resolved by this PR. It covers four stranded branches and this PR lands one of them. The other three need no code: `feat/ps48-relation-evidence` already landed as #1657, `triage/spec`'s only commit is live on `origin/chore/journey-validation-formula`, and `feat/ps48-track-b-relation-evidence-schema` is recommended for discard (PR #1679 was closed unmerged and #1729 removed the append-only migration chain it was built on). The triage record is on the bead.

Tracks-Bead: astro-plan-2cy4e
Merge-Bead: astro-plan-igf4g
