### PR TITLE
feat(calibration)!: match on camera body identity, recreate your dev database

### DIFF
--- a/crates/app/calibration/src/matching/loaders.rs
+++ b/crates/app/calibration/src/matching/loaders.rs
@@ -48,6 +48,7 @@ pub(super) async fn load_session(
             rotation_deg: r.rotation_deg,
             binning: r.binning,
             optic_train: r.optic_train,
+            camera_body_id: r.camera_body_id,
             observing_night_date: r.observing_night_date,
             has_observer_location: r.has_observer_location.unwrap_or(0) != 0,
             has_exposure_start_utc: r.has_exposure_start_utc.unwrap_or(0) != 0,
@@ -102,6 +103,7 @@ pub(super) async fn load_masters(
                 rotation_deg: r.rotation_deg,
                 binning: r.binning,
                 optic_train: r.optic_train,
+                camera_body_id: r.camera_body_id,
                 source_session_id: r.source_session_id,
                 observing_night_date: r.observing_night_date,
             })
@@ -133,6 +135,7 @@ pub(super) async fn load_master_by_id(
             rotation_deg: r.rotation_deg,
             binning: r.binning,
             optic_train: r.optic_train,
+            camera_body_id: r.camera_body_id,
             source_session_id: r.source_session_id,
             observing_night_date: r.observing_night_date,
         })

--- a/crates/app/calibration/src/matching/masters.rs
+++ b/crates/app/calibration/src/matching/masters.rs
@@ -188,6 +188,7 @@ async fn compute_compatible_sessions(
             rotation_deg: row.rotation_deg,
             binning: row.binning,
             optic_train: row.optic_train,
+            camera_body_id: row.camera_body_id,
             observing_night_date: row.observing_night_date,
             has_observer_location: row.has_observer_location.unwrap_or(0) != 0,
             has_exposure_start_utc: row.has_exposure_start_utc.unwrap_or(0) != 0,

--- a/crates/app/calibration/src/matching/tests.rs
+++ b/crates/app/calibration/src/matching/tests.rs
@@ -857,6 +857,7 @@ async fn load_config_relaxes_gain_and_binning_hard_rules_from_tolerances_table()
         rotation_deg: None,
         binning: None,
         optic_train: None,
+        camera_body_id: None,
         source_session_id: None,
         observing_night_date: None,
     };
@@ -871,6 +872,7 @@ async fn load_config_relaxes_gain_and_binning_hard_rules_from_tolerances_table()
         rotation_deg: Some(0.0),
         binning: Some("2x2".to_owned()),
         optic_train: Some("train-a".to_owned()),
+        camera_body_id: None,
         source_session_id: None,
         observing_night_date: None,
     };

--- a/crates/app/core/tests/calibration_integration.rs
+++ b/crates/app/core/tests/calibration_integration.rs
@@ -207,6 +207,26 @@ async fn suggest_returns_candidates_when_master_matches() {
     );
 }
 
+/// Set `camera_body_id` on an existing `acquisition_fingerprint` row.
+async fn set_session_body(pool: &sqlx::SqlitePool, id: &str, body: &str) {
+    sqlx::query("UPDATE acquisition_fingerprint SET camera_body_id = ? WHERE id = ?")
+        .bind(body)
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap_or_else(|e| panic!("set session camera_body_id failed: {e}"));
+}
+
+/// Set `camera_body_id` on an existing `calibration_fingerprint` row.
+async fn set_master_body(pool: &sqlx::SqlitePool, id: &str, body: &str) {
+    sqlx::query("UPDATE calibration_fingerprint SET camera_body_id = ? WHERE id = ?")
+        .bind(body)
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap_or_else(|e| panic!("set master camera_body_id failed: {e}"));
+}
+
 /// astro-plan-ugux2 end-to-end: the `camera_body_id` column must survive the
 /// round trip through `acquisition_fingerprint`/`calibration_fingerprint` and the
 /// matcher loaders, so a master captured with a different physical body is
@@ -215,24 +235,6 @@ async fn suggest_returns_candidates_when_master_matches() {
 async fn suggest_excludes_a_master_from_a_different_camera_body() {
     let (db, _repo, _bus) = support::setup().await;
     let pool = db.pool();
-
-    async fn set_session_body(pool: &sqlx::SqlitePool, id: &str, body: &str) {
-        sqlx::query("UPDATE acquisition_fingerprint SET camera_body_id = ? WHERE id = ?")
-            .bind(body)
-            .bind(id)
-            .execute(pool)
-            .await
-            .unwrap_or_else(|e| panic!("set session camera_body_id failed: {e}"));
-    }
-
-    async fn set_master_body(pool: &sqlx::SqlitePool, id: &str, body: &str) {
-        sqlx::query("UPDATE calibration_fingerprint SET camera_body_id = ? WHERE id = ?")
-            .bind(body)
-            .bind(id)
-            .execute(pool)
-            .await
-            .unwrap_or_else(|e| panic!("set master camera_body_id failed: {e}"));
-    }
 
     let session_id = Uuid::new_v4().to_string();
     let same_body_master = Uuid::new_v4().to_string();

--- a/crates/app/core/tests/calibration_integration.rs
+++ b/crates/app/core/tests/calibration_integration.rs
@@ -207,6 +207,73 @@ async fn suggest_returns_candidates_when_master_matches() {
     );
 }
 
+/// astro-plan-ugux2 end-to-end: the `camera_body_id` column must survive the
+/// round trip through `acquisition_fingerprint`/`calibration_fingerprint` and the
+/// matcher loaders, so a master captured with a different physical body is
+/// excluded rather than silently offered. Two masters differ only in body id.
+#[tokio::test]
+async fn suggest_excludes_a_master_from_a_different_camera_body() {
+    let (db, _repo, _bus) = support::setup().await;
+    let pool = db.pool();
+
+    async fn set_session_body(pool: &sqlx::SqlitePool, id: &str, body: &str) {
+        sqlx::query("UPDATE acquisition_fingerprint SET camera_body_id = ? WHERE id = ?")
+            .bind(body)
+            .bind(id)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|e| panic!("set session camera_body_id failed: {e}"));
+    }
+
+    async fn set_master_body(pool: &sqlx::SqlitePool, id: &str, body: &str) {
+        sqlx::query("UPDATE calibration_fingerprint SET camera_body_id = ? WHERE id = ?")
+            .bind(body)
+            .bind(id)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|e| panic!("set master camera_body_id failed: {e}"));
+    }
+
+    let session_id = Uuid::new_v4().to_string();
+    let same_body_master = Uuid::new_v4().to_string();
+    let other_body_master = Uuid::new_v4().to_string();
+
+    insert_acq_session(pool, &session_id).await;
+    insert_acq_fingerprint(pool, &session_id, 100.0, 10.0, -10.0, "1x1").await;
+    set_session_body(pool, &session_id, "player one_serial-a").await;
+
+    for (master_id, body) in
+        [(&same_body_master, "player one_serial-a"), (&other_body_master, "player one_serial-b")]
+    {
+        insert_cal_session(pool, master_id, "dark").await;
+        insert_cal_fingerprint(pool, master_id, "dark", 100.0, 10.0, -10.0, "1x1").await;
+        set_master_body(pool, master_id, body).await;
+    }
+
+    let resp = suggest(
+        pool,
+        CalibrationMatchSuggestRequest {
+            contract_version: SUGGEST_CONTRACT_VERSION.to_owned(),
+            request_id: Uuid::new_v4().to_string(),
+            session_id: session_id.clone(),
+            calibration_types: Some(vec![CalibrationType::Dark]),
+        },
+    )
+    .await
+    .expect("suggest should not return Err");
+
+    assert_eq!(resp.status, "success", "expected success, got: {:?}", resp.error);
+    let matches = resp.matches.expect("expected Some(matches)");
+    assert!(
+        matches.iter().any(|m| m.master_id == same_body_master),
+        "the master from the same body was not offered: {matches:?}"
+    );
+    assert!(
+        !matches.iter().any(|m| m.master_id == other_body_master),
+        "a master from a different camera body was offered: {matches:?}"
+    );
+}
+
 /// T134 (Q16 / FR-136) regression: calibration matching runs on the
 /// Option-typed domain `SessionInfo`/`MasterInfo`, loaded straight from
 /// `acquisition_fingerprint`/`calibration_fingerprint` — never through the

