### PR TITLE
docs(journeys): mark the frozen pre-migration tree superseded on the paths readers arrive by

### DIFF
--- a/docs/product/journeys/INDEX.md
+++ b/docs/product/journeys/INDEX.md
@@ -1,3 +1,8 @@
+> **MIGRATED:** current truth now lives under `docs/journeys/`, whose
+> `INDEX.md` is the generated routing table. This file is frozen legacy
+> history from the pre-migration campaign and may not match current
+> behavior. See `docs/product/journeys/README.md`.
+
 # Wave 0 rerun plan — per-journey state
 
 For each journey Wave 0 touches: the union of stages needing rerun, which tasks trigger each, the minimal rerun set, and coverage gaps. This is the sheet the team executes: rerun only the listed stages, not whole journeys. Stage labels are quoted from `JNN-slug/journey.md`; NEW stages (behavior Wave 0 introduces that no current journey stage covers) are flagged **journey doc update needed**.

--- a/docs/product/journeys/J01-first-run-setup-data-sources/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J01-first-run-setup-data-sources/deltas/2026-07-14-jval-docdrift.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J01-first-run-setup-data-sources/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # jval-docdrift — J01-first-run-setup-data-sources: Wizard is 6 steps with a new Observing Site step; Project outputs is required
 
 Task: jval-docdrift · Status: observed-live-2026-07-14

--- a/docs/product/journeys/J01-first-run-setup-data-sources/deltas/2026-07-14-q15-t123.md
+++ b/docs/product/journeys/J01-first-run-setup-data-sources/deltas/2026-07-14-q15-t123.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J01-first-run-setup-data-sources/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t123 — J01-first-run-setup-data-sources: Source protection override is audited
 
 Task: q15-t123 · Status: merged-spec

--- a/docs/product/journeys/J01-first-run-setup-data-sources/deltas/2026-07-14-q15-t125.md
+++ b/docs/product/journeys/J01-first-run-setup-data-sources/deltas/2026-07-14-q15-t125.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J01-first-run-setup-data-sources/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t125 — J01-first-run-setup-data-sources: Source register/enable/disable/remap/rescan audited
 
 Task: q15-t125 · Status: merged-spec

--- a/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-jval-docdrift.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J02-ingest-review-reclassify-confirm-move/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # jval-docdrift — J02-ingest-review-reclassify-confirm-move: Destination-root picker surfaces inside the Review-plans overlay, not an inline Confirm modal
 
 Task: jval-docdrift · Status: observed-live-2026-07-14

--- a/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q15-t125.md
+++ b/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q15-t125.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J02-ingest-review-reclassify-confirm-move/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t125 — J02-ingest-review-reclassify-confirm-move: Inbox Rescan is audited
 
 Task: q15-t125 · Status: merged-spec

--- a/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q16-t131.md
+++ b/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q16-t131.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J02-ingest-review-reclassify-confirm-move/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t131 — J02-ingest-review-reclassify-confirm-move: PropertyTable couples source badge to value presence
 
 Task: q16-t131 · Status: merged-spec

--- a/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q16-t132.md
+++ b/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q16-t132.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J02-ingest-review-reclassify-confirm-move/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t132 — J02-ingest-review-reclassify-confirm-move: Shared renderer adopted on this surface
 
 Task: q16-t132 · Status: merged-spec

--- a/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q16-t133.md
+++ b/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q16-t133.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J02-ingest-review-reclassify-confirm-move/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t133 — J02-ingest-review-reclassify-confirm-move: Detail panel adds information over its row
 
 Task: q16-t133 · Status: merged-spec

--- a/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q27-f10.md
+++ b/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q27-f10.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J02-ingest-review-reclassify-confirm-move/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f10 — J02-ingest-review-reclassify-confirm-move: Confirm persists the chosen attribution
 
 Task: q27-f10 · Status: merged-spec

--- a/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q27-f5.md
+++ b/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q27-f5.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J02-ingest-review-reclassify-confirm-move/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f5 — J02-ingest-review-reclassify-confirm-move: Inbox confirm suggests framing/project attribution (NEW)
 
 Task: q27-f5 · Status: merged-spec

--- a/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q27-f6.md
+++ b/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-q27-f6.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J02-ingest-review-reclassify-confirm-move/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f6 — J02-ingest-review-reclassify-confirm-move: Attribution to a completed project offers add + reopen
 
 Task: q27-f6 · Status: merged-spec

