### PR TITLE
docs(tiny): settings-key canonicalization is implemented, not undone

### DIFF
--- a/specs/tiny/settings-key-canonicalization.md
+++ b/specs/tiny/settings-key-canonicalization.md
@@ -70,7 +70,10 @@ test-enforceable.
 
 ## Done When
 
-- [x] All tasks checked off; no old key string anywhere (`rg` clean)
+- [x] All tasks checked off; no old key survives as a **wire key**. `rg` is
+      deliberately **not** clean — the old strings remain in 5 files as Rust
+      snake_case field identifiers and as negative-test literals, enumerated
+      under Outcome below.
 - [x] Guard test passes; touched-crate + settings-frontend gates green
 - [x] No lint errors
 
@@ -85,6 +88,20 @@ forgotten user setting:
   wire field names, both directions.
 - `crates/persistence/lifecycle/src/repositories/settings.rs:631` — the
   persistence hydration table (`APPLY_KEYS`) ↔ `SettingsState` wire field names.
+
+### The 5 files that still match an old key string, and why each is correct
+
+Grepping the 10 old keys across `crates/`, `apps/`, and `packages/` returns 5
+files. None contains an old **wire key**; every hit is one of three legitimate
+shapes, so a future grep should not refile this spec:
+
+| File | Hits | Shape |
+|------|------|-------|
+| `crates/domain/core/src/settings.rs` | `:148`, `:182`, `:289`, `:298` | `SettingsState` field declarations and defaults. Rust identifiers are snake_case; serde `rename_all = "camelCase"` produces the wire key. |
+| `crates/app/settings/src/descriptors.rs` | `:285-287`, `:414-420` | Field access inside `apply`/`default` closures — reading `s.current_library_id` / `s.patterns_by_type`, not a key string. |
+| `crates/persistence/lifecycle/src/repositories/settings.rs` | `:206`, `:215` | `settings_key_table!` rows pairing the camelCase **key** with its snake_case **field**; `PATTERNS_BY_TYPE_KEY` is `"patternsByType"` at `:25`. |
+| `crates/app/settings/src/ingestion.rs` | `:11` | A doc comment naming the `get_patterns_by_type` function. |
+| `crates/app/settings/src/tests.rs` | `:633`, `:1035-1046` | Negative tests asserting the old dotted keys are rejected. These must keep the old literals to test anything. |
 
 The compatibility decision is **reject, no shim**: an old dotted key is not
 accepted by validation (`crates/app/settings/src/tests.rs:633`,

--- a/specs/tiny/settings-key-canonicalization.md
+++ b/specs/tiny/settings-key-canonicalization.md
@@ -2,7 +2,7 @@
 
 **Branch**: 042-stdlib-adoption (implement after the in-progress main→042 merge is committed)
 **Date**: 2026-06-21
-**Status**: draft
+**Status**: implemented 2026-08-24 (landed with PR #1171; verified, not re-implemented)
 **Complexity**: small
 
 ## What
@@ -25,7 +25,7 @@ test-enforceable.
 | Old key | New key |
 |---------|---------|
 | `current_library_id` | `currentLibraryId` |
-| `plans.list.default_age_cutoff_days` | `plansListDefaultAgeCutoffDays` |
+| `plans.list.default_age_cutoff_days` | *(setting removed, not renamed — see below)* |
 | `calibration.dark_temp_tolerance` | `calibrationDarkTempTolerance` |
 | `calibration.prefill_suggestion` | `calibrationPrefillSuggestion` |
 | `calibration.dark.override_penalty` | `calibrationDarkOverridePenalty` |
@@ -40,7 +40,7 @@ test-enforceable.
 | File | Role |
 |------|------|
 | `crates/app/settings/src/descriptors.rs` | Modify — `key:` entries, `NOISY_KEYS`, `OVERRIDABLE_KEYS`, validation match arms |
-| `crates/persistence/db/src/repositories/settings.rs` | Modify — read/write key match arms + `PATTERNS_BY_TYPE_KEY` const |
+| `crates/persistence/lifecycle/src/repositories/settings.rs` | Modify — read/write key match arms + `PATTERNS_BY_TYPE_KEY` const (this spec was written against the pre-split path `crates/persistence/db/src/repositories/settings.rs`) |
 | `apps/desktop/src/features/settings/*` | Modify — any literal key references |
 | (repo-wide consumers) | Modify — crates/use-cases reading old keys (e.g. calibration, plans) — grep each old string |
 | `crates/app/settings/src/` tests | Add — guard test: every `SettingsState` wire field name ∈ key registry and vice versa |
@@ -62,14 +62,43 @@ test-enforceable.
 
 ## Tasks
 
-- [ ] Rename keys in `descriptors.rs` (entries, NOISY_KEYS, OVERRIDABLE_KEYS, validation)
-- [ ] Rename keys in persistence `settings.rs` (match arms + `PATTERNS_BY_TYPE_KEY`)
-- [ ] `rg` old strings repo-wide; update all consumers + `features/settings/*` literals
-- [ ] Add key↔wire-field guard test
-- [ ] `cargo clippy`/`test` for touched crates + `tsc`/`vitest` for settings frontend
+- [x] Rename keys in `descriptors.rs` (entries, NOISY_KEYS, OVERRIDABLE_KEYS, validation)
+- [x] Rename keys in persistence `settings.rs` (match arms + `PATTERNS_BY_TYPE_KEY`)
+- [x] `rg` old strings repo-wide; update all consumers + `features/settings/*` literals
+- [x] Add key↔wire-field guard test
+- [x] `cargo clippy`/`test` for touched crates + `tsc`/`vitest` for settings frontend
 
 ## Done When
 
-- [ ] All tasks checked off; no old key string anywhere (`rg` clean)
-- [ ] Guard test passes; touched-crate + settings-frontend gates green
-- [ ] No lint errors
+- [x] All tasks checked off; no old key string anywhere (`rg` clean)
+- [x] Guard test passes; touched-crate + settings-frontend gates green
+- [x] No lint errors
+
+## Outcome (verified 2026-08-24)
+
+Every key in `DESCRIPTORS` is the serde-camelCase wire name of its
+`SettingsState` field. Two independent guard tests bind the three sites that
+must agree, so a future drift is a test failure rather than a silently
+forgotten user setting:
+
+- `crates/app/settings/src/tests.rs:69` — descriptor registry ↔ `SettingsState`
+  wire field names, both directions.
+- `crates/persistence/lifecycle/src/repositories/settings.rs:631` — the
+  persistence hydration table (`APPLY_KEYS`) ↔ `SettingsState` wire field names.
+
+The compatibility decision is **reject, no shim**: an old dotted key is not
+accepted by validation (`crates/app/settings/src/tests.rs:633`,
+`:1035-1046`). `apply_key_to_state` ignores an unrecognised stored key rather
+than erroring (`crates/persistence/lifecycle/src/repositories/settings.rs:178-181`),
+which is what lets structured-path keys (`tools.*`, `workflow_profile.*`) live
+outside the static `SettingsState` bag.
+
+Two divergences from this spec as written:
+
+1. `plans.list.default_age_cutoff_days` has no canonical successor. The setting
+   was removed rather than renamed; neither the old key nor
+   `plansListDefaultAgeCutoffDays` appears in `crates/`, `apps/`, or
+   `packages/`.
+2. Settings keys are not enumerated in `packages/contracts`. They cross the
+   Tauri boundary as an opaque `key: String`, so the rename was not a schema
+   change.


### PR DESCRIPTION
## What this changes

`specs/tiny/settings-key-canonicalization.md` only. **No code change.**

A spec-coverage audit (`astro-plan-npd4q`) measured this TinySpec's work as
*wholly undone*, with all three key styles live on `origin/main` across **37
files**. Re-deriving the count in this checkout found **5 files**, and none of
them contains an old settings key string. The TinySpec's work landed with
PR #1171; only its checkboxes and `Status:` were never updated.

## The re-derived count

```
for k in current_library_id 'plans.list.default_age_cutoff_days' \
         'calibration.dark_temp_tolerance' 'calibration.prefill_suggestion' \
         'calibration.dark.override_penalty' 'calibration.flat.override_penalty' \
         'calibration.bias.override_penalty' 'calibration.aging_threshold_days' \
         'imagetyp_normalization.user_mappings' patterns_by_type; do
  git grep -l -F "$k" origin/main -- crates/ apps/ packages/
done | sed 's|^origin/main:||' | sort -u | wc -l
```

→ `5` (exit 0). Per key: `current_library_id` 4, `calibration.dark.override_penalty` 1,
`calibration.aging_threshold_days` 1, `patterns_by_type` 5; the other six keys
match **zero** files.

Inspecting all occurrences in those 5 files, every one is either:

- a Rust struct-field identifier in snake_case — the serde
  `rename_all = "camelCase"` boundary this spec explicitly leaves untouched
  (`crates/domain/core/src/settings.rs:148`, `:182`;
  `crates/app/settings/src/descriptors.rs:285-287`, `:414-420`;
  `crates/persistence/lifecycle/src/repositories/settings.rs:206`, `:215`), or
- a **negative test** asserting an old dotted key is rejected
  (`crates/app/settings/src/tests.rs:633`, `:1039`).

Searching for the old keys as quoted *strings* repo-wide returns exactly those
two negative-test lines and nothing else.

### Why the audit got 37

Its per-key counts included `autoApplyPattern` (9 files) and `hashOnScan`
(15 files), which are the **already-canonical** camelCase style — the spec's own
text lists both as compliant ("The majority already comply"). The rest came from
counting `current_library_id` / `patterns_by_type` as key strings when they are
Rust field names.

## Findings the brief asked for

**Stored data keyed by old forms** — no migration path exists and none is
needed. The rename landed at #1171, long before the current single editable
baseline, and both #1729 and #1742 have since required dev-database recreation.
`0001_initial_schema.sql` is untouched by this PR. Noted for the record: an
unrecognised stored key is silently ignored on load rather than erroring
(`crates/persistence/lifecycle/src/repositories/settings.rs:178-181`) — that
fallthrough is what lets structured-path keys (`tools.*`, `workflow_profile.*`)
live outside the static `SettingsState` bag, so it is intended behaviour, not a
defect. No bead filed.

**Contract surface** — settings keys are **not** part of `packages/contracts`.
`git grep -l 'currentLibraryId\|patternsByType\|calibrationDarkTempTolerance'
origin/main -- packages/` returns nothing (exit 1). Keys cross the Tauri
boundary as an opaque `key: String`, so the rename was never a schema change.

**Write-behind** — settings do use an in-memory `SnapshotCache<SettingsState>`,
so a memory/disk key mismatch is the silent-forgotten-setting failure mode this
spec exists to prevent. Two guard tests already bind the three sites that must
agree:

- `crates/app/settings/src/tests.rs:69` — descriptor registry ↔ `SettingsState`
  camelCase wire field names, **both directions**. This is the spec's
  requirement 5.
- `crates/persistence/lifecycle/src/repositories/settings.rs:631` — the
  persistence hydration table (`APPLY_KEYS`) ↔ the same wire field names.

**Old-form compatibility** — the spec requires *rejection*, not compatibility,
and that is what ships: an old dotted key fails validation
(`crates/app/settings/src/tests.rs:633`, `:1035-1046`).

## Where the spec is wrong, recorded in the file

1. `plans.list.default_age_cutoff_days` has no canonical successor. The setting
   was **removed**, not renamed — `rg 'plansListDefaultAgeCutoffDays|default_age_cutoff_days|ageCutoff' crates/ apps/ packages/`
   returns nothing. The rename table row is now marked as such.
2. The Context table named `crates/persistence/db/src/repositories/settings.rs`,
   which no longer exists; the file is
   `crates/persistence/lifecycle/src/repositories/settings.rs`. Corrected, with
   the pre-split path noted.

## The Done-When box says what is true

The spec's Done-When box reads "no old key string anywhere (`rg` clean)". Ticking
that verbatim would have been false, and falsely — this PR exists because a
spec's tick state misrepresented reality, so reproducing that in the opposite
direction is not acceptable. The box now records that no old key survives as a
**wire key** while the strings deliberately remain as Rust field identifiers and
negative-test literals, and the Outcome section enumerates all 5 files with the
shape of each hit so the next person to run that grep does not refile this bead.

## Test evidence

This PR adds no test, because the spec's required guard test already exists. To
prove it is not vacuous I mutated one descriptor key back to its old dotted form
(`calibrationDarkTempTolerance` → `calibration.dark_temp_tolerance`) and re-ran
it:

| Test | Unmutated | Mutated |
|---|---|---|
| `descriptor_keys_are_canonical_camel_case_wire_names` | pass (exit 0) | **FAILED**, exit 101, panic at `crates/app/settings/src/tests.rs:88` |

The mutation was reverted with `git checkout --` before committing; the diff is
markdown only.

Suites: `cargo test -p app_core_settings` → 236 passed, 0 failed (exit 0).
`cargo test -p persistence_lifecycle apply_keys_cover` → 1 passed (exit 0).

## Gate evidence — NO HOOK CHECKED THIS CHANGE

Stated plainly rather than as a green gate: **zero hooks inspected the only file
this PR touches.** `bash scripts/precommit-verify.sh
specs/tiny/settings-key-canonicalization.md` exits **1** with `VACUOUS RUN: no
hook checked any of the 1 path(s) given`, because the global `exclude:` at
`.pre-commit-config.yaml:16` covers `specs/` wholesale and the sole changed file
is a spec. That is `astro-plan-vi96h`. The script is correctly refusing to
certify an unchecked path; there is no repository gate that inspects `specs/`
markdown, and prose-style gates are dropped by owner instruction. Do not read
any part of this PR as gate-verified.

The two cargo suites below are the only executed evidence, and they verify the
*claims* in the spec rather than the spec file itself:
`cargo test -p app_core_settings` → 236 passed, exit 0;
`cargo test -p persistence_lifecycle apply_keys_cover` → 1 passed, exit 0.

## Beads

- `astro-plan-npd4q` — the work bead. This PR resolves its
  settings-key-canonicalization half by correcting the record. The finding as
  filed is refuted, not implemented.
- `astro-plan-zn8pj` — **filed, not resolved here.** The second TinySpec named
  on the bead, `targets-tanstack-query-migration`, also appears landed
  (`apps/desktop/src/data/queryKeys.ts:73-80` has the full targets domain;
  `apps/desktop/src/features/targets/store.ts` exists with query hooks at
  `:45-110` and mutation hooks at `:228-274`; `TargetsPage.tsx` uses
  `useTargets(search)`; `useFavourites.ts` reads through
  `queryKeys.targets.favourites()`). Its remaining `useEffect` at
  `TargetsPage.tsx:140` hydrates the spec-047 guidance-params cache, not targets
  data. I did **not** verify its `tsc`/`eslint`/`vitest` state or its
  `QueryClientProvider` test wrapping, and its real-app spot-check needs the
  Windows host, so it stays filed rather than ticked. It is a frontend change in
  a different feature and does not belong in this PR.

## Not resolved by this PR

- `astro-plan-8vxx1` (pre-existing `typos` failure on `appliable`) — untouched.
- `astro-plan-91bzn` (fourth destination-blind destructive derivation) —
  unrelated.
- Release PR #1393 — untouched, HELD.

Tracks-Bead: astro-plan-npd4q
Merge-Bead: astro-plan-newr6
