### PR TITLE
chore(mcp): add the Tauri MCP server so journey validation has a driver

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -32,6 +32,14 @@
         "repomix",
         "--mcp"
       ]
+    },
+    "tauri": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@hypothesi/tauri-mcp-server@0.11.2"
+      ]
     }
   }
 }


### PR DESCRIPTION
Adds `@hypothesi/tauri-mcp-server@0.11.2` to the tracked `.mcp.json`. This is the client half of the Tauri MCP bridge; without it, journey validation cannot run at all.

## Why this was missing

The APM package `srobroek/agentic-packages/packages/mcp-tauri` (v2.0.0, `apm.yml:33`) is installed, but unlike `mcp-playwright` it ships no `.mcp.json` fragment — per `apm.lock.yaml` it deploys exactly one file, `.claude/rules/50-tauri-mcp.md`. So the steering rule telling agents to use a Tauri MCP server was installed while the server never was.

The app half was already complete and needed no change: `tauri-plugin-mcp-bridge` is a workspace dependency and is registered at `apps/desktop/src-tauri/src/lib.rs:136` behind the dev-only surface.

## Why 0.11.2 exactly, and not @latest

`Cargo.lock` pins `tauri-plugin-mcp-bridge` at **0.11.2**. Server and crate move in lockstep, so the server must match. `@latest` is currently **0.12.0**, which would pair a 0.12 client against a 0.11.2 plugin. The other four servers here use `@latest` or unpinned; this one is deliberately pinned for that reason.

## What this does not do

It does not make journeys runnable on its own. The bridge needs three gates, not one: the `dev-tools` feature, `PV_MCP_BRIDGE_ENABLE=1`, and `withGlobalTauri`.

An earlier draft of this body claimed `docs/development/windows-native-rust-dev.md` documents only `debug_assertions`. That was **false** and is corrected here: the file contains zero occurrences of `debug_assertions` and already names all three gates. `astro-plan-73e7v` was filed on that mistaken reading and may already be satisfied; it is re-checked rather than closed on this PR's authority.

Release builds are unaffected: the bridge is compile-time gated out, and release binaries must omit `dev-tools`.

## Port: 9223 is correct

`docs/journeys/README.md:41` declares WebSocket **9223** and that is right for this pairing. `mcp-tauri`'s changelog mentions a move to TCP:9999, but that is 1.0.0-era history about a different crate (P3GLEG) and does not apply to `@hypothesi` 0.11.2. No journey or doc change is needed for the port.

## Verification

- `.mcp.json` parses; servers are `context7`, `mcp-package-version`, `playwright`, `repomix`, `tauri`.
- `Cargo.lock` `tauri-plugin-mcp-bridge` version read directly as 0.11.2, confirming the pin.
- Package screened before pinning: publisher `@hypothesi`, maintainer `mluedke`, 27 releases, not deprecated.
- One file, 8 insertions, no code touched.

**Gate evidence: no hook checked this change beyond JSON validity.** `.mcp.json` is not Rust or TypeScript, so no build or test applies; the claim above rests on reading `Cargo.lock` and parsing the JSON, not on a green suite.

Authorized directly by the repository owner. A dispatched agent declined to make this edit because the authorization reached it only relayed through the coordinator, which is not owner consent — that refusal was correct, and the edit was made by the coordinator who received the instruction first-hand.

Tracks-Bead: astro-plan-8dchw
Tracks-Bead: astro-plan-zp4lb
Closes-Bead: astro-plan-8dchw
Merge-Bead: astro-plan-8nbm8