--- a/docs/product/journeys/J03-ingest-confirm-catalogue-in-place/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J03-ingest-confirm-catalogue-in-place/deltas/2026-07-14-jval-docdrift.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J03-ingest-confirm-catalogue-in-place/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # jval-docdrift — J03-ingest-confirm-catalogue-in-place: Rescan-all-roots is inbox-only; catalogue plan's destructive-destination control observed absent
 
 Task: jval-docdrift · Status: observed-live-2026-07-14

--- a/docs/product/journeys/J03-ingest-confirm-catalogue-in-place/deltas/2026-07-14-q27-f10.md
+++ b/docs/product/journeys/J03-ingest-confirm-catalogue-in-place/deltas/2026-07-14-q27-f10.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J03-ingest-confirm-catalogue-in-place/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f10 — J03-ingest-confirm-catalogue-in-place: Catalogue confirm persists attribution identically
 
 Task: q27-f10 · Status: merged-spec

--- a/docs/product/journeys/J03-ingest-confirm-catalogue-in-place/deltas/2026-07-14-q27-f5.md
+++ b/docs/product/journeys/J03-ingest-confirm-catalogue-in-place/deltas/2026-07-14-q27-f5.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J03-ingest-confirm-catalogue-in-place/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f5 — J03-ingest-confirm-catalogue-in-place: Catalogue-in-place confirm also runs attribution (NEW)
 
 Task: q27-f5 · Status: merged-spec

--- a/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-jval-docdrift.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J04-sessions-review-derived/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # jval-docdrift — J04-sessions-review-derived: PR #415 interaction-parity gap is closed; frame-type filter intentionally removed
 
 Task: jval-docdrift · Status: observed-live-2026-07-14

--- a/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-q16-t129.md
+++ b/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-q16-t129.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J04-sessions-review-derived/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t129 — J04-sessions-review-derived: Session detail stops synthesizing absent metadata
 
 Task: q16-t129 · Status: merged-spec

--- a/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-q16-t131.md
+++ b/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-q16-t131.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J04-sessions-review-derived/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t131 — J04-sessions-review-derived: PropertyTable couples source badge to value presence
 
 Task: q16-t131 · Status: merged-spec

--- a/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-q16-t132.md
+++ b/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-q16-t132.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J04-sessions-review-derived/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t132 — J04-sessions-review-derived: Shared renderer adopted on this surface
 
 Task: q16-t132 · Status: merged-spec

--- a/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-q16-t133.md
+++ b/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-q16-t133.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J04-sessions-review-derived/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t133 — J04-sessions-review-derived: Detail panel adds information over its row
 
 Task: q16-t133 · Status: merged-spec

--- a/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-q27-f10.md
+++ b/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-q27-f10.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J04-sessions-review-derived/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f10 — J04-sessions-review-derived: Sessions show framing membership
 
 Task: q27-f10 · Status: merged-spec

--- a/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-jval-docdrift.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J05-project-lifecycle/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # jval-docdrift — J05-project-lifecycle: Duplicate-name error fires at Create-time, not as-you-type
 
 Task: jval-docdrift · Status: observed-live-2026-07-14

--- a/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q16-t132.md
+++ b/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q16-t132.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J05-project-lifecycle/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t132 — J05-project-lifecycle: Shared renderer adopted on this surface
 
 Task: q16-t132 · Status: merged-spec

--- a/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q16-t133.md
+++ b/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q16-t133.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J05-project-lifecycle/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t133 — J05-project-lifecycle: Detail panel adds information over its row
 
 Task: q16-t133 · Status: merged-spec

--- a/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f11.md
+++ b/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f11.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J05-project-lifecycle/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f11 — J05-project-lifecycle: Tolerance changes affect clustering
 
 Task: q27-f11 · Status: merged-spec

--- a/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f2.md
+++ b/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f2.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J05-project-lifecycle/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f2 — J05-project-lifecycle: Project light sessions cluster into framings (NEW)
 
 Task: q27-f2 · Status: merged-spec

--- a/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f3.md
+++ b/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f3.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J05-project-lifecycle/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f3 — J05-project-lifecycle: Merge/split/reassign framings (NEW)
 
 Task: q27-f3 · Status: merged-spec

--- a/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f4.md
+++ b/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f4.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J05-project-lifecycle/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f4 — J05-project-lifecycle: Mosaic-mode flag on project create/update (NEW)
 
 Task: q27-f4 · Status: merged-spec