--- a/crates/app/core/tests/confirm_master_integration.rs
+++ b/crates/app/core/tests/confirm_master_integration.rs
@@ -74,11 +74,26 @@ async fn test_db(dest_root: &Path) -> Database {
 
 /// Write a minimal FITS file (single 2880-byte block).
 fn write_fits(dir: &Path, name: &str, imagetyp: &str) {
+    write_fits_with_camera(dir, name, imagetyp, None);
+}
+
+/// `camera` writes an `INSTRUME`/`CAMERAID` pair, which the master-registration
+/// path reduces to `calibration_fingerprint.camera_body_id`.
+fn write_fits_with_camera(dir: &Path, name: &str, imagetyp: &str, camera: Option<(&str, &str)>) {
     let mut block = vec![b' '; 2880];
-    let card = format!("IMAGETYP= '{imagetyp:<8}'");
-    let bytes = card.as_bytes();
-    block[..bytes.len().min(80)].copy_from_slice(&bytes[..bytes.len().min(80)]);
-    block[80..83].copy_from_slice(b"END");
+    let mut idx = 0usize;
+    let mut write_card = |card: &str| {
+        let bytes = card.as_bytes();
+        let len = bytes.len().min(80);
+        block[idx * 80..idx * 80 + len].copy_from_slice(&bytes[..len]);
+        idx += 1;
+    };
+    write_card(&format!("IMAGETYP= '{imagetyp:<8}'"));
+    if let Some((instrume, cameraid)) = camera {
+        write_card(&format!("INSTRUME= '{instrume}'"));
+        write_card(&format!("CAMERAID= '{cameraid}'"));
+    }
+    block[idx * 80..idx * 80 + 3].copy_from_slice(b"END");
     let path = dir.join(name);
     let mut f = std::fs::File::create(path).unwrap();
     f.write_all(&block).unwrap();
@@ -218,7 +233,12 @@ async fn apply_and_register(db: &Database, bus: &EventBus, item_id: &str) {
 #[tokio::test]
 async fn confirm_master_creates_plan_then_registers_at_apply() {
     let tmp = tempfile::tempdir().unwrap();
-    write_fits(tmp.path(), "masterDark_300s.fits", "DARK");
+    write_fits_with_camera(
+        tmp.path(),
+        "masterDark_300s.fits",
+        "DARK",
+        Some(("Poseidon-C PRO", "Player One_CAMD2282B4C061209000")),
+    );
 
     let db = test_db(&tmp.path().join("dest")).await;
     let bus = EventBus::with_pool(db.pool().clone());
@@ -289,6 +309,20 @@ async fn confirm_master_creates_plan_then_registers_at_apply() {
             .await
             .unwrap();
     assert_eq!(source_id.as_deref(), Some(item_id));
+
+    // astro-plan-ugux2: the master-registration path must derive the body id
+    // from the master frame's own CAMERAID, normalized the way
+    // `sessions::camera_body_id` normalizes.
+    let camera_body_id: Option<String> =
+        sqlx::query_scalar("SELECT camera_body_id FROM calibration_fingerprint LIMIT 1")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(
+        camera_body_id.as_deref(),
+        Some("player one_camd2282b4c061209000"),
+        "CAMERAID must reach the master fingerprint through the real registration derivation"
+    );
 }
 
 /// US4 master parity: a master from an ORGANIZED source produces a `catalogue`

--- a/crates/app/core/tests/ingest_sessions_integration.rs
+++ b/crates/app/core/tests/ingest_sessions_integration.rs
@@ -613,6 +613,7 @@ async fn ingested_session_matches_a_calibration_master() {
             temp_c: Some(-10.0),
             binning: Some("1x1"),
             optic_train: None,
+            camera_body_id: None,
         },
     )
     .await

--- a/crates/app/core/tests/ingest_sessions_integration.rs
+++ b/crates/app/core/tests/ingest_sessions_integration.rs
@@ -54,6 +54,7 @@ fn write_fits(
     object: Option<&str>,
     filter: Option<&str>,
     date_obs: Option<&str>,
+    camera: Option<(&str, &str)>,
 ) {
     let path = dir.join(name);
     let mut block = vec![b' '; 2880];
@@ -82,6 +83,10 @@ fn write_fits(
     write_card(&format!("{:<80}", "OFFSET  = 50"));
     write_card(&format!("{:<80}", "EXPTIME = 300.0"));
     write_card(&format!("{:<80}", "SET-TEMP= -10.0"));
+    if let Some((instrume, cameraid)) = camera {
+        write_card(&format!("{:<80}", format!("INSTRUME= '{instrume}'")));
+        write_card(&format!("{:<80}", format!("CAMERAID= '{cameraid}'")));
+    }
     block[idx * 80..idx * 80 + 3].copy_from_slice(b"END");
     let mut f = std::fs::File::create(path).unwrap();
     f.write_all(&block).unwrap();
@@ -211,6 +216,7 @@ async fn two_m31_frames_group_into_one_linked_session() {
         Some("M 31"),
         Some("Ha"),
         Some("2026-06-21T22:00:00"),
+        None,
     );
     write_fits(
         tmp.path(),
@@ -219,6 +225,7 @@ async fn two_m31_frames_group_into_one_linked_session() {
         Some("NGC 224"),
         Some("Ha"),
         Some("2026-06-21T23:00:00"),
+        None,
     );
 
     build_applied_plan(
@@ -337,6 +344,7 @@ async fn catalogued_frame_is_recorded_identically_to_a_moved_frame() {
             Some("M 31"),
             Some("Ha"),
             Some("2026-06-21T22:00:00"),
+            None,
         );
         filetime::set_file_mtime(
             tmp.path().join(name),
@@ -399,6 +407,7 @@ async fn unknown_object_session_backfills_after_resolve() {
         Some("WeirdObject 42"),
         Some("L"),
         Some("2026-06-21T22:00:00"),
+        None,
     );
     build_applied_plan(pool, "plan-2", root_id, &[("u.fits", "move", true)]).await;
 
@@ -466,6 +475,7 @@ async fn ingested_session_total_size_is_sum_of_real_frame_sizes() {
         Some("M 31"),
         Some("Ha"),
         Some("2026-06-21T22:00:00"),
+        None,
     );
     write_fits(
         tmp.path(),
@@ -474,6 +484,7 @@ async fn ingested_session_total_size_is_sum_of_real_frame_sizes() {
         Some("M 31"),
         Some("Ha"),
         Some("2026-06-21T23:00:00"),
+        None,
     );
     // Pad the second frame by one FITS block so the two sizes differ.
     std::fs::OpenOptions::new()
@@ -558,6 +569,7 @@ async fn ingested_session_matches_a_calibration_master() {
         Some("M 31"),
         Some("Ha"),
         Some("2026-06-21T22:00:00"),
+        Some(("Poseidon-C PRO", "Player One_CAMD2282B4C061209000")),
     );
     build_applied_plan(pool, "plan-siyk", root_id, &[("light.fits", "move", true)]).await;
 
@@ -585,6 +597,21 @@ async fn ingested_session_matches_a_calibration_master() {
             .fetch_one(pool)
             .await
             .unwrap();
+
+    // astro-plan-ugux2: the body id must be DERIVED from the frame's own
+    // CAMERAID by the production writer, normalized the way
+    // `sessions::camera_body_id` normalizes. Asserting a value the fixture
+    // never wrote is what distinguishes this from seeding the column by hand.
+    let camera_body_id: Option<String> =
+        sqlx::query_scalar("SELECT camera_body_id FROM acquisition_fingerprint")
+            .fetch_one(pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        camera_body_id.as_deref(),
+        Some("player one_camd2282b4c061209000"),
+        "CAMERAID must reach the fingerprint through the real ingest derivation"
+    );
     assert_eq!(dims.0, Some(100.0), "GAIN must reach the fingerprint (hard rule, every kind)");
     assert_eq!(dims.1, Some(50.0), "OFFSET must reach the fingerprint (dark hard rule)");
     assert_eq!(dims.2, Some(300.0), "EXPTIME must reach the fingerprint");

--- a/crates/app/inbox/src/plan_listener.rs
+++ b/crates/app/inbox/src/plan_listener.rs
@@ -473,6 +473,7 @@ async fn write_master_fingerprint(
             temp_c: dims.temp_c,
             binning: dims.binning.as_deref(),
             optic_train: dims.optic_train.as_deref(),
+            camera_body_id: dims.camera_body_id.as_deref(),
         },
     )
     .await
@@ -488,6 +489,7 @@ struct MasterFingerprintDims {
     temp_c: Option<f64>,
     binning: Option<String>,
     optic_train: Option<String>,
+    camera_body_id: Option<String>,
 }
 
 /// Read the applied master frame's header for the dimensions
@@ -527,6 +529,10 @@ async fn read_master_fingerprint_dims(
             meta.telescop.as_deref(),
             meta.instrume.as_deref(),
             meta.focal_length_mm,
+        ),
+        camera_body_id: sessions::camera_body_id(
+            meta.cameraid.as_deref(),
+            meta.instrume.as_deref(),
         ),
     }
 }

--- a/crates/app/targets/src/ingest_sessions.rs
+++ b/crates/app/targets/src/ingest_sessions.rs
@@ -364,6 +364,8 @@ async fn backfill_session_fingerprint(
         meta.instrume.as_deref(),
         meta.focal_length_mm,
     );
+    let camera_body_id =
+        sessions::camera_body_id(meta.cameraid.as_deref(), meta.instrume.as_deref());
 
     // Sensor set-point first: it is the temperature a calibration master is
     // matched on, with the measured CCD reading as the fallback.
@@ -390,6 +392,7 @@ async fn backfill_session_fingerprint(
             rotation_deg: meta.rotator_angle_deg,
             binning: (!binning.is_empty()).then_some(binning.as_str()),
             optic_train: optic_train.as_deref(),
+            camera_body_id: camera_body_id.as_deref(),
             observing_night_date: observing_night_date.as_deref(),
             // R11: ingest always uses the UTC observing-night fallback, so no
             // frame can assert a real observer location (mirrors

--- a/crates/calibration/core/src/assign.rs
+++ b/crates/calibration/core/src/assign.rs
@@ -110,13 +110,19 @@ pub fn evaluate_assign(
 /// Collect dimensions with hard-rule violations for the given master type.
 ///
 /// Uses [`crate::rules::hard_rule_numeric`] / [`crate::rules::hard_rule_string`]
-/// — the same exact-match-or-exclude policy the `rules::{bias,dark,flat}`
-/// evaluators apply — so an assign override's violation list always agrees
-/// with what `suggest` would have excluded.
+/// / [`crate::rules::camera_bodies_conflict`] — the same exact-match-or-exclude
+/// policy the `rules::{bias,dark,flat}` evaluators apply — so an assign
+/// override's violation list always agrees with what `suggest` would have
+/// excluded.
 fn collect_hard_violations(session: &SessionInfo, master: &MasterInfo) -> Vec<Dimension> {
-    use crate::rules::{hard_rule_numeric, hard_rule_string};
+    use crate::rules::{camera_bodies_conflict, hard_rule_numeric, hard_rule_string};
 
     let mut violations = Vec::new();
+    // Dark, flat and bias all apply the camera-body rule, so the check sits
+    // outside the per-kind arms rather than being repeated in each.
+    if camera_bodies_conflict(session.camera_body_id.as_deref(), master.camera_body_id.as_deref()) {
+        violations.push(Dimension::Camera);
+    }
     match master.kind {
         CalibrationKind::Dark | CalibrationKind::Bias => {
             if !hard_rule_numeric(session.gain, master.gain) {
@@ -213,6 +219,7 @@ mod tests {
             rotation_deg: None,
             binning: None,
             optic_train: None,
+            camera_body_id: None,
             source_session_id: None,
             observing_night_date: None,
         }
@@ -230,8 +237,58 @@ mod tests {
             rotation_deg: None,
             binning: None,
             optic_train: None,
+            camera_body_id: None,
             source_session_id: None,
             observing_night_date: None,
+        }
+    }
+
+    /// `collect_hard_violations` and the `rules::*` evaluators must agree on what
+    /// a camera-body conflict is, or an override reports a violation list that
+    /// contradicts the exclusion `suggest` actually made. Both read
+    /// [`crate::rules::camera_bodies_conflict`]; these cases pin that two
+    /// different bodies are a violation and an absent id on either side is not.
+    #[test]
+    fn a_camera_body_conflict_is_a_hard_violation_but_a_missing_id_is_not() {
+        let with_body = |body: Option<&str>| SessionInfo {
+            camera_body_id: body.map(str::to_owned),
+            ..session("light", 100.0, 50.0)
+        };
+        let master_with = |body: Option<&str>| MasterInfo {
+            camera_body_id: body.map(str::to_owned),
+            ..dark_master(100.0, 50.0)
+        };
+        let config = MatchingRuleConfig::default();
+
+        let conflict = evaluate_assign(
+            &with_body(Some("body-a")),
+            &master_with(Some("body-b")),
+            false,
+            &config,
+        );
+        assert!(
+            matches!(
+                conflict,
+                Err(AssignError::IncompatibleDimensions { ref dimensions })
+                    if dimensions.contains(&Dimension::Camera)
+            ),
+            "two different bodies must be refused, got {conflict:?}"
+        );
+
+        for (session_body, master_body) in
+            [(None, None), (Some("body-a"), None), (None, Some("body-a"))]
+        {
+            let decision = evaluate_assign(
+                &with_body(session_body),
+                &master_with(master_body),
+                false,
+                &config,
+            )
+            .expect("an absent camera id must not refuse an assign");
+            assert!(
+                !decision.mismatched_dimensions.contains(&Dimension::Camera),
+                "{session_body:?}/{master_body:?} was reported as a camera violation"
+            );
         }
     }
 

--- a/crates/calibration/core/src/lib.rs
+++ b/crates/calibration/core/src/lib.rs
@@ -61,6 +61,9 @@ pub enum Dimension {
     Rotation,
     Binning,
     OpticTrain,
+    /// Physical camera body, keyed on the `CAMERAID` serial rather than the
+    /// `INSTRUME` model — two identical bodies share a model but not a serial.
+    Camera,
     ObservingNightProximity,
     DateProximity,
 }
@@ -131,6 +134,7 @@ impl Dimension {
             Self::Rotation => "rotation",
             Self::Binning => "binning",
             Self::OpticTrain => "optic_train",
+            Self::Camera => "camera",
             Self::ObservingNightProximity => "observing_night_proximity",
             Self::DateProximity => "date_proximity",
         }
@@ -155,6 +159,10 @@ pub struct SessionInfo {
     pub rotation_deg: Option<f64>,
     pub binning: Option<String>,
     pub optic_train: Option<String>,
+    /// Physical camera body identifier, `None` whenever the headers carried no
+    /// serial beyond the `INSTRUME` model. Absent on the majority of cameras,
+    /// so it is never required for a match.
+    pub camera_body_id: Option<String>,
     /// ISO-8601 date string of the observing night (local date, noon-to-noon).
     pub observing_night_date: Option<String>,
     /// Whether the session has a known observer_location (required for
@@ -191,6 +199,8 @@ pub struct MasterInfo {
     pub rotation_deg: Option<f64>,
     pub binning: Option<String>,
     pub optic_train: Option<String>,
+    /// Physical camera body identifier; see [`SessionInfo::camera_body_id`].
+    pub camera_body_id: Option<String>,
     /// Originating session id (used for same_session selection reason).
     pub source_session_id: Option<String>,
     /// ISO-8601 date string of the observing night of the calibration session.
@@ -309,6 +319,7 @@ mod tests {
             rotation_deg: Some(0.0),
             binning: Some("1x1".to_owned()),
             optic_train: Some("train-a".to_owned()),
+            camera_body_id: None,
             observing_night_date: Some("2026-01-15".to_owned()),
             has_observer_location: true,
             has_exposure_start_utc: true,
@@ -327,6 +338,7 @@ mod tests {
             rotation_deg: None,
             binning: None,
             optic_train: None,
+            camera_body_id: None,
             source_session_id: None,
             observing_night_date: None,
         }
@@ -415,6 +427,7 @@ mod tests {
             rotation_deg: None,
             binning: None,
             optic_train: None,
+            camera_body_id: None,
             source_session_id: None,
             observing_night_date: None,
         };
@@ -450,6 +463,175 @@ mod tests {
         // Only request flat — dark master should not appear
         let matches = suggest(&session, &[dark], &[CalibrationKind::Flat], &config).unwrap();
         assert!(matches.is_empty());
+    }
+
+    // ── Camera-body dimension (astro-plan-ugux2) ──────────────────────────────
+
+    /// Session and master fixtures that agree on every dimension the three
+    /// evaluators compare, so only the camera body can change the outcome.
+    fn body_pair(
+        kind: CalibrationKind,
+        session_body: Option<&str>,
+        master_body: Option<&str>,
+    ) -> (SessionInfo, MasterInfo) {
+        let session =
+            SessionInfo { camera_body_id: session_body.map(str::to_owned), ..default_session() };
+        let master = MasterInfo {
+            id: "m-body".to_owned(),
+            kind,
+            gain: session.gain,
+            offset: session.offset,
+            exposure_s: session.exposure_s,
+            temp_c: session.temp_c,
+            filter: session.filter.clone(),
+            rotation_deg: session.rotation_deg,
+            binning: session.binning.clone(),
+            optic_train: session.optic_train.clone(),
+            camera_body_id: master_body.map(str::to_owned),
+            source_session_id: None,
+            observing_night_date: session.observing_night_date.clone(),
+        };
+        (session, master)
+    }
+
+    fn suggest_one(session: &SessionInfo, master: &MasterInfo) -> Vec<CalibrationMatch> {
+        suggest(
+            session,
+            std::slice::from_ref(master),
+            &[master.kind],
+            &MatchingRuleConfig::default(),
+        )
+        .unwrap()
+    }
+
+    const MATCHABLE_KINDS: [CalibrationKind; 3] =
+        [CalibrationKind::Dark, CalibrationKind::Flat, CalibrationKind::Bias];
+
+    /// The defect: a master from body A silently calibrated lights from body B.
+    #[test]
+    fn two_identical_bodies_with_different_camera_ids_do_not_match() {
+        for kind in MATCHABLE_KINDS {
+            let (session, master) =
+                body_pair(kind, Some("player one_serial-a"), Some("player one_serial-b"));
+            assert!(
+                suggest_one(&session, &master).is_empty(),
+                "{kind:?}: a master from a different body was offered as a candidate"
+            );
+        }
+    }
+
+    /// The majority case the owner called out: most vendors write no usable
+    /// `CAMERAID`, so a frame without one must score exactly as it did before the
+    /// dimension existed — no entry, no penalty.
+    #[test]
+    fn frames_without_a_camera_id_match_exactly_as_before() {
+        for kind in MATCHABLE_KINDS {
+            let (session, master) = body_pair(kind, None, None);
+            let matches = suggest_one(&session, &master);
+            assert_eq!(matches.len(), 1, "{kind:?}: an unidentified body stopped matching");
+            let m = &matches[0];
+            assert!(
+                (m.confidence - 1.0).abs() < 1e-9,
+                "{kind:?}: confidence dropped to {} without any camera evidence",
+                m.confidence
+            );
+            assert!(
+                !m.dimensions_matched.iter().any(|d| d.dimension == "camera")
+                    && !m.dimensions_mismatched.iter().any(|d| d.dimension == "camera"),
+                "{kind:?}: a skipped dimension was still reported"
+            );
+        }
+    }
+
+    /// Two agreeing body ids are recorded as a matched dimension at no cost.
+    #[test]
+    fn agreeing_camera_ids_match_at_full_confidence() {
+        for kind in MATCHABLE_KINDS {
+            let (session, master) =
+                body_pair(kind, Some("player one_serial-a"), Some("player one_serial-a"));
+            let matches = suggest_one(&session, &master);
+            assert_eq!(matches.len(), 1, "{kind:?}: agreeing bodies failed to match");
+            assert!(
+                (matches[0].confidence - 1.0).abs() < 1e-9,
+                "{kind:?}: agreement cost confidence"
+            );
+            assert!(
+                matches[0].dimensions_matched.iter().any(|d| d.dimension == "camera"),
+                "{kind:?}: the agreement was not recorded"
+            );
+        }
+    }
+
+    /// Present on one side only, both directions: the match stands (a mixed
+    /// library must still calibrate) but carries the reduced confidence
+    /// constitution II requires of an inferred match.
+    #[test]
+    fn a_camera_id_on_one_side_only_matches_at_reduced_confidence() {
+        let expected = 1.0 - crate::rules::UNKNOWN_CAMERA_BODY_PENALTY;
+        for kind in MATCHABLE_KINDS {
+            for (session_body, master_body) in
+                [(Some("player one_serial-a"), None), (None, Some("player one_serial-a"))]
+            {
+                let (session, master) = body_pair(kind, session_body, master_body);
+                let matches = suggest_one(&session, &master);
+                assert_eq!(
+                    matches.len(),
+                    1,
+                    "{kind:?} {session_body:?}/{master_body:?}: a one-sided id must not exclude"
+                );
+                let m = &matches[0];
+                assert!(
+                    (m.confidence - expected).abs() < 1e-9,
+                    "{kind:?} {session_body:?}/{master_body:?}: confidence {}, expected {expected}",
+                    m.confidence
+                );
+                let entry = m
+                    .dimensions_mismatched
+                    .iter()
+                    .find(|d| d.dimension == "camera")
+                    .expect("unproven body agreement must be reported");
+                assert_eq!(entry.reason, MismatchReason::MetadataMissing);
+            }
+        }
+    }
+
+    /// The two defects fixed in this area were a NaN delta scored as a match and
+    /// a negative delta raising confidence. The camera dimension is string
+    /// equality with a constant penalty, so it reports no delta at all and can
+    /// only ever lower a score.
+    #[test]
+    fn the_camera_dimension_carries_no_delta_and_cannot_raise_confidence() {
+        let penalty = crate::rules::UNKNOWN_CAMERA_BODY_PENALTY;
+        assert!(penalty.is_finite() && penalty > 0.0, "penalty {penalty} cannot lower confidence");
+
+        let (agreed_s, agreed_m) = body_pair(CalibrationKind::Dark, Some("body-a"), Some("body-a"));
+        let (partial_s, partial_m) = body_pair(CalibrationKind::Dark, Some("body-a"), None);
+        let agreed = suggest_one(&agreed_s, &agreed_m).remove(0);
+        let partial = suggest_one(&partial_s, &partial_m).remove(0);
+
+        assert!(
+            partial.confidence < agreed.confidence,
+            "an unproven body scored {} against a proven {}",
+            partial.confidence,
+            agreed.confidence
+        );
+        assert!(
+            agreed
+                .dimensions_matched
+                .iter()
+                .chain(partial.dimensions_matched.iter())
+                .filter(|d| d.dimension == "camera")
+                .all(|d| d.delta.is_none()),
+            "a matched camera dimension reported a numeric delta"
+        );
+        assert!(
+            partial
+                .dimensions_mismatched
+                .iter()
+                .filter(|d| d.dimension == "camera")
+                .all(|d| d.delta.is_none()),
+            "a mismatched camera dimension reported a numeric delta"
+        );
     }
 
     #[test]

--- a/crates/calibration/core/src/rules/bias.rs
+++ b/crates/calibration/core/src/rules/bias.rs
@@ -54,6 +54,14 @@ pub fn evaluate(
         &mut mismatched,
     )?;
 
+    // ── Optional hard rule: camera body ───────────────────────────────────────
+    confidence -= crate::rules::optional_camera_rule(
+        session.camera_body_id.as_deref(),
+        master.camera_body_id.as_deref(),
+        &mut matched,
+        &mut mismatched,
+    )?;
+
     // ── Soft rule: master age (±age_limit_days) ───────────────────────────────
     confidence -= crate::rules::apply_age_rule(
         session.observing_night_date.as_deref(),
@@ -102,6 +110,7 @@ mod tests {
             rotation_deg: None,
             binning: None,
             optic_train: None,
+            camera_body_id: None,
             source_session_id: None,
             observing_night_date: None,
         }

--- a/crates/calibration/core/src/rules/dark.rs
+++ b/crates/calibration/core/src/rules/dark.rs
@@ -51,6 +51,14 @@ pub fn evaluate(
         &mut mismatched,
     )?;
 
+    // ── Optional hard rule: camera body ───────────────────────────────────────
+    confidence -= crate::rules::optional_camera_rule(
+        session.camera_body_id.as_deref(),
+        master.camera_body_id.as_deref(),
+        &mut matched,
+        &mut mismatched,
+    )?;
+
     // ── Soft rule: exposure (±tolerance%) ─────────────────────────────────────
     let exp_cfg = config.dark_exposure_config();
     match (session.exposure_s, master.exposure_s) {
@@ -164,6 +172,7 @@ mod tests {
             rotation_deg: None,
             binning: None,
             optic_train: None,
+            camera_body_id: None,
             source_session_id: None,
             observing_night_date: None,
         }

--- a/crates/calibration/core/src/rules/flat.rs
+++ b/crates/calibration/core/src/rules/flat.rs
@@ -62,6 +62,14 @@ pub fn evaluate(
         _ => return None,
     }
 
+    // ── Optional hard rule: camera body ───────────────────────────────────────
+    confidence -= crate::rules::optional_camera_rule(
+        session.camera_body_id.as_deref(),
+        master.camera_body_id.as_deref(),
+        &mut matched,
+        &mut mismatched,
+    )?;
+
     // ── Hard rule: gain (exact, no tolerance — 2026-05-23 decision) ───────────
     confidence -= crate::rules::relaxable_numeric(
         Dimension::Gain,
@@ -189,6 +197,7 @@ mod tests {
             rotation_deg: Some(rotation),
             binning: Some(binning.to_owned()),
             optic_train: Some(optic_train.to_owned()),
+            camera_body_id: None,
             source_session_id: None,
             observing_night_date: Some(night.to_owned()),
         }

--- a/crates/calibration/core/src/rules/mod.rs
+++ b/crates/calibration/core/src/rules/mod.rs
@@ -38,6 +38,61 @@ pub fn hard_rule_string(session_val: Option<&str>, master_val: Option<&str>) -> 
 /// toggle costs the same wherever it is set.
 pub const RELAXED_HARD_RULE_PENALTY: f64 = 0.2;
 
+/// Confidence penalty when exactly one of the light session and the master
+/// carries a camera body id, so the match is made without body agreement
+/// (constitution II: an inferred match carries a confidence level).
+///
+/// A constant rather than a [`crate::ranking::MatchingRuleConfig`] field: that
+/// struct is filled from settings keys with no construction-time validation, so
+/// a configurable penalty would be one more unvalidated float reaching the
+/// scorer.
+pub const UNKNOWN_CAMERA_BODY_PENALTY: f64 = 0.1;
+
+/// Whether two camera body ids are positive proof of different hardware.
+///
+/// Only two present-and-different identifiers qualify. An absent identifier is
+/// the majority case — most vendors emit no `CAMERAID` serial at all — and is
+/// never a conflict. Shared by [`optional_camera_rule`] and
+/// `assign::collect_hard_violations` so an override's violation list agrees
+/// with what `suggest` excluded.
+#[must_use]
+pub fn camera_bodies_conflict(session_val: Option<&str>, master_val: Option<&str>) -> bool {
+    matches!((session_val, master_val), (Some(s), Some(m)) if s != m)
+}
+
+/// Optional camera-body dimension shared by `bias`/`dark`/`flat`.
+///
+/// `None` excludes the candidate: two known, different bodies cannot calibrate
+/// each other. Both ids absent skips the dimension entirely and costs nothing,
+/// keeping every camera that writes no serial on its previous score. Exactly one
+/// id present keeps the candidate at [`UNKNOWN_CAMERA_BODY_PENALTY`], recording
+/// a `metadata_missing` entry so the unproven body agreement is visible rather
+/// than assumed.
+///
+/// The dimension is string equality throughout, so no numeric delta exists to be
+/// NaN or negative, and the penalty is a constant that cannot raise confidence.
+pub fn optional_camera_rule(
+    session_val: Option<&str>,
+    master_val: Option<&str>,
+    matched: &mut Vec<MatchedDim>,
+    mismatched: &mut Vec<MismatchedDim>,
+) -> Option<f64> {
+    if camera_bodies_conflict(session_val, master_val) {
+        return None;
+    }
+    match (session_val, master_val) {
+        (Some(s), Some(_)) => {
+            matched.push(MatchedDim::exact_string(Dimension::Camera, s));
+            Some(0.0)
+        }
+        (None, None) => Some(0.0),
+        _ => {
+            mismatched.push(MismatchedDim::metadata_missing(Dimension::Camera));
+            Some(UNKNOWN_CAMERA_BODY_PENALTY)
+        }
+    }
+}
+
 /// Numeric hard rule that the user can relax, shared by the gain and offset
 /// comparisons in `bias`/`dark`/`flat`.
 ///

--- a/crates/metadata/core/src/lib.rs
+++ b/crates/metadata/core/src/lib.rs
@@ -242,6 +242,10 @@ pub struct RawFileMetadata {
     pub naxis2: Option<String>,
     /// `INSTRUME` (camera/instrument identifier).
     pub instrume: Option<String>,
+    /// `CAMERAID` (`vendor_model_serial` camera body identifier). Distinguishes
+    /// two bodies of one model only for vendors that populate the serial
+    /// segment; see `sessions::camera_body_id` for the derivation.
+    pub cameraid: Option<String>,
     /// `TELESCOP` (telescope identifier).
     pub telescop: Option<String>,
     /// `DATE-OBS` (ISO 8601 string or FITS-style `YYYY-MM-DDTHH:MM:SS`).

--- a/crates/metadata/fits/src/lib.rs
+++ b/crates/metadata/fits/src/lib.rs
@@ -11,8 +11,8 @@
 //!
 //! This extractor reads only the header keywords required for inbox
 //! classification: `IMAGETYP`, `FILTER`, `OBJECT`, `EXPTIME`, `EXPOSURE`,
-//! `GAIN`, `XBINNING`, `YBINNING`, `NAXIS1`, `NAXIS2`, `INSTRUME`, `TELESCOP`,
-//! `DATE-OBS`.
+//! `GAIN`, `XBINNING`, `YBINNING`, `NAXIS1`, `NAXIS2`, `INSTRUME`, `CAMERAID`,
+//! `TELESCOP`, `DATE-OBS`.
 //!
 //! No cfitsio or heavy C dependencies — `fits-header` is pure Rust. A header
 //! missing individual keywords still yields `Ok`, with `None` for each absent
@@ -191,6 +191,7 @@ fn parse_header(header: &Header) -> RawFileMetadata {
     meta.naxis1 = get(header, "NAXIS1");
     meta.naxis2 = get(header, "NAXIS2");
     meta.instrume = get_str(header, "INSTRUME");
+    meta.cameraid = get_str(header, "CAMERAID");
     meta.telescop = get_str(header, "TELESCOP");
     meta.date_obs = get_str(header, "DATE-OBS");
 

--- a/crates/metadata/xisf/src/lib.rs
+++ b/crates/metadata/xisf/src/lib.rs
@@ -142,6 +142,7 @@ fn parse_header(header: &Header) -> RawFileMetadata {
     meta.naxis1 = non_empty(get_str(header, "NAXIS1"));
     meta.naxis2 = non_empty(get_str(header, "NAXIS2"));
     meta.instrume = non_empty(get_str(header, "INSTRUME"));
+    meta.cameraid = non_empty(get_str(header, "CAMERAID"));
     meta.telescop = non_empty(get_str(header, "TELESCOP"));
     meta.date_obs = non_empty(get_str(header, "DATE-OBS"));
 

--- a/crates/persistence/calibration/src/repositories/q_calibration.rs
+++ b/crates/persistence/calibration/src/repositories/q_calibration.rs
@@ -61,6 +61,7 @@ pub struct AcquisitionFingerprintRow {
     pub rotation_deg: Option<f64>,
     pub binning: Option<String>,
     pub optic_train: Option<String>,
+    pub camera_body_id: Option<String>,
     pub observing_night_date: Option<String>,
     pub has_observer_location: Option<i64>,
     pub has_exposure_start_utc: Option<i64>,
@@ -79,6 +80,7 @@ pub struct CalibrationFingerprintRow {
     pub rotation_deg: Option<f64>,
     pub binning: Option<String>,
     pub optic_train: Option<String>,
+    pub camera_body_id: Option<String>,
     pub source_session_id: Option<String>,
     pub observing_night_date: Option<String>,
 }
@@ -137,7 +139,8 @@ pub async fn get_acquisition_fingerprint(
         "
         SELECT id, session_type, gain, offset_val, exposure_s,
                temp_c, filter_name, rotation_deg, binning, optic_train,
-               observing_night_date, has_observer_location, has_exposure_start_utc
+               camera_body_id, observing_night_date, has_observer_location,
+               has_exposure_start_utc
         FROM acquisition_fingerprint
         WHERE id = ?
         ",
@@ -160,6 +163,7 @@ pub struct UpsertAcquisitionFingerprint<'a> {
     pub rotation_deg: Option<f64>,
     pub binning: Option<&'a str>,
     pub optic_train: Option<&'a str>,
+    pub camera_body_id: Option<&'a str>,
     pub observing_night_date: Option<&'a str>,
     pub has_observer_location: bool,
     pub has_exposure_start_utc: bool,
@@ -188,9 +192,9 @@ pub async fn upsert_acquisition_fingerprint(
         "
         INSERT INTO acquisition_fingerprint
             (id, session_type, gain, offset_val, exposure_s, temp_c, filter_name,
-             rotation_deg, binning, optic_train, observing_night_date,
-             has_observer_location, has_exposure_start_utc)
-        VALUES (?, 'light', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             rotation_deg, binning, optic_train, camera_body_id,
+             observing_night_date, has_observer_location, has_exposure_start_utc)
+        VALUES (?, 'light', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             gain                   = COALESCE(gain, excluded.gain),
             offset_val             = COALESCE(offset_val, excluded.offset_val),
@@ -200,6 +204,7 @@ pub async fn upsert_acquisition_fingerprint(
             rotation_deg           = COALESCE(rotation_deg, excluded.rotation_deg),
             binning                = COALESCE(binning, excluded.binning),
             optic_train            = COALESCE(optic_train, excluded.optic_train),
+            camera_body_id         = COALESCE(camera_body_id, excluded.camera_body_id),
             observing_night_date   = COALESCE(observing_night_date, excluded.observing_night_date),
             has_observer_location  = MAX(has_observer_location, excluded.has_observer_location),
             has_exposure_start_utc = MAX(has_exposure_start_utc, excluded.has_exposure_start_utc)
@@ -214,6 +219,7 @@ pub async fn upsert_acquisition_fingerprint(
     .bind(fp.rotation_deg)
     .bind(fp.binning)
     .bind(fp.optic_train)
+    .bind(fp.camera_body_id)
     .bind(fp.observing_night_date)
     .bind(i64::from(fp.has_observer_location))
     .bind(i64::from(fp.has_exposure_start_utc))
@@ -234,7 +240,8 @@ pub async fn list_light_acquisition_fingerprints(
         "
         SELECT id, session_type, gain, offset_val, exposure_s,
                temp_c, filter_name, rotation_deg, binning, optic_train,
-               observing_night_date, has_observer_location, has_exposure_start_utc
+               camera_body_id, observing_night_date, has_observer_location,
+               has_exposure_start_utc
         FROM acquisition_fingerprint
         WHERE session_type = 'light'
         ",
@@ -258,7 +265,7 @@ pub async fn list_calibration_fingerprints(
         "
         SELECT id, calibration_type, gain, offset_val, exposure_s,
                temp_c, filter_name, rotation_deg, binning, optic_train,
-               source_session_id, observing_night_date
+               camera_body_id, source_session_id, observing_night_date
         FROM calibration_fingerprint
         WHERE calibration_type IN ('dark', 'flat', 'bias')
         ",
@@ -280,7 +287,7 @@ pub async fn get_calibration_fingerprint(
         "
         SELECT id, calibration_type, gain, offset_val, exposure_s,
                temp_c, filter_name, rotation_deg, binning, optic_train,
-               source_session_id, observing_night_date
+               camera_body_id, source_session_id, observing_night_date
         FROM calibration_fingerprint
         WHERE id = ?
         ",

--- a/crates/persistence/core/migrations/0001_initial_schema.sql
+++ b/crates/persistence/core/migrations/0001_initial_schema.sql
@@ -16,6 +16,7 @@ CREATE TABLE acquisition_fingerprint (
     rotation_deg          REAL,
     binning               TEXT,
     optic_train           TEXT,
+    camera_body_id        TEXT,   -- CAMERAID body identity; NULL when the vendor writes no serial
     observing_night_date  TEXT,   -- YYYY-MM-DD local observing night
     has_observer_location INTEGER NOT NULL DEFAULT 0,
     has_exposure_start_utc INTEGER NOT NULL DEFAULT 0
@@ -205,6 +206,7 @@ CREATE TABLE calibration_fingerprint (
     rotation_deg          REAL,
     binning               TEXT,
     optic_train           TEXT,
+    camera_body_id        TEXT,   -- CAMERAID body identity; NULL when the vendor writes no serial
     source_session_id     TEXT,   -- originating capture session (for same_session reason)
     observing_night_date  TEXT    -- YYYY-MM-DD local observing night
 );

--- a/crates/persistence/inbox/src/repositories/q_inbox.rs
+++ b/crates/persistence/inbox/src/repositories/q_inbox.rs
@@ -107,6 +107,9 @@ pub struct InsertCalibrationFingerprint<'a> {
     pub binning: Option<&'a str>,
     /// Hard-rule dimension for flat matching.
     pub optic_train: Option<&'a str>,
+    /// Optional dimension for every calibration kind: two present-and-different
+    /// body ids exclude the candidate, absent on either side does not.
+    pub camera_body_id: Option<&'a str>,
 }
 
 /// Idempotency guard for master registration: does a `calibration_session`
@@ -162,8 +165,8 @@ pub async fn insert_calibration_fingerprint(
     sqlx::query(
         "INSERT INTO calibration_fingerprint
             (id, calibration_type, exposure_s, filter_name, gain, offset_val,
-             temp_c, binning, optic_train)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+             temp_c, binning, optic_train, camera_body_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(fp.calibration_session_id)
     .bind(fp.calibration_type)
@@ -174,6 +177,7 @@ pub async fn insert_calibration_fingerprint(
     .bind(fp.temp_c)
     .bind(fp.binning)
     .bind(fp.optic_train)
+    .bind(fp.camera_body_id)
     .execute(pool)
     .await?;
     Ok(())

--- a/crates/sessions/src/camera_body.rs
+++ b/crates/sessions/src/camera_body.rs
@@ -1,0 +1,88 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Physical camera-body identity derived from the FITS/XISF `CAMERAID` keyword.
+//!
+//! The single canonical derivation shared by the two write paths that persist a
+//! calibration fingerprint — `app_core_targets::ingest_sessions` for light
+//! sessions and `app_core_inbox::plan_listener` for registered masters. A
+//! divergent implementation in either place would let a light and a master from
+//! the same body key under different identities, which excludes them from each
+//! other as a camera-body conflict.
+
+use crate::optic_train::normalize_text;
+
+/// Body identity for one frame, or `None` when the headers prove nothing.
+///
+/// `CAMERAID` is written as `vendor_model_serial`, and serial population is
+/// vendor-dependent: Player One writes a real serial, ZWO writes either the bare
+/// `INSTRUME` model or a trailing empty serial segment, and Dwarf omits the
+/// keyword. Only a value carrying a non-empty segment after the last `_`, and
+/// differing from `INSTRUME`, distinguishes two bodies of the same model; every
+/// other shape yields `None` so the matcher skips the dimension rather than
+/// keying two bodies under one model string.
+#[must_use]
+pub fn camera_body_id(cameraid: Option<&str>, instrume: Option<&str>) -> Option<String> {
+    let id = normalize_text(cameraid)?;
+    let serial = id.rsplit_once('_')?.1;
+    if serial.is_empty() {
+        return None;
+    }
+    if normalize_text(instrume).is_some_and(|model| model == id) {
+        return None;
+    }
+    Some(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::camera_body_id;
+
+    /// The three vendor shapes sampled from the owner's library (600 FITS files
+    /// under `/mnt/d/astrophotography`), recorded on `astro-plan-ugux2`.
+    #[test]
+    fn only_a_cameraid_carrying_a_serial_yields_a_body_id() {
+        assert_eq!(
+            camera_body_id(Some("Player One_CAMD2282B4C061209000"), Some("Poseidon-C PRO")),
+            Some("player one_camd2282b4c061209000".to_owned()),
+            "a populated serial is the one shape that identifies a body"
+        );
+        assert_eq!(
+            camera_body_id(Some("ZWO ASI2600MM Pro"), Some("ZWO ASI2600MM Pro")),
+            None,
+            "N.I.N.A. + ZWO repeats INSTRUME, which cannot separate two bodies"
+        );
+        assert_eq!(
+            camera_body_id(Some("ZWOptical_ZWO ASI2600MM Pro_"), Some("ZWO ASI2600MM Pro")),
+            None,
+            "ASIDeepStack exposes the field with an empty serial segment"
+        );
+        assert_eq!(camera_body_id(None, None), None, "Dwarf 3 omits the keyword");
+    }
+
+    #[test]
+    fn a_blank_or_separatorless_cameraid_yields_no_body_id() {
+        assert_eq!(camera_body_id(Some("   "), Some("Poseidon-C PRO")), None);
+        assert_eq!(camera_body_id(Some("PoseidonC"), Some("Poseidon-C PRO")), None);
+    }
+
+    /// Two bodies of one model differ only past the last `_`, which is the whole
+    /// point of the dimension.
+    #[test]
+    fn two_bodies_of_the_same_model_get_different_ids() {
+        let a = camera_body_id(Some("Player One_SERIAL-A"), Some("Poseidon-C PRO"));
+        let b = camera_body_id(Some("Player One_SERIAL-B"), Some("Poseidon-C PRO"));
+        assert!(a.is_some() && b.is_some());
+        assert_ne!(a, b);
+    }
+
+    /// Case and internal whitespace come from the writing tool, not the
+    /// hardware, so they must not split one body into two identities.
+    #[test]
+    fn normalization_matches_the_optic_train_key_rules() {
+        assert_eq!(
+            camera_body_id(Some("  PLAYER   One_CAMD228  "), None),
+            camera_body_id(Some("player one_camd228"), None)
+        );
+    }
+}

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -3,12 +3,14 @@
 
 //! Acquisition and calibration session modeling boundaries.
 
+pub mod camera_body;
 pub mod clustering;
 pub mod identity;
 pub mod key;
 pub mod observing_night;
 pub mod optic_train;
 
+pub use camera_body::camera_body_id;
 pub use clustering::{
     angular_separation_deg, circular_mean_deg, derive_clustering, fov_diagonal_deg,
     rotation_axial_distance_deg, Assignment, ClusteringResult, ExistingFraming, NewFramingGroup,

--- a/crates/sessions/src/optic_train.rs
+++ b/crates/sessions/src/optic_train.rs
@@ -53,7 +53,7 @@ pub fn optic_train_key(
     ))
 }
 
-fn normalize_text(value: Option<&str>) -> Option<String> {
+pub(crate) fn normalize_text(value: Option<&str>) -> Option<String> {
     let v = value?.trim();
     if v.is_empty() {
         return None;


### PR DESCRIPTION
## Defect

Two identical camera bodies owned by one user were indistinguishable to the
calibration matcher, so a master dark or bias captured with body A could
silently calibrate lights from body B.

Verified against `origin/main` at `c0f7e10ea` before designing:

- `Dimension` had no camera variant (`crates/calibration/core/src/lib.rs:55-66`
  at base).
- `git grep -E 'CAMERAID|SERIALNO|CCDSERNO|CAMSERIA|INSTRSN|SENSORID' c0f7e10ea
  -- crates apps packages` → exit 1. No serial keyword was read anywhere, so only
  the `INSTRUME` **model** reached the matcher, folded into `optic_train`
  (`crates/sessions/src/optic_train.rs`). Two identical bodies on one scope
  produce an identical `optic_train` key.

## Change

`CAMERAID` is extracted in both metadata adapters, reduced to a body identity by
one shared derivation, persisted on both fingerprint tables, and compared as an
**optional** dimension by all three evaluators.

| Layer | File |
|---|---|
| Keyword extraction | `crates/metadata/fits/src/lib.rs:194`, `crates/metadata/xisf/src/lib.rs:145`, field at `crates/metadata/core/src/lib.rs:245-248` |
| Body-id derivation | `crates/sessions/src/camera_body.rs` |
| Schema | `crates/persistence/core/migrations/0001_initial_schema.sql:19,209` |
| Repositories | `crates/persistence/calibration/src/repositories/q_calibration.rs`, `crates/persistence/inbox/src/repositories/q_inbox.rs` |
| Write paths | `crates/app/targets/src/ingest_sessions.rs` (lights), `crates/app/inbox/src/plan_listener.rs` (masters) |
| Matcher | `crates/calibration/core/src/rules/mod.rs:41-94`, called from `rules/{dark,bias,flat}.rs` |
| Assign agreement | `crates/calibration/core/src/assign.rs:117-125` |

### Why the dimension is optional

Serial population is vendor-dependent, per the sample recorded on
`astro-plan-ugux2`: Player One writes a real serial, ZWO writes either the bare
`INSTRUME` model or a trailing empty segment, and Dwarf 3 omits the keyword. A
body id is derived only from a `CAMERAID` with a non-empty segment past the last
underscore that also differs from `INSTRUME`; every other shape yields `None`.

### Ruling on the present-on-one-side-only case

| Session / master | Outcome |
|---|---|
| Both present, equal | matched dimension, no penalty |
| Both present, different | candidate **excluded** |
| Both absent | dimension **skipped entirely**, no entry, no penalty |
| Exactly one present | candidate kept at `1.0 - UNKNOWN_CAMERA_BODY_PENALTY` (0.1) with a `metadata_missing` entry |

Rejected alternatives: excluding on a one-sided id would break every mixed
library and contradicts the requirement that a frame lacking the keyword stay
matchable; matching silently at full confidence is the defect itself and
violates constitution II, which requires an inferred match to carry a confidence
level; penalising the both-absent case would charge every ZWO and Dwarf owner
for information they cannot supply.

### Configurable knob

None added. The penalty is a constant, because `MatchingRuleConfig` is filled
from settings keys with no construction-time validation
(`crates/calibration/core/src/ranking.rs:150-172` has only a `Default` impl), so
a configurable penalty would be one more unvalidated float reaching the scorer.

### NaN and negative delta

The dimension is string equality end to end. It has no numeric delta:
`MatchedDim::exact_string` and `MismatchedDim::metadata_missing` both set
`delta: None`, and the penalty is a compile-time constant, so no NaN or negative
value can produce a match or raise confidence. Asserted by
`the_camera_dimension_carries_no_delta_and_cannot_raise_confidence`.

### Single conflict predicate

`camera_bodies_conflict` (`crates/calibration/core/src/rules/mod.rs:59`) is
defined once and read by both `optional_camera_rule` (the exclusion path for all
three evaluators) and `assign::collect_hard_violations`, so an override's
violation list cannot drift from what `suggest` excluded — the drift shape that
took #1735 three derivations.

## Tests — revert or mutation result per test

### Matcher behaviour

Revert = `camera_bodies_conflict` forced `false` and `optional_camera_rule`
reduced to `Some(0.0)`, keeping the struct fields so the tree still compiles.

| Test | Reverted |
|---|---|
| `two_identical_bodies_with_different_camera_ids_do_not_match` (dark, flat, bias) | FAILED |
| `a_camera_id_on_one_side_only_matches_at_reduced_confidence` (both directions × 3 kinds) | FAILED |
| `agreeing_camera_ids_match_at_full_confidence` | FAILED |
| `the_camera_dimension_carries_no_delta_and_cannot_raise_confidence` | FAILED |
| `assign::a_camera_body_conflict_is_a_hard_violation_but_a_missing_id_is_not` | FAILED |
| `frames_without_a_camera_id_match_exactly_as_before` | **PASSED — disclosed below** |

`frames_without_a_camera_id_match_exactly_as_before` cannot fail at base: base
applies no penalty either, so it is a guard against over-correction rather than a
reproduction. It discriminates — substituting a wrong implementation that
penalises the both-absent case makes it fail with `Dark: confidence dropped to
0.9 without any camera evidence`.

### Derivation, write paths and read path

Round 1 review found the end-to-end test seeded `camera_body_id` with a direct
SQL `UPDATE`, so it never reached the production derivation: nulling the
derivation left all 11 integration tests green. Both write paths are now driven
from a frame's own header, and each is proven by nulling its derivation.

| Test | Path under test | Mutation | Result |
|---|---|---|---|
| `ingested_session_matches_a_calibration_master` | light ingest, `crates/app/targets/src/ingest_sessions.rs:367` | derivation → `None` | FAILED (`left: None`, `right: Some("player one_camd2282b4c061209000")`) |
| `confirm_master_creates_plan_then_registers_at_apply` | master registration, `crates/app/inbox/src/plan_listener.rs:533-536` | derivation → `None` | FAILED (same shape) |
| `suggest_excludes_a_master_from_a_different_camera_body` | matcher loaders (read side) | all 3 `camera_body_id: r.camera_body_id` mappings → `None` | FAILED |

Both write-path tests extend a test that already drove the real path over a real
FITS file, rather than adding a parallel one; each now asserts a normalized body
id the fixture never wrote. The read-path mutation establishes that seeding that
one fixture by `UPDATE` still exercises the column's read side, so it was kept.

### Derivation unit tests

The four `camera_body.rs` tests cover a function that does not exist at base, so
they were proven against wrong implementations instead, each disclosed:

| Test | Wrong implementation | Result |
|---|---|---|
| `only_a_cameraid_carrying_a_serial_yields_a_body_id` | trust `CAMERAID` verbatim | FAILED (`Some("zwo asi2600mm pro")` vs `None`) |
| `a_blank_or_separatorless_cameraid_yields_no_body_id` | trust `CAMERAID` verbatim | FAILED (`Some("poseidonc")` vs `None`) |
| `two_bodies_of_the_same_model_get_different_ids` | key on `INSTRUME` | FAILED (`left != right`) |
| `normalization_matches_the_optic_train_key_rules` | skip normalization | FAILED |

## Verification

| Command | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` (the lane's own command) | exit 0, 0 errors, 0 warnings |
| `cargo test -p calibration_core -p sessions -p metadata_core -p metadata_fits -p metadata_xisf -p persistence_calibration -p persistence_inbox -p persistence_core` | 427 passed, exit 0 |
| `cargo test -p app_core -p app_core_calibration -p app_core_targets -p app_core_inbox -p app_core_projects` | 1119 passed, 1 ignored, exit 0 |
| `cargo fmt --all -- --check` | exit 0 |
| `scripts/precommit-verify.sh` | exit 0 — **6 hooks actually ran**: added-large-files, detect-private-key, end-of-files, trailing-whitespace, hardcoded-secrets, typos |
| `scripts/check-db-boundary.sh` | exit 0 — 0 production query sites across 428 files |
| `scripts/check-dead-callers.sh` | exit 0 — 529 files scanned, 148 baselined |
| `scripts/check-generated-drift.sh` | exit 0 |
| `git merge origin/main` (at `9bd824eb3`) | merged by `ort`, **no conflicted file** |

Round 1 fixed `clippy::items_after_statements` at
`crates/app/core/tests/calibration_integration.rs` by hoisting two helpers to
module level. A crate-scoped clippy run missed it because the test lives in
`app_core`, which that scope omitted; the lane command above is now what was run.

## Not done

- **No user-assigned body label on the cameras registry.** Step 3 of the bead's
  proposed direction, and the only thing that separates two ZWO or Dwarf bodies,
  which headers cannot distinguish. It needs a registry column, an assignment
  UI, and an attribution flow — out of scope here. Filed as `astro-plan-tktvy`.
- **`astro-plan-3y8tt` is not resolved by this PR.** The `require_same_camera`
  toggle it describes no longer exists: #1729 removed the column from the
  baseline. This PR adds no replacement toggle.
- **Spec-062 `calibration_family.camera_row_id` is untouched.** It cannot
  distinguish two bodies today either — the `camera` table carries
  `row_id`/`public_id`/`display_name` and no serial — and it has no matcher
  consumer.
- No frontend change. `dimension` is a free-form string in the suggest contract
  (`specs/007-calibration-matching-rules/contracts/calibration.match.suggest.json:47`),
  so no schema or binding regeneration was required.

## Breaking change

`camera_body_id` is added to `acquisition_fingerprint` and
`calibration_fingerprint` by editing the `0001` baseline **in place**, which
changes the v1 checksum and makes `migrate()` reject an existing development
database (`crates/persistence/core/src/lib.rs:400-414`). **Delete your local
database and let it be recreated.**

Work bead: `astro-plan-ugux2`. Merge bead: `astro-plan-ozgzc`.

Tracks-Bead: astro-plan-ugux2
Merge-Bead: astro-plan-ozgzc
