### PR TITLE
test(ci): cover the main-push shape in the dead-caller base-resolution self-test

### DIFF
--- a/scripts/check-dead-callers.sh
+++ b/scripts/check-dead-callers.sh
@@ -549,6 +549,12 @@ FIX
 # fixture main deletes `deleted_on_main` on a commit the branch never has, which
 # is the exact shape that reported 39 names on branches that never opened the
 # file.
+#
+# The main-push half covers the other shape: on a push to main `origin/main` is
+# the commit just pushed, the merge base degenerates to HEAD, and the base can
+# only come from HEAD~1. That shape turned main red for three consecutive pushes
+# (astro-plan-9tbwc) while this self-test stayed green, because only the
+# feature-branch shape was constructed.
 base_resolution_self_test() {
     local tmp up work branch_point resolved out rc=0
     tmp="$(mktemp -d)"
@@ -578,6 +584,16 @@ base_resolution_self_test() {
     git -C "$up" add -A
     git -C "$up" commit --quiet -m 'main drops deleted_on_main'
 
+    # The tip adds an untracked name, so a main-push run that resolves its base
+    # correctly has a violation to find, while one that compares the tip with
+    # itself finds nothing.
+    printf '# tracked by astro-plan-aaaa\nkept\n\npushed_untracked\n' \
+        >"$up/scripts/dead-callers-baseline.txt"
+    git -C "$up" add -A
+    git -C "$up" commit --quiet -m 'main push adds an untracked name'
+    local pushed_parent
+    pushed_parent="$(git -C "$up" rev-parse 'HEAD~1')"
+
     git clone --quiet --depth=1 "file://$up" "$work" >/dev/null 2>&1
     git -C "$work" fetch --quiet --depth=1 origin \
         '+refs/heads/feature:refs/remotes/origin/feature' >/dev/null 2>&1
@@ -600,7 +616,110 @@ base_resolution_self_test() {
         return 1
     fi
 
-    echo "OK: base-resolution self-test passed — the base is the branch point, not the ref tip."
+    # Main-push shape. `origin/main` IS the commit just pushed, so the merge base
+    # degenerates to HEAD and only HEAD~1 can serve as a base. A depth-1 checkout
+    # has no HEAD~1, so the gate has no base at all and fails closed; depth 2 is
+    # the shallowest checkout that resolves. The `fetch-depth: 2` on every ci.yml
+    # job running this script is load-bearing for that reason, not incidental.
+    local push_work
+    push_work="$tmp/push-depth1"
+    git clone --quiet --depth=1 "file://$up" "$push_work" >/dev/null 2>&1
+    if [ "$(git -C "$push_work" rev-parse HEAD)" \
+        != "$(git -C "$push_work" rev-parse origin/main)" ]; then
+        echo "FAIL: base-resolution self-test: the main-push fixture does not have origin/main == HEAD." >&2
+        return 1
+    fi
+
+    resolved="$(ROOT="$push_work" DEAD_CALLERS_BASE_REF=origin/main resolve_base_commit)"
+    if [ -n "$resolved" ]; then
+        echo "FAIL: base-resolution self-test: a depth-1 main push resolved a base it cannot have." >&2
+        echo "  expected: []" >&2
+        echo "  actual:   [$resolved]" >&2
+        return 1
+    fi
+
+    rc=0
+    out="$(ROOT="$push_work" SCRIPT_DIR="$push_work/scripts" \
+        BASELINE="$push_work/scripts/dead-callers-baseline.txt" \
+        DEAD_CALLERS_BASE_REF=origin/main CI=1 check_tracking_references 2>&1)" || rc=$?
+    if [ "$rc" -eq 0 ] || ! printf '%s' "$out" | grep -q 'cannot resolve a base'; then
+        echo "FAIL: base-resolution self-test: a depth-1 main push did not fail closed on an unresolvable base." >&2
+        echo "  exit:   [$rc]" >&2
+        printf '%s\n' "$out" >&2
+        return 1
+    fi
+
+    push_work="$tmp/push-depth2"
+    git clone --quiet --depth=2 "file://$up" "$push_work" >/dev/null 2>&1
+    resolved="$(ROOT="$push_work" DEAD_CALLERS_BASE_REF=origin/main resolve_base_commit)"
+    if [ "$resolved" != "$pushed_parent" ]; then
+        echo "FAIL: base-resolution self-test: a depth-2 main push did not fall back to HEAD~1." >&2
+        echo "  expected: [$pushed_parent]" >&2
+        echo "  actual:   [$resolved]" >&2
+        return 1
+    fi
+
+    rc=0
+    out="$(ROOT="$push_work" SCRIPT_DIR="$push_work/scripts" \
+        BASELINE="$push_work/scripts/dead-callers-baseline.txt" \
+        DEAD_CALLERS_BASE_REF=origin/main CI=1 check_tracking_references 2>&1)" || rc=$?
+    if [ "$rc" -eq 0 ] || ! printf '%s' "$out" | grep -q 'pushed_untracked'; then
+        echo "FAIL: base-resolution self-test: a depth-2 main push did not read the pushed commit's own additions." >&2
+        echo "  exit:   [$rc]" >&2
+        printf '%s\n' "$out" >&2
+        return 1
+    fi
+
+    echo "OK: base-resolution self-test passed — the base is the branch point on a branch, HEAD~1 on a main push, and a depth-1 main push fails closed."
+}
+
+# Require every ci.yml job that runs the ratchet to check out at least two
+# commits.
+#
+# Needed because the depth requirement is unobservable from inside the script:
+# the fixture cases above prove a depth-1 main push has no base and fails closed,
+# but nothing stops a workflow from checking out at depth 1 anyway. That is the
+# defect itself -- it reddened main for three consecutive pushes
+# (astro-plan-9tbwc, fixed in #1728) with every self-test green, because the depth
+# lives in the workflow while the failure surfaces here. `fetch-depth: 0` (full
+# history) also satisfies this.
+checkout_depth_self_test() {
+    local workflow report shallow
+    workflow="$ROOT/.github/workflows/ci.yml"
+    if [ ! -f "$workflow" ]; then
+        echo "FAIL: checkout-depth self-test: $workflow is missing." >&2
+        return 1
+    fi
+
+    # `job<TAB>depth` per job running the ratchet; `none` means the job pins no
+    # fetch-depth, and a job with several checkouts is judged on its shallowest.
+    report="$(awk '
+        /^  [A-Za-z0-9_-]+:[[:space:]]*$/ {
+            job = $1; sub(/:$/, "", job); depth[job] = "none"; next
+        }
+        job == "" { next }
+        $1 == "fetch-depth:" {
+            if (depth[job] == "none" || $2 + 0 < depth[job] + 0) depth[job] = $2
+        }
+        /run:[[:space:]]*just dead-callers[[:space:]]*$/ { ratchet[job] = 1 }
+        END { for (j in ratchet) print j "\t" depth[j] }
+    ' "$workflow" | sort)"
+
+    if [ -z "$report" ]; then
+        echo "FAIL: checkout-depth self-test: no ci.yml job runs \`just dead-callers\`, so the depth requirement is unenforced." >&2
+        return 1
+    fi
+
+    shallow="$(printf '%s\n' "$report" | awk -F'\t' \
+        '$2 == "none" || ($2 + 0 > 0 && $2 + 0 < 2) { print "  " $1 " (fetch-depth: " $2 ")" }')"
+    if [ -n "$shallow" ]; then
+        echo "FAIL: checkout-depth self-test: these ci.yml jobs run the ratchet without HEAD~1:" >&2
+        printf '%s\n' "$shallow" >&2
+        echo "On a main push origin/main is the commit just pushed, so the base can only come from HEAD~1 and the ratchet fails closed without it. Set fetch-depth to 2 or more, or 0 for full history." >&2
+        return 1
+    fi
+
+    echo "OK: checkout-depth self-test passed — $(printf '%s\n' "$report" | grep -c . ) ci.yml job(s) running the ratchet check out HEAD~1."
 }
 
 # Fixture corpus: a live fn, a doc-comment-only fn, a test-only fn, one called
@@ -743,6 +862,7 @@ main() {
             self_test
             tracking_self_test
             base_resolution_self_test
+            checkout_depth_self_test
             return
             ;;
     esac
@@ -786,6 +906,11 @@ HDR
 
     base_resolution_self_test >/dev/null || {
         echo "FAIL: base-resolution self-test failed; the tracking check's base is not trustworthy." >&2
+        exit 1
+    }
+
+    checkout_depth_self_test >/dev/null || {
+        echo "FAIL: checkout-depth self-test failed; a workflow runs this ratchet on a checkout too shallow to resolve a base." >&2
         exit 1
     }
 


### PR DESCRIPTION
## What

The dead-caller ratchet's base-resolution self-test only ever built the
feature-branch shape, where the merge base starts empty and the
deepen/unshallow loop resolves it. The main-push shape was never constructed:
on a push to main `origin/main` IS the commit just pushed, so the merge base
degenerates to HEAD and the base can only come from `HEAD~1`. A depth-1
checkout has no `HEAD~1`, so the ratchet failed closed and turned main red for
three consecutive pushes (`astro-plan-9tbwc`, fixed in #1728 with
`fetch-depth: 2`) while the self-test reported green throughout.

Two additions to `scripts/check-dead-callers.sh`, both real repository
fixtures — no stubbing of the function under test:

1. `base_resolution_self_test` gains the main-push shape. Its upstream fixture
   grows a tip commit that adds an untracked name, and two clones are taken off
   it. At depth 1, `resolve_base_commit` must return empty and
   `check_tracking_references` must fail closed naming an unresolvable base. At
   depth 2 it must return `HEAD~1` and the tracking check must report the pushed
   commit's own addition. The case asserts `origin/main == HEAD` in the fixture
   first, so an empty result cannot come from a missing ref.

2. A new `checkout_depth_self_test` over `.github/workflows/ci.yml`. The
   fixture cases pin the contract but cannot see the workflow, and the workflow
   is where the original defect lived. It keys on `run: just dead-callers`
   rather than a step label, requires `fetch-depth` of 2 or more (or 0), and
   fails rather than passing if it matches no job.

Both are wired into `--self-test` and into the pre-run guard in `main()`.

## Verification

| Command | Exit |
| --- | --- |
| `bash scripts/check-dead-callers.sh --self-test` | 0 (4 cases OK) |
| `shellcheck scripts/check-dead-callers.sh` | 0 |
| `just dead-callers` | 0 — `no new dead pub fns across 529 scanned file(s) (148 baselined)` |
| `bash scripts/precommit-verify.sh scripts/check-dead-callers.sh` | 0 — 6 hooks ran and passed |

No cargo build was run: this is a shell-only change and touches no Rust.

## Mutation results

Each mutation was applied, the self-test run, then reverted.

| Mutation | Result |
| --- | --- |
| Delete `fetch-depth: 2` from both `ci.yml` jobs — the original #1728 defect | FAIL: checkout-depth case, naming `integration` and `dead-caller-main` |
| Delete the `HEAD~1` reassignment in `resolve_base_commit` | FAIL: depth-1 case resolved a base it cannot have |
| Reassign the base to `HEAD` instead of `HEAD~1` | FAIL: depth-2 case did not fall back to `HEAD~1` |
| Make an unresolvable base skip instead of fail closed under CI | FAIL: depth-1 fail-closed case, exit 0 |

The third mutation exists because the second short-circuits at the depth-1 case;
it isolates the depth-2 assertion and is the "baseline compared with itself"
regression in its own right.

## Deepen/unshallow coverage

Already covered, measured rather than reasoned. A traced run shows the existing
feature-branch case entering both rungs, `--deepen=50` then `--unshallow`, with
`--unshallow` the one that resolves. The new main-push cases do not enter the
loop: `[ -z "$base" ]` guards it and a degenerate base is non-empty, which is
why #1728 had to fix this at the checkout level.

## Not done here

- `astro-plan-k7azh` is NOT unblocked, and its premise does not hold against
  this tree. `scripts/check-hot-read-ratchet.sh` performs no git base
  resolution at all — `grep -n 'merge-base\|HEAD~\|origin/main\|BASE_REF\|rev-parse'`
  over it returns nothing, and it compares against a checked-in baseline in the
  working tree. Across `scripts/*.sh` only `check-dead-callers.sh` and
  `bd-close-guard.sh` use `merge-base`, and only `check-dead-callers.sh` uses
  `HEAD~1`; `bd-close-guard.sh`'s use is `--is-ancestor`, which has no
  degenerate-base hazard. So there is no identical defect to fix there and no
  pattern to reuse for it. `k7azh` needs its premise re-checked, not a fix.
- `astro-plan-8vxx1` (the pre-existing `appliable` typos failure) is untouched.
- No change to `.github/workflows/ci.yml` itself; the new case reads it.

Tracks-Bead: astro-plan-lg8ok
Closes-Bead: astro-plan-lg8ok
Merge-Bead: astro-plan-ws12a