--- a/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f6.md
+++ b/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f6.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J05-project-lifecycle/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f6 — J05-project-lifecycle: Project reopens via completed→processing on attribution add
 
 Task: q27-f6 · Status: merged-spec

--- a/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f7.md
+++ b/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-q27-f7.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J05-project-lifecycle/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f7 — J05-project-lifecycle: Per-framing source view + manifest (NEW, blocked)
 
 Task: q27-f7 · Status: blocked-on-Q20/Q10

--- a/docs/product/journeys/J06-cleanup-scan-review-apply/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J06-cleanup-scan-review-apply/deltas/2026-07-14-jval-docdrift.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J06-cleanup-scan-review-apply/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # jval-docdrift — J06-cleanup-scan-review-apply: PR #413 UI gap is stale; real blocker is the protection/audit backend
 
 Task: jval-docdrift · Status: observed-live-2026-07-14

--- a/docs/product/journeys/J06-cleanup-scan-review-apply/deltas/2026-07-14-q15-t123.md
+++ b/docs/product/journeys/J06-cleanup-scan-review-apply/deltas/2026-07-14-q15-t123.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J06-cleanup-scan-review-apply/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t123 — J06-cleanup-scan-review-apply: Cleanup protected-item acknowledgement is audited
 
 Task: q15-t123 · Status: merged-spec

--- a/docs/product/journeys/J07-archive-delete/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J07-archive-delete/deltas/2026-07-14-jval-docdrift.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J07-archive-delete/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # jval-docdrift — J07-archive-delete: Archive button auto-generates the plan in one click; Known-gap #1 is false
 
 Task: jval-docdrift · Status: observed-live-2026-07-14

--- a/docs/product/journeys/J07-archive-delete/deltas/2026-07-14-q15-t123.md
+++ b/docs/product/journeys/J07-archive-delete/deltas/2026-07-14-q15-t123.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J07-archive-delete/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t123 — J07-archive-delete: Archive protected-item acknowledgement is audited
 
 Task: q15-t123 · Status: merged-spec

--- a/docs/product/journeys/J07-archive-delete/deltas/2026-07-14-q16-t132.md
+++ b/docs/product/journeys/J07-archive-delete/deltas/2026-07-14-q16-t132.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J07-archive-delete/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t132 — J07-archive-delete: Shared renderer adopted on this surface
 
 Task: q16-t132 · Status: merged-spec

--- a/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-jval-docdrift.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J08-calibration-ingest-masters-matching/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # jval-docdrift — J08-calibration-ingest-masters-matching: Master detection requires master-style filenames or IMAGETYP=master
 
 Task: jval-docdrift · Status: observed-live-2026-07-14

--- a/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q15-t122.md
+++ b/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q15-t122.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J08-calibration-ingest-masters-matching/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t122 — J08-calibration-ingest-masters-matching: Offset-tolerance change is audited
 
 Task: q15-t122 · Status: merged-spec

--- a/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q16-t128.md
+++ b/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q16-t128.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J08-calibration-ingest-masters-matching/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t128 — J08-calibration-ingest-masters-matching: Master detail stops fabricating Gain 0 / Size 0 KB
 
 Task: q16-t128 · Status: merged-spec

--- a/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q16-t129.md
+++ b/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q16-t129.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J08-calibration-ingest-masters-matching/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t129 — J08-calibration-ingest-masters-matching: De-zero calibration fingerprints and master size
 
 Task: q16-t129 · Status: merged-spec

--- a/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q16-t131.md
+++ b/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q16-t131.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J08-calibration-ingest-masters-matching/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t131 — J08-calibration-ingest-masters-matching: PropertyTable couples source badge to value presence
 
 Task: q16-t131 · Status: merged-spec

--- a/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q16-t132.md
+++ b/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q16-t132.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J08-calibration-ingest-masters-matching/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t132 — J08-calibration-ingest-masters-matching: Shared renderer adopted on this surface
 
 Task: q16-t132 · Status: merged-spec

--- a/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q16-t133.md
+++ b/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-q16-t133.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J08-calibration-ingest-masters-matching/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t133 — J08-calibration-ingest-masters-matching: Detail panel adds information over its row
 
 Task: q16-t133 · Status: merged-spec

--- a/docs/product/journeys/J09-targets-planning/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J09-targets-planning/deltas/2026-07-14-jval-docdrift.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J09-targets-planning/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # jval-docdrift — J09-targets-planning: 044/047 shipped — astronomy columns are real, not stubs (reconciles q16-t132/t133)
 
 Task: jval-docdrift · Status: observed-live-2026-07-14

--- a/docs/product/journeys/J09-targets-planning/deltas/2026-07-14-q16-t132.md
+++ b/docs/product/journeys/J09-targets-planning/deltas/2026-07-14-q16-t132.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J09-targets-planning/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t132 — J09-targets-planning: Shared renderer adopted on this surface
 
 Task: q16-t132 · Status: merged-spec

--- a/docs/product/journeys/J09-targets-planning/deltas/2026-07-14-q16-t133.md
+++ b/docs/product/journeys/J09-targets-planning/deltas/2026-07-14-q16-t133.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J09-targets-planning/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t133 — J09-targets-planning: Detail panel adds information over its row
 
 Task: q16-t133 · Status: merged-spec

--- a/docs/product/journeys/J10-settings-appearance-i18n/deltas/2026-07-14-q15-t122.md
+++ b/docs/product/journeys/J10-settings-appearance-i18n/deltas/2026-07-14-q15-t122.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J10-settings-appearance-i18n/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t122 — J10-settings-appearance-i18n: Settings mutations write durable audit rows
 
 Task: q15-t122 · Status: merged-spec

--- a/docs/product/journeys/J10-settings-appearance-i18n/deltas/2026-07-14-q15-t126.md
+++ b/docs/product/journeys/J10-settings-appearance-i18n/deltas/2026-07-14-q15-t126.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J10-settings-appearance-i18n/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t126 — J10-settings-appearance-i18n: Bottom log panel severity from durable audit
 
 Task: q15-t126 · Status: blocked-on-Q9

--- a/docs/product/journeys/J10-settings-appearance-i18n/deltas/2026-07-14-q27-f11.md
+++ b/docs/product/journeys/J10-settings-appearance-i18n/deltas/2026-07-14-q27-f11.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J10-settings-appearance-i18n/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f11 — J10-settings-appearance-i18n: Clustering tunables in Settings (NEW)
 
 Task: q27-f11 · Status: merged-spec

--- a/docs/product/journeys/J12-failure-refusal-handling/deltas/2026-07-14-q15-t127.md
+++ b/docs/product/journeys/J12-failure-refusal-handling/deltas/2026-07-14-q15-t127.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J12-failure-refusal-handling/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t127 — J12-failure-refusal-handling: Refused/failed mutations are durably audited
 
 Task: q15-t127 · Status: merged-spec

--- a/docs/product/journeys/J12-failure-refusal-handling/deltas/2026-07-14-q16-t130.md
+++ b/docs/product/journeys/J12-failure-refusal-handling/deltas/2026-07-14-q16-t130.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J12-failure-refusal-handling/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q16-t130 — J12-failure-refusal-handling: Unresolved chip is visually distinct from an error
 
 Task: q16-t130 · Status: merged-spec

--- a/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t122.md
+++ b/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t122.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J13-audit-activity-investigation/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t122 — J13-audit-activity-investigation: Audit Log now shows settings changes
 
 Task: q15-t122 · Status: merged-spec

--- a/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t123.md
+++ b/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t123.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J13-audit-activity-investigation/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t123 — J13-audit-activity-investigation: Protection changes appear in the Audit Log
 
 Task: q15-t123 · Status: merged-spec

--- a/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t124.md
+++ b/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t124.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J13-audit-activity-investigation/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t124 — J13-audit-activity-investigation: Equipment changes are in the Audit Log
 
 Task: q15-t124 · Status: merged-spec

--- a/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t125.md
+++ b/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t125.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J13-audit-activity-investigation/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t125 — J13-audit-activity-investigation: Source/rescan ops appear in the Audit Log
 
 Task: q15-t125 · Status: merged-spec

--- a/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t126.md
+++ b/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t126.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J13-audit-activity-investigation/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t126 — J13-audit-activity-investigation: Activity panel reads durable audit
 
 Task: q15-t126 · Status: blocked-on-Q9

--- a/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t127.md
+++ b/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q15-t127.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J13-audit-activity-investigation/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t127 — J13-audit-activity-investigation: Audit negative-space is enforced
 
 Task: q15-t127 · Status: merged-spec

--- a/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q27-f3.md
+++ b/docs/product/journeys/J13-audit-activity-investigation/deltas/2026-07-14-q27-f3.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J13-audit-activity-investigation/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f3 — J13-audit-activity-investigation: Framing adjustments emit audit events
 
 Task: q27-f3 · Status: merged-spec

--- a/docs/product/journeys/J14-target-first-project-start/deltas/2026-07-14-q27-f4.md
+++ b/docs/product/journeys/J14-target-first-project-start/deltas/2026-07-14-q27-f4.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J14-target-first-project-start/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q27-f4 — J14-target-first-project-start: Mosaic flag available in target-first create
 
 Task: q27-f4 · Status: merged-spec

--- a/docs/product/journeys/J15-equipment-observing-site-setup/deltas/2026-07-14-q15-t124.md
+++ b/docs/product/journeys/J15-equipment-observing-site-setup/deltas/2026-07-14-q15-t124.md
@@ -1,3 +1,9 @@
+> **MIGRATED:** current truth now lives at
+> `docs/journeys/J15-equipment-observing-site-setup/journey.md`.
+> This delta is frozen legacy history: it records behavior as understood on
+> its own date and may not match current behavior.
+> See `docs/product/journeys/README.md`.
+
 # q15-t124 — J15-equipment-observing-site-setup: Equipment CRUD is audited
 
 Task: q15-t124 · Status: merged-spec

--- a/docs/product/journeys/README.md
+++ b/docs/product/journeys/README.md
@@ -1,0 +1,37 @@
+# Frozen pre-migration journey history
+
+> **MIGRATED:** current truth lives under `docs/journeys/`. Nothing in this
+> directory describes current product behavior.
+
+This tree is the pre-migration journey catalogue, frozen on 2026-07-15. It is
+retained, not abandoned: the live journeys under `docs/journeys/` cite these
+files by path in their `trace:` frontmatter as the provenance for their
+baselines, and the per-task behavior deltas here exist nowhere else.
+
+For current journey truth use `docs/journeys/`:
+
+| For | Read |
+|---|---|
+| Per-journey routing table (generated) | `docs/journeys/INDEX.md` |
+| Journey file format spec | `docs/journeys/FORMAT.md` |
+| Per-project config and cross-cutting validator rules | `docs/journeys/README.md` |
+
+## What is here
+
+- `JNN-slug/journey.md` — 17 frozen baseline narratives (J01–J17). The live
+  catalogue supersedes each of these and adds J18.
+- `JNN-slug/deltas/*.md` — 58 per-task behavior deltas from the Wave 0
+  campaign. These have no counterpart in the live tree.
+- `INDEX.md`, `wave0-rerun-plan.md`, `wave0-task-index.md` — pre-format Wave 0
+  rerun sheets.
+
+Every file carries its own banner, because live journeys cite individual
+`deltas/*.md` and `journey.md` paths rather than this directory.
+
+## Editing
+
+These files are a record of what was believed when they were written. Do not
+update them to match current behavior — that would break their only purpose,
+which is being the historical baseline the live journeys' `trace:` fields cite.
+Known drift against today's code is expected and is not a defect here. Amend
+the live journey under `docs/journeys/` instead.

--- a/docs/product/journeys/wave0-rerun-plan.md
+++ b/docs/product/journeys/wave0-rerun-plan.md
@@ -1,3 +1,8 @@
+> **MIGRATED:** current truth now lives under `docs/journeys/`, whose
+> `INDEX.md` is the generated routing table. This file is frozen legacy
+> history from the pre-migration campaign and may not match current
+> behavior. See `docs/product/journeys/README.md`.
+
 # Wave 0 rerun plan — per-journey state
 
 For each journey Wave 0 touches: the union of stages needing rerun, which tasks trigger each, the minimal rerun set, and coverage gaps. This is the sheet the team executes: rerun only the listed stages, not whole journeys. Stage labels are quoted from `JNN-slug/journey.md`; NEW stages (behavior Wave 0 introduces that no current journey stage covers) are flagged **journey doc update needed**.

--- a/docs/product/journeys/wave0-task-index.md
+++ b/docs/product/journeys/wave0-task-index.md
@@ -1,3 +1,8 @@
+> **MIGRATED:** current truth now lives under `docs/journeys/`, whose
+> `INDEX.md` is the generated routing table. This file is frozen legacy
+> history from the pre-migration campaign and may not match current
+> behavior. See `docs/product/journeys/README.md`.
+
 # Wave 0 — task index (reviewer view)
 
 One row per Wave-0 grilling task (Q15 T120–T127, Q16 T128–T134, Q27 F-Framing-1..11). "Impacted journeys" links the per-journey × task delta file. Tasks with no journey impact carry an indirect-risk note and no delta files. Per-journey rerun unions live in `INDEX.md`.

--- a/docs/product/user-journeys.md
+++ b/docs/product/user-journeys.md
@@ -1,75 +1,28 @@
 # PlateVault user journeys
 
-This document is the **index** to the complete set of user journeys through
-PlateVault (formerly Astro Library Manager) at product level — for product
-review, manual testers, and onboarding. Each journey's full baseline narrative
-now lives in its own directory under `docs/product/journeys/JNN-slug/journey.md`,
-alongside per-task **behavior deltas** in `journeys/JNN-slug/deltas/`. This split
-lets a change to product behavior be tracked next to the exact journey stages it
-affects, so the team can rerun only the impacted stages after an implementation
-lands. See `docs/product/journeys/INDEX.md` (per-journey rerun state) and
-`docs/product/journeys/wave0-task-index.md` (per-task campaign view).
+Current journey truth lives under `docs/journeys/`, not in this file and not
+under `docs/product/journeys/`:
 
-Ground truth for the baselines is the five `verify-plans-*` scenario branches
-(PRs #416–#420) plus `PRODUCT.md`,
-`docs/development/orchestrator-handover-2026-07-03.md`, and the merged code on
-`redesign-ui-platevault`. The J-numbering and each journey's internal stage
-numbering are canonical — cite journey stages by their number and label as they
-appear in `journeys/JNN-slug/journey.md`; do not renumber.
+| For | Read |
+|---|---|
+| Per-journey routing table (generated; J01–J18) | `docs/journeys/INDEX.md` |
+| Journey file format, and how to read one | `docs/journeys/FORMAT.md` |
+| Per-project config, cross-cutting product and validator rules | `docs/journeys/README.md` |
 
-## How to read a journey
+`docs/product/journeys/` is the pre-migration catalogue, frozen 2026-07-15. It
+is retained as the historical baseline that the live journeys cite by path in
+their `trace:` frontmatter, and it holds the 58 Wave 0 behavior deltas that
+exist nowhere else. It does not describe current behavior — see
+`docs/product/journeys/README.md`.
 
-Each `journey.md` lists:
+The J-numbering and each journey's internal stage numbering are canonical: cite
+stages by the number and label they carry in
+`docs/journeys/JNN-slug/journey.md`, and do not renumber.
 
-- **Goal** — what the user is trying to accomplish.
-- **Preconditions** — what state the app/library needs to be in.
-- **Narrative flow** — numbered, UI-surface-level stages (not click-by-click).
-- **Touch & validate** — the journey's coverage contract: every control the
-  journey must exercise and every assertion a run must make. A journey run that
-  skips a Touch & validate item is incomplete, even if the narrative "worked".
-- **Safety & trust notes** — where the constitution's reviewable-plan and
-  no-silent-overwrite guarantees show up in this journey.
-- **Scenario files** — the executable, click-by-click version(s).
-- **Known gaps** — what's stubbed, deferred, or not yet wired.
+## Cross-journey canonical scenarios
 
-Two product rules run through almost every journey and are stated once here
-instead of being repeated in each:
-
-- **Reviewable filesystem mutation.** Every move, copy, archive, or delete is
-  proposed as a plan first. Confirming an inbox item, generating a cleanup
-  plan, or requesting an archive never moves a file by itself — only approving
-  and applying a plan does, and every applied action gets an audit record.
-- **Custody, not conversion.** Cataloguing a source "in place" (an
-  already-organized folder) never moves or rewrites files; it only teaches the
-  database about them.
-- **Every action answers back.** Each mutating step names its success signal
-  (toast, navigation, visible state change) and its failure signal (refusal
-  reason, per-item error). Journey validation treats "the only evidence was a
-  badge changing somewhere else" as a failed step.
-
-## Journey index
-
-| # | Journey | Summary | Baseline |
-|---|---------|---------|----------|
-| 1 | First-run setup → data sources | Empty DB → registered source folders (lights/calibration/projects/inbox) via the 5-step wizard, then ongoing rescan/remap/disable/delete. | [journey.md](journeys/J01-first-run-setup-data-sources/journey.md) |
-| 2 | Ingest → review/reclassify → confirm (move) | Unorganized inbox files → single-type items → needs-review gate → bulk reclassify → confirm → plan apply into the library. | [journey.md](journeys/J02-ingest-review-reclassify-confirm-move/journey.md) |
-| 3 | Ingest → confirm (catalogue-in-place) | Teach the DB about an already-organized root — zero moves, byte-identical, decided by the root's organization state. | [journey.md](journeys/J03-ingest-confirm-catalogue-in-place/journey.md) |
-| 4 | Sessions review (derived) | Read-only, always-current acquisition-session view derived from confirmed inventory — no review/lifecycle controls. | [journey.md](journeys/J04-sessions-review-derived/journey.md) |
-| 5 | Project lifecycle create → artifacts | Create project → attach confirmed sources → manifests/notes → tool launch → artifact observation. | [journey.md](journeys/J05-project-lifecycle/journey.md) |
-| 6 | Cleanup: scan → review → apply | Read-only cleanup preview → generate plan (Archive/Trash) → protected-item ack → apply. | [journey.md](journeys/J06-cleanup-scan-review-apply/journey.md) |
-| 7 | Archive → delete from archive | Plan-gated archive of a completed project, then trash / literal-DELETE permanent removal. | [journey.md](journeys/J07-archive-delete/journey.md) |
-| 8 | Calibration: ingest → masters → matching | Ingest master cal frames as individual items → per-master fingerprint columns → advisory session matching + tolerances. | [journey.md](journeys/J08-calibration-ingest-masters-matching/journey.md) |
-| 9 | Targets & planning (real vs. stub) | Browse/search catalog, SIMBAD resolve-on-demand, identity/aliases/notes — with disclosed planner-column stubs. | [journey.md](journeys/J09-targets-planning/journey.md) |
-| 10 | Settings, appearance, and i18n | 11-pane settings, auto-save, themes, log panel, full i18n coverage. | [journey.md](journeys/J10-settings-appearance-i18n/journey.md) |
-| 11 | Mistake recovery | Undo a wrong classification, reset-to-detected, discard a plan, un-assign a master — index-only, files untouched. | [journey.md](journeys/J11-mistake-recovery/journey.md) |
-| 12 | Failure & refusal handling | Refusals/failures explained in-context (lifecycle, empty plan, partial apply, stale plan) with audit parity. | [journey.md](journeys/J12-failure-refusal-handling/journey.md) |
-| 13 | Audit & activity investigation | Activity panel (now) + Audit Log (done) reconstruct what PlateVault did/refused. | [journey.md](journeys/J13-audit-activity-investigation/journey.md) |
-| 14 | Target-first project start | From a Targets planner row, launch project create with the target association carried through. | [journey.md](journeys/J14-target-first-project-start/journey.md) |
-| 15 | Equipment & observing-site setup | Register cameras/telescopes/trains/filters and observing site(s); aliases join FITS strings to friendly names. | [journey.md](journeys/J15-equipment-observing-site-setup/journey.md) |
-| 16 | Keyboard-first navigation & windows | Command palette, keyboard row traversal, focus management, new-window pop-out. | [journey.md](journeys/J16-keyboard-first-navigation/journey.md) |
-| 17 | Software update & install | Passive update check → signature-verified download → explicit restart. | [journey.md](journeys/J17-software-update-install/journey.md) |
-
-## Cross-journey index
+The executable, click-by-click counterpart to each journey, under
+`e2e-agentic-test/`. Seven journeys have no scenario yet.
 
 | # | Journey | Canonical scenario |
 |---|---|---|


### PR DESCRIPTION
## What and why

`docs/product/user-journeys.md` described `docs/product/journeys/` as where journey truth "now lives", and every row of its journey index linked into that tree. That tree was frozen on 2026-07-15 (last content commit `5c33a1474`, PR #861). A reader or validator following it got one-day-old, frozen instructions while believing they were current — the 2026-08-24 coverage audit ran an entire journey sweep against it before noticing there were two trees.

Deletion was investigated and rejected on `astro-plan-ud7si`. The tree stays: it holds 58 `deltas/*.md` that exist nowhere else (`find docs/journeys -path '*/deltas/*' -name '*.md' | wc -l` = 0 in the live tree, 58 in the frozen one), and live journeys cite those exact paths in their `trace:` frontmatter.

## Where the banner goes, and why per-file

All 17 `JNN-slug/journey.md` files **already** carried a `MIGRATED` banner. The gap was the 61 files that did not: 58 `deltas/*.md`, `INDEX.md`, and the two wave0 sheets.

Citation granularity decided the placement. Of the 23 inbound citations into the tree, 20 resolve to a specific deep file and only 2 to the tree root:

```
rg -o --no-filename 'docs/product/journeys[A-Za-z0-9_./-]*' --glob '!docs/product/journeys/**' . | sort | uniq -c
```

- 12 → `deltas/*.md`
- 7 → a `journey.md`
- 1 → `INDEX.md`
- 2 → the tree root (one of which is the `JNN-slug/` placeholder)

A reader arriving from `trace:` lands on `deltas/2026-07-14-q16-t131.md`, never on a root README, so a root-only banner would be decoration on the path that actually matters. Hence: a banner on every file, plus a `README.md` at the root for the 2 root citations and for folder browsing. Per-file duplication normally risks drift; these files are frozen and never edited again, so the cost is one-time and cannot drift.

Banner wording is copied from the existing `journey.md` banners rather than invented, so it stays consistent with `docs/journeys/README.md:120-128`, which already designates the tree frozen legacy history. No second, differently-worded policy is introduced.

## `user-journeys.md` reduced to what only it holds

Not merely repointed. Its content was duplicative and partly false:

- The 17-row journey index duplicated the generated `docs/journeys/INDEX.md`, was missing J18 (18 live journey dirs vs 17 frozen), linked into the frozen tree, and carried stale summaries — J01's "via the 5-step wizard" against 10 step components and an existing `apps/desktop/src/features/settings/DataSources.disable-delete.test.tsx`.
- "How to read a journey" duplicated `docs/journeys/FORMAT.md` and the cross-cutting rules at `docs/journeys/README.md:22-31`.

Kept: the cross-journey canonical-scenario table, verified path-by-path under `e2e-agentic-test/` — 9 scenarios exist, the 7 marked *(to be authored)* genuinely do not. Nothing in the live tree holds this. New pointers are backticked paths, not relative markdown links, so they cannot silently re-resolve into the wrong tree the way the original index did.

## Ruling: the frozen J01 staleness is NOT corrected

`docs/product/journeys/J01-.../journey.md` claims a 5-step wizard and PR #404 open. Left as written, deliberately. The tree's only value is being the baseline the live journeys' `trace:` fields cite; editing it to match today's code destroys that and produces a record that is neither current nor historical. The banner states the file may not match current behavior, and the new root README states the no-edit rule explicitly so the next reader does not re-open this question.

## Verification

- Frozen-tree diff is **purely additive**: `git diff --numstat origin/main -- docs/product/journeys/` → 363 insertions, 0 deletions, no file with a non-zero delete column. All 65 deletions in the commit are in `user-journeys.md` (`git show --numstat HEAD -- docs/product/user-journeys.md` → `18 65`).
- 78 of 79 `.md` files in the tree now open with a `>` banner; the exception is the new `README.md`, whose banner is on line 3 under its title.
- Gates: `scripts/precommit-verify.sh` on all 63 staged paths → exit 0, **6 hooks actually ran** (large-files, detect-private-key, end-of-file-fixer, trailing-whitespace, gitleaks, typos); 4 skipped for no matching files (json, toml, yaml, rustfmt).
- No cargo or pnpm build was run: the change touches only `.md` files, no Rust or TS source, so neither would exercise anything.

## Not done

- `docs/journeys/` journey bodies are untouched — `astro-plan-0r5c9` owns those, including the J06 amendment after PR #1735.
- Nothing deleted. Preservation artifact from the earlier investigation: `/Users/sjors/tmp/crash-recovery/astro-plan-ud7si/docs-product-journeys-9bd824eb3.tar.gz`.
- `docs/journeys/README.md:126-127` says "all seventeen journeys (J01–J17)" but the live `INDEX.md` lists J18. Not fixed here — that file belongs to `astro-plan-0r5c9`.

## Discovered, filed not absorbed

`docs/manual/` carries 14 anchor links across 10 files of the form `user-journeys.md#journey-N--...`. These were **already broken before this PR**: at `origin/main` that file had only 4 headings (`# PlateVault user journeys`, `## How to read a journey`, `## Journey index`, `## Cross-journey index`) and no `## Journey N` heading. The per-journey headings those anchors target live in the frozen tree's `journey.md` files. This PR neither creates nor worsens the breakage. Filed separately.

Tracks-Bead: astro-plan-694fu
Merge-Bead: astro-plan-nnmez

Discovered follow-up filed: astro-plan-vdrbi (14 dead docs/manual anchors, pre-existing).
