### PR TITLE
docs(specs): correct nine spec statuses that understated shipped work

### DIFF
--- a/specs/015-token-pattern-builder/plan.md
+++ b/specs/015-token-pattern-builder/plan.md
@@ -1,7 +1,11 @@
 # Implementation Plan: Token Pattern Builder
 
 **Feature**: `015-token-pattern-builder`
-**Status**: Draft
+**Status**: Implemented (post-hoc record, verified 2026-08-24) — agrees with
+`spec.md`'s Implemented header, which was previously contradicted here. Resolver
+`crates/patterns/src/resolver.rs`, validator `crates/patterns/src/validator.rs`,
+builder UI shipped renamed as
+`apps/desktop/src/features/settings/NamingStructure.tsx`.
 **Constitution check**: passes — local-first metadata, reviewable mutation (resolver feeds plans, never applies directly), PixInsight boundary preserved (no image processing), research-led vocabulary, portable contracts via JSON Schema.
 
 ## Goal

--- a/specs/016-source-protection-defaults/spec.md
+++ b/specs/016-source-protection-defaults/spec.md
@@ -6,7 +6,8 @@
 
 **Feature Branch**: `016-source-protection-defaults`  
 **Created**: 2026-05-09  
-**Status**: Draft  
+**Status**: Implemented (post-hoc record, verified 2026-08-24) — see
+Implementation Status below for the per-item evidence.  
 **Input**: User description: "Specify protection settings as per-source behavior with global defaults rather than only a global protection setting."
 
 ## User Scenarios & Testing *(mandatory)*
@@ -110,10 +111,32 @@ As a user, I want global protection defaults for newly added sources so that com
 - Per-source override surfaces (Sources detail / row) are scoped to future
   implementation; mockup demonstrates inheritance language only.
 
-**Pending implementation:**
+**Shipped** (verified against `origin/main` a52c637f2 on 2026-08-24; these four
+items were carried as "Pending implementation" long after they landed):
 
-- Per-source protection override storage and resolver (override → global default).
-- Protection evaluation hook inside plan generation (spec 017 cleanup, spec 025
-  archive) producing blocked / requires-acknowledgement plan items.
-- Protected categories enforcement (frame-type / role membership check).
-- Audit events for protection changes and protected-plan acknowledgements.
+- Per-source protection override storage and resolver (override → global default):
+  `crates/app/core/src/protection/source_protection.rs:35` `get_source_protection`
+  (a `None` `source_id` returns the global defaults directly) and `:102`
+  `set_source_protection`; global defaults at
+  `crates/app/core/src/protection/global_defaults.rs:36`. Exposed as
+  `source_protection_get` / `source_protection_set`
+  (`apps/desktop/src-tauri/src/commands/protection.rs:37`/`:56`). The per-source
+  override UI shipped as
+  `apps/desktop/src/features/settings/SourceProtectionOverride.tsx`, superseding
+  the "scoped to future implementation" note above.
+- Protection evaluation hook inside plan generation:
+  `crates/app/core/src/protection/plan_check.rs` `plan_protection_check`, which
+  marks items `requires_acknowledgement` at `:103`; command
+  `plan_protection_check_cmd` (`protection.rs:80`).
+- Protected categories enforcement: `protected_categories` is applied in cleanup
+  generation at `crates/app/core/src/cleanup_generator/raw_frames.rs:33` and
+  `cleanup_generator/scan.rs`, with the setting defined in
+  `crates/app/settings/src/descriptors.rs`.
+- Audit events for protection changes and protected-plan acknowledgements:
+  `set_source_protection` returns a resolvable `audit_id`
+  (`crates/app/core/src/protection/tests.rs:211` and `:230`, the latter asserting
+  a durable `audit_log_entry` row), and `acknowledge_protected_item`
+  (`plan_check.rs:132`) emits `protection.plan.acknowledged`
+  (`tests.rs:395`-`:405`). Command surface at `protection.rs:101`.
+
+End-to-end coverage: `crates/e2e-tests/tests/cleanup_protection_gate_journey.rs`.

--- a/specs/026-generated-project-source-view-removal/research.md
+++ b/specs/026-generated-project-source-view-removal/research.md
@@ -1,7 +1,9 @@
 # Research: Generated Project Source View Removal
 
 **Spec**: `specs/026-generated-project-source-view-removal/spec.md`  
-**Status**: NOT IMPLEMENTED
+**Status**: IMPLEMENTED (post-hoc record, corrected 2026-08-24). This document was
+left on the pre-implementation value when `spec.md`, `plan.md`, `data-model.md`
+and `tasks.md` were all flipped to Implemented.
 
 ## R1: When Source Views Become Stale
 

--- a/specs/037-e2e-integration-testing/spec.md
+++ b/specs/037-e2e-integration-testing/spec.md
@@ -4,18 +4,43 @@
 
 **Created**: 2026-06-19
 
-**Status**: Draft
+**Status**: Implemented (post-hoc record, verified 2026-08-24 against `origin/main`
+a52c637f2). Both layers and all five user stories ship:
+
+- **Layer 1, real-backend integration**: `crates/e2e-tests/` with 15 entries under
+  `crates/e2e-tests/tests/` (archive, calibration UI, cleanup protection gate,
+  inbox UI, inventory, journeys, lifecycle UI, onboarding, plan-review overlay,
+  sessions, settings, smoke, source view, targets, plus `common/`).
+- **Layer 2, full-stack end-to-end**: `tests/e2e/` with 39 tracked files —
+  Playwright specs plus `tests/e2e/support/`. The real-UI variant runs through
+  `desktop_shell` under the `e2e` feature with `thirtyfour` +
+  `tauri-plugin-webdriver` (no per-OS external WebDriver).
+- **US2, cross-platform automation**: `.github/workflows/e2e.yml` ("Real-UI E2E
+  (thirtyfour + nextest + tauri-plugin-webdriver)") builds and runs on
+  `ubuntu-latest`, `windows-latest` and `macos-latest`;
+  `.github/workflows/ci.yml` carries the fast mock-mode `ui-e2e` lane and its
+  `ui-e2e-gate`.
+- **US4, one-command local execution**: `apps/desktop/package.json`
+  `test:e2e` (`playwright test`) and `test:e2e:real`
+  (`scripts/run-e2e-real.sh`); `just test-e2e`.
+- **US5, standing convention**: `.claude/rules/22-astro-build-run.md:32` documents
+  the two layers as the project's default way of working and points at
+  `contracts/coverage-matrix.md`, which is maintained per feature area.
+
+Correction of record: an earlier audit concluded Layer 2 had not shipped by
+checking `apps/desktop/e2e`, which has never existed. The Playwright tree is
+`tests/e2e/`.
 
 **Input**: User description: "Full integration testing of our app: exercise the real application (real data store, real command/IPC dispatch, real side effects) rather than mocked stubs, covering all currently implemented features, across Windows, Linux, and macOS, in both CI/CD and during local development. Update the project instructions so this is the standing convention."
 
 ## Overview
 
-Today the automated tests prove that individual pieces work in isolation: pure
-domain logic is unit-tested, and the desktop UI is tested against an in-process
-mock that fakes every backend response. Nothing exercises the **real** running
-application — real data store, real command dispatch and serialization, real
-filesystem and network side effects — as a user actually experiences it. That
-gap means a whole class of failures (command wiring, payload shape mismatches,
+When this spec was written, the automated tests proved only that individual pieces
+work in isolation: pure domain logic was unit-tested, and the desktop UI was
+tested against an in-process mock that faked every backend response. Nothing
+exercised the **real** running application — real data store, real command
+dispatch and serialization, real filesystem and network side effects — as a user
+actually experiences it. That gap meant a whole class of failures (command wiring, payload shape mismatches,
 data-store migrations, state injection, UI↔backend contract drift) can pass all
 existing checks and still break the shipped product. Several such failures have
 already reached real builds and were only caught by hand on one developer's

--- a/specs/037-e2e-integration-testing/spec.md
+++ b/specs/037-e2e-integration-testing/spec.md
@@ -7,29 +7,52 @@
 **Status**: Implemented (post-hoc record, verified 2026-08-24 against `origin/main`
 a52c637f2). Both layers and all five user stories ship:
 
-- **Layer 1, real-backend integration**: `crates/e2e-tests/` with 15 entries under
-  `crates/e2e-tests/tests/` (archive, calibration UI, cleanup protection gate,
-  inbox UI, inventory, journeys, lifecycle UI, onboarding, plan-review overlay,
-  sessions, settings, smoke, source view, targets, plus `common/`).
-- **Layer 2, full-stack end-to-end**: `tests/e2e/` with 39 tracked files —
-  Playwright specs plus `tests/e2e/support/`. The real-UI variant runs through
-  `desktop_shell` under the `e2e` feature with `thirtyfour` +
-  `tauri-plugin-webdriver` (no per-OS external WebDriver).
-- **US2, cross-platform automation**: `.github/workflows/e2e.yml` ("Real-UI E2E
-  (thirtyfour + nextest + tauri-plugin-webdriver)") builds and runs on
-  `ubuntu-latest`, `windows-latest` and `macos-latest`;
-  `.github/workflows/ci.yml` carries the fast mock-mode `ui-e2e` lane and its
-  `ui-e2e-gate`.
+Three distinct test populations exist; they are **not** interchangeable, and the
+CI tier names do not match this document's layer names (see the note at the head
+of `contracts/coverage-matrix.md`).
+
+- **Layer 1, real-backend integration**: the `integration` matrix job in
+  `.github/workflows/ci.yml` ("Unit + integration (L1+L2)"), exercising core logic
+  against real SQLite and a real temporary filesystem with the network mocked at
+  its outermost boundary.
+- **Layer 2, full-stack end-to-end**: the **`thirtyfour` Rust journey suite** —
+  **30** tests across 14 files under `crates/e2e-tests/tests/` (plus `common/`),
+  driving the built `desktop_shell` under the `e2e` feature via
+  `tauri-plugin-webdriver`, with no per-OS external WebDriver. All 30 are
+  `#[ignore]`d in-source, so `cargo test --workspace` never runs them; they run only
+  through `.github/workflows/e2e.yml`.
+- **Mock-mode UI regression** (neither spec layer): **38** Playwright `.spec.ts`
+  files under `tests/e2e/`, plus `tests/e2e/support/`. Run by the `ui-e2e` job in
+  `ci.yml` ("UI mock-mode (Playwright) — run") on `ubuntu-latest`, frontend-gated,
+  with `ui-e2e-gate` publishing the required context. These drive the UI against
+  in-process mocks, **not** a real backend, so they do not satisfy Layer 2.
+- **US2, cross-platform automation** — what runs **by default** versus what is
+  opt-in (`.github/workflows/e2e.yml:14-35`):
+  - Every `pull_request` and `merge_group` entry: a Tier-1 real-UI **smoke subset**
+    on `ubuntu-latest` only. Required context "Real-UI smoke (L3) — ubuntu-latest".
+  - Every push to `main`: the Tier-2 full matrix, `ubuntu-latest` (4 shards) +
+    `windows-latest` (3 shards). Windows is deliberately off PRs as the slow and
+    historically flaky leg.
+  - `macos-latest`: **opt-in only.** It runs on an explicit `workflow_dispatch` with
+    `run_macos=true`, which defaults to `false` (`:163-168`, gated at `:303`). It is
+    skipped on ordinary PR and main-push runs, so the spec's "across Windows, Linux,
+    and macOS" is met on Linux and Windows automatically and on macOS on request.
 - **US4, one-command local execution**: `apps/desktop/package.json`
-  `test:e2e` (`playwright test`) and `test:e2e:real`
+  `test:e2e` (`playwright test`, mock mode) and `test:e2e:real`
   (`scripts/run-e2e-real.sh`); `just test-e2e`.
 - **US5, standing convention**: `.claude/rules/22-astro-build-run.md:32` documents
   the two layers as the project's default way of working and points at
   `contracts/coverage-matrix.md`, which is maintained per feature area.
 
 Correction of record: an earlier audit concluded Layer 2 had not shipped by
-checking `apps/desktop/e2e`, which has never existed. The Playwright tree is
-`tests/e2e/`.
+checking `apps/desktop/e2e`. That path **did** exist — added 2026-06-19/20 across
+`329c6d11d`, `db56e34ee`, `695f668b6` and `e3793a598`, holding
+`playwright.real-backend.config.ts`, `real-backend/*.spec.ts`, `helpers/` and a
+`README.md` — and was removed across `e3793a598`, `7a4f70446` (2026-06-20, which
+standardized real-UI E2E on `tauri-plugin-webdriver` and retired wdio) and
+`a504a7fce` (2026-07-11). So the audit cited a deleted path, not one that never
+existed. Its `research.md` citations of `apps/desktop/e2e/helpers/*.ts` are stale
+records of that tree, not planned paths.
 
 **Input**: User description: "Full integration testing of our app: exercise the real application (real data store, real command/IPC dispatch, real side effects) rather than mocked stubs, covering all currently implemented features, across Windows, Linux, and macOS, in both CI/CD and during local development. Update the project instructions so this is the standing convention."
 

--- a/specs/037-ipc-wrapper-removal/spec.md
+++ b/specs/037-ipc-wrapper-removal/spec.md
@@ -4,14 +4,21 @@
 
 **Created**: 2026-06-19
 
-**Status**: Draft
+**Status**: Draft — **remains open**, but rescoped 2026-08-24 against `origin/main`
+a52c637f2. `apps/desktop/src/api/commands.ts` was deleted (1673 lines) at
+`54b56d284` (2026-07-05, PR #439) and the switcher this spec proposed now exists
+as `apps/desktop/src/api/ipc.ts:61`. The remaining subject is **24** hand-written
+wrappers in two feature modules, not ~90 in `commands.ts`: see the rescoped
+Background below.
 
 **Input**: Remove the hand-written `apps/desktop/src/api/commands.ts` `invoke()` wrappers and migrate the desktop app to call the generated tauri-specta bindings directly, eliminating the IPC name/payload drift bug class while preserving mock mode and the dev-tools recording proxy.
 
 ## Background
 
-The desktop app talks to the Rust backend through ~90 hand-written `invoke('<name>', <payload>)`
-wrappers in `commands.ts`. The generated tauri-specta bindings (`bindings/index.ts`,
+### As written (2026-06-19)
+
+The desktop app talked to the Rust backend through ~90 hand-written
+`invoke('<name>', <payload>)` wrappers in `apps/desktop/src/api/commands.ts`. The generated tauri-specta bindings (`bindings/index.ts`,
 `export const commands`) already describe every command's exact name and camelCase payload
 shape, but the wrappers re-declare both by hand and silently drift. Because mock mode
 (`VITE_USE_MOCKS`) short-circuits `invoke()`, drift is invisible on Linux/CI and only surfaces
@@ -24,6 +31,27 @@ on a real Windows build. Three drift incidents shipped this cycle:
 
 The guard prevents regressions but the wrappers remain the root cause. This feature removes
 them so the generated bindings are the single source of truth.
+
+### Rescoped (2026-08-24, verified against `origin/main` a52c637f2)
+
+`commands.ts` no longer exists — it was deleted, 1673 lines, at `54b56d284`
+(2026-07-05, PR #439), sixteen days after this spec was created. The switcher this
+spec proposed shipped as `apps/desktop/src/api/ipc.ts:61`.
+
+The remaining subject is **24** hand-written `invoke()` wrappers in two feature
+IPC modules, both importing `invoke` from the switcher (`@/api/ipc`):
+
+- `apps/desktop/src/features/sessions/sessionsGroupsIpc.ts` — 15
+- `apps/desktop/src/features/calibration/calibrationHandoffIpc.ts` — 9
+
+So US1's Independent Test does **not** yet pass. Two further `invoke(` sites are
+**not** in scope and must not be counted as wrappers:
+
+- `apps/desktop/src/dev/ContractsPage.tsx:142` — a deliberate *dynamic*
+  `invoke(cmd, …)` replaying a recorded call, which is the spec-021 dev-tools
+  surface this migration is required to preserve (and is `dev-tools`-gated).
+- `apps/desktop/src/data/logSubscription.ts:52` — a comment, not a call; that
+  module already routes through the generated binding.
 
 ### Constraint that makes this non-trivial
 

--- a/specs/041-inbox-plan-surface/spec.md
+++ b/specs/041-inbox-plan-surface/spec.md
@@ -25,7 +25,14 @@
 
 **Updated**: 2026-06-23
 
-**Status**: Implemented — confirm pipeline + reviewable plan surface + apply (59/59 tasks); iteration-1 added single-type sub-items at ingest + destination model (PR #315). Supersedes spec 005; absorbed parts of specs 025/045.
+**Status**: Implemented — confirm pipeline + reviewable plan surface + apply (59/59 tasks); iteration-1 added single-type sub-items at ingest + destination model (PR #315). Supersedes spec 005; absorbed parts of specs 025/045. FR-006a/b/c (the explicit
+approval gate on apply) were **added to this document 2026-08-24**, after the
+59/59 count: the behaviour shipped in PR #1740 (`c0f7e10ea`) but the spec was
+silent on it, so the count does not cover them. The gate is live at
+`crates/app/core/src/inbox_plan.rs:207` (refuses with `plan.approval_required`),
+documented at `:162-168`/`:177`/`:224`/`:334`, asserted at `:1138`, with token
+verification in `crates/app/core/src/plan_apply/paths.rs:122-149` and both codes in
+`crates/contracts/core/src/error_code.rs:169`/`:171`.
 
 **Input**: User description: "Rework the inbox confirmation experience and the file-organization plan model so confirming an item produces a visible, reviewable plan; the review surface is structured (no overflowing pills, multi-level grouping) and shows per-file metadata; users can override header-derived values beyond frame type and apply overrides to a multi-selection; and whether files are moved or catalogued in place depends on where they came from (inbox vs already-organized library root)."
 
@@ -379,7 +386,10 @@ As a user, I want the app to extract the additional header fields the new groupi
 - **FR-004**: "View plan" and plan review MUST keep the user within the inbox surface and MUST NOT navigate to the Archive page or any unrelated page.
 - **FR-005**: Applying a plan MUST execute its actions, MUST never overwrite existing files silently, and MUST write an audit record for each attempted action and its outcome.
 - **FR-006**: Users MUST be able to review the full plan and cancel a plan before applying, leaving all files untouched.
-- **FR-007**: The system MUST refuse to apply a plan whose source files have changed since the plan was generated, and MUST surface the staleness to the user.
+- **FR-006a**: Applying an inbox plan MUST require an explicit user approval recorded before apply (the approval token spec 017 issues and spec 025 FR-001 requires). The inbox apply path MUST NOT mint an approval on the user's behalf. A plan carrying no approval MUST be refused with `plan.approval_required` and MUST NOT be applied. Under `inbox.plan.apply_all` and `inbox.plan.apply_selected` this is a per-plan result rather than a whole-batch failure: an unapproved plan is reported individually and the remaining plans still apply.
+- **FR-006b**: The recorded approval MUST be handed to the shared apply executor for verification, so an absent, empty, or mismatched token — a plan re-approved or tampered with since the user approved it — is refused with `plan.approval.stale` (spec 025 FR-011). There is no approval TTL.
+- **FR-006c**: The one exception is the mkdir-only auto-apply path (`plans::auto_apply`), which creates directories, moves no user file, and does not route through inbox apply. Every path that moves or catalogues a user file is bound by FR-006a.
+- **FR-007**: The system MUST refuse to apply a plan whose source files have changed since the plan was generated, and MUST surface the staleness to the user. This staleness (`plan.stale`, raised per item by the executor's content check) is distinct from the approval staleness of FR-006b.
 
 **Structured, groupable review + metadata (US2)**
 

--- a/specs/044-targets-planner-astronomy/spec.md
+++ b/specs/044-targets-planner-astronomy/spec.md
@@ -4,13 +4,32 @@
 
 **Created**: 2026-07-04
 
-**Status**: Draft
+**Status**: Implemented (post-hoc record, verified 2026-08-24 — surfaces for all
+six user stories located on `origin/main` a52c637f2; per-FR verification was not
+performed, so treat individual FRs as unconfirmed rather than closed). US1 engine
+`apps/desktop/src/features/targets/planner-astronomy.ts:256`
+`computeNightObservability` with `usableAltDeg` now a prop defaulting to
+`USABLE_ALT_DEG` (`TargetsTable.tsx:203`, `TargetDetail.tsx:88`); US2
+`PlannerDatePicker.tsx`; US3 `features/settings/ObservingSites.tsx` over the
+`observerSites` setting (`crates/app/settings/src/descriptors.rs`); US4 per-site
+`twilight` / `minHorizonAltDeg` in that same descriptor; US5
+`features/targets/astro/lunar-separation.ts` plus the registered
+`target_moon_opposition_batch` command (`bootstrap/specta.rs:138`, `:265`); US6
+first-run default site `features/setup/steps/StepSite.tsx`. Supporting modules
+`astro/observing-night.ts`, `astro/opposition.ts`, `astro/best-moon-date.ts` and
+`astro/row-planning.ts`, each with a colocated `.test.ts`.
+
+**Implementation location** (resolved after the fact; this spec deliberately left
+it to plan/research): the ephemeris engine is **frontend TypeScript** under
+`apps/desktop/src/features/targets/`, not a Rust crate. There is no observer-site
+Tauri command; sites are a settings key described in
+`crates/app/settings/src/descriptors.rs`.
 
 **Input**: User description: "Give the Targets planner real, per-site, per-date observability. For each deep-sky target (and the Moon), compute where it is in the sky over a chosen night from a chosen observing site: altitude over time, when it transits, when it rises/sets, its best imaging date, and its geometry against the Moon — so the planner can show real max-altitude, altitude sparkline, visible-tonight, imaging-time and per-filter moon-free time instead of placeholders. Let the user keep several named observing sites, pick which is active, choose how dark 'night' must be and how low the horizon reaches, set the lowest usable altitude, and plan any date — with a default site created in the first-run wizard so the planner works out of the box."
 
 ## Context & Motivation
 
-The Targets planner table and the target detail view already expose columns and an altitude graph for observability — maximum altitude, an altitude sparkline over the night, a "visible tonight" flag, imaging time above a usable altitude, transit / best-date, Moon distance, and a filter recommendation — but those values are currently driven by placeholder logic. The usable-altitude cutoff is a hardcoded constant (`USABLE_ALT_DEG`), there is no real observing site behind the numbers, "tonight" is the only planning horizon, and the Moon figure is not a real angular separation. The planner looks like a planning tool without yet being one.
+The Targets planner table and the target detail view already expose columns and an altitude graph for observability — maximum altitude, an altitude sparkline over the night, a "visible tonight" flag, imaging time above a usable altitude, transit / best-date, Moon distance, and a filter recommendation — but at the time this spec was written those values were driven by placeholder logic: the usable-altitude cutoff was a hardcoded constant (`USABLE_ALT_DEG`), there was no real observing site behind the numbers, "tonight" was the only planning horizon, and the Moon figure was not a real angular separation. The planner looked like a planning tool without yet being one. (All four conditions have since been removed — see the Status header.)
 
 This feature (Track B) provides the real **ephemeris and observer-location engine** behind those surfaces: given an observing site and a date, it computes where each target is over the night — altitude samples, transit, rise, set, best imaging date — and the Moon's real geometry over that night (its altitude and its angular separation from each target). From that geometry it derives the total imaging time above the usable altitude and, integrating the filter track's per-band Moon-avoidance rule over the night, a **per-filter moon-free imaging time**. It also introduces the user-facing model the engine needs: multiple named observing sites with a default and an active choice, a per-site definition of how dark "night" must be and how low the horizon reaches, a configurable usable-altitude threshold, and a **default site created in the first-run wizard** so the planner is populated from the start.
 

--- a/specs/047-targets-planner-moon-filters/spec.md
+++ b/specs/047-targets-planner-moon-filters/spec.md
@@ -4,7 +4,21 @@
 
 **Created**: 2026-07-04
 
-**Status**: Draft (Track A, split out of the spec 044 placeholder; spec 044 is now Track B)
+**Status**: Implemented (post-hoc record, verified 2026-08-24 — surfaces for all
+four user stories located on `origin/main` a52c637f2; per-FR verification was not
+performed, so treat individual FRs as unconfirmed rather than closed). Track A,
+split out of the spec 044 placeholder; spec 044 is now Track B. US1 moon summary
+`apps/desktop/src/features/targets/MoonSummary.tsx` over
+`features/targets/astro/moon-state.ts` (phase / illumination); US2 real lunar
+distance `features/targets/astro/lunar-separation.ts`; US3 per-band viability and
+filter guidance `features/targets/GuidanceCell.tsx` and `FilterBadges.tsx`, with
+the tunable per-band `(distance, width)` parameters in
+`features/settings/PlannerSettings.tsx` over the `plannerMoonAvoidance` setting
+(`crates/app/settings/src/descriptors.rs`); US4 opposition / best-season
+`features/targets/astro/opposition.ts` (`nextOpposition:104`,
+`oppositionRelative:161`) and `astro/best-moon-date.ts`. Each `astro/` module has
+a colocated `.test.ts`. `iteration-2026-07-15-applied.md` in this directory
+records a further applied iteration.
 
 **Input**: User description: "Track A of the Targets Planner: moon-aware,
 filter-aware target planning using existing target data and simple well-known

--- a/specs/048-per-frame-inventory/spec.md
+++ b/specs/048-per-frame-inventory/spec.md
@@ -4,15 +4,43 @@
 
 **Created**: 2026-07-04
 
-**Status**: Draft
+**Status**: Partial (verified 2026-08-24 against `origin/main` a52c637f2). The
+inventory, cleanup and relink halves ship; the live-detection trigger does not.
+
+Shipped:
+
+- **US1** per-frame inventory with real sizes — frame records are written at plan
+  apply by `crates/app/inbox/src/plan_listener.rs` (`stat_frame` → `size_bytes` at
+  `:556`), and calibration-master `frame_ids` are populated there rather than left
+  as the historical `'[]'` placeholder (`:340`, `:996`, test at `:1096`).
+- **US2 (on-demand half)** — `crates/app/core/src/frame_inventory/reconcile.rs` and
+  `relink.rs`, exposed as `inventory_reconcile_run`, `inventory_frame_list` and
+  `inventory_frame_relink` (`bootstrap/specta.rs:74`, `:413-415`). Relink matches
+  on sha256 computed on demand (`relink.rs:21`), per the 2026-07-04 clarification.
+- **US3** raw sub-frame cleanup candidates —
+  `crates/app/core/src/cleanup_generator/raw_frames.rs`, summing real
+  `frame.size_bytes` into `total_reclaimable_bytes` at `:190`/`:204` and refusing
+  the scan outright when a session's `frame_ids` is unreadable (`:47`, PR #1739).
+- **US4 (config half)** — `crates/app/settings/src/root_config.rs` carries
+  per-root `ReconcileMode` (`flag_missing` default, `auto_reconcile` opt-in) and
+  the `detection.live` / `.scheduled` / `.on_open` / `.follow_symlinks` keys.
+- **US5** missing-frame awareness for calibration matches —
+  `crates/app/core/tests/calibration_missing_flag_integration.rs`.
+
+**Not built**: the detection *triggers* US2 and US4 describe. `detection.live`,
+`detection.scheduled` and `detection.on_open` are stored and validated but have no
+consumer outside `root_config.rs`; nothing starts a frame-tree watcher or a
+scheduled sweep, so reconciliation only happens when the user asks for it. The
+`notify`-based watcher in `crates/workflow/artifacts/src/watcher.rs` belongs to
+spec 012 (artifact observation) and does not cover frame inventory.
 
 **Input**: User description: "Per-frame (per-file) inventory with live session membership. Complete PlateVault's per-frame inventory so raw sub-frame cleanup is possible and sessions stay honest about what is on disk."
 
 ## Overview
 
-PlateVault groups ingested images into acquisition and calibration **sessions**, but it does not keep an accurate, durable record of the **individual frames** (sub-exposures) that make up each session, nor of how large they are on disk. Two consequences follow:
+PlateVault groups ingested images into acquisition and calibration **sessions**. When this spec was written it did not keep an accurate, durable record of the **individual frames** (sub-exposures) that make up each session, nor of how large they are on disk. Two consequences followed:
 
-1. **Raw sub-frame cleanup is impossible.** Raw lights, darks, and flats are the largest consumers of disk space, but because the app cannot enumerate the individual frames it recorded (calibration frames are recorded with no frame list at all, and every frame's byte size is recorded as zero), the cleanup review flow refuses to consider them and can only offer processing artifacts as cleanup candidates. The biggest disk win is unavailable.
+1. **Raw sub-frame cleanup was impossible.** Raw lights, darks, and flats are the largest consumers of disk space, but because the app could not enumerate the individual frames it recorded (calibration frames were recorded with no frame list at all, and every frame's byte size was recorded as zero), the cleanup review flow refused to consider them and could only offer processing artifacts as cleanup candidates. The biggest disk win was unavailable. (All three conditions have since been removed — see the Status header.)
 2. **Sessions drift from reality.** Astrophotographers routinely cull sub-frames **outside** PlateVault — reviewing in Blink or by hand and then deleting rejects or moving them to a "rejects" folder. After that, a PlateVault session still claims frames that are no longer where it recorded them. Counts, size totals, and cleanup previews become wrong, and calibration matches may silently reference frames that have vanished.
 
 This feature completes the per-frame inventory so that every ingested frame — light **and** calibration — is recorded with its real on-disk size and its session membership; it teaches sessions to notice frames that were deleted or moved outside the app; and it unblocks the cleanup review flow to propose individual raw sub-frames as reviewable cleanup candidates. Consistent with PlateVault's principles, reconciliation only updates the app's records and what the user sees — it never deletes or moves a file as a side effect.

--- a/specs/048-per-frame-inventory/spec.md
+++ b/specs/048-per-frame-inventory/spec.md
@@ -4,35 +4,41 @@
 
 **Created**: 2026-07-04
 
-**Status**: Partial (verified 2026-08-24 against `origin/main` a52c637f2). The
-inventory, cleanup and relink halves ship; the live-detection trigger does not.
-
-Shipped:
+**Status**: Implemented (post-hoc record, verified 2026-08-24 against `origin/main`
+a52c637f2). All five user stories ship, including the live-detection triggers.
 
 - **US1** per-frame inventory with real sizes — frame records are written at plan
   apply by `crates/app/inbox/src/plan_listener.rs` (`stat_frame` → `size_bytes` at
   `:556`), and calibration-master `frame_ids` are populated there rather than left
   as the historical `'[]'` placeholder (`:340`, `:996`, test at `:1096`).
-- **US2 (on-demand half)** — `crates/app/core/src/frame_inventory/reconcile.rs` and
-  `relink.rs`, exposed as `inventory_reconcile_run`, `inventory_frame_list` and
-  `inventory_frame_relink` (`bootstrap/specta.rs:74`, `:413-415`). Relink matches
-  on sha256 computed on demand (`relink.rs:21`), per the 2026-07-04 clarification.
+- **US2** frames removed or moved outside the app —
+  `crates/app/core/src/frame_inventory/reconcile.rs` and `relink.rs`, exposed as
+  `inventory_reconcile_run`, `inventory_frame_list` and `inventory_frame_relink`
+  (`apps/desktop/src-tauri/src/commands/inventory_frame.rs:53`/`:39`/`:69`). Relink
+  matches on sha256 computed on demand (`relink.rs:21`), per the 2026-07-04
+  clarification.
 - **US3** raw sub-frame cleanup candidates —
   `crates/app/core/src/cleanup_generator/raw_frames.rs`, summing real
   `frame.size_bytes` into `total_reclaimable_bytes` at `:190`/`:204` and refusing
   the scan outright when a session's `frame_ids` is unreadable (`:47`, PR #1739).
-- **US4 (config half)** — `crates/app/settings/src/root_config.rs` carries
-  per-root `ReconcileMode` (`flag_missing` default, `auto_reconcile` opt-in) and
-  the `detection.live` / `.scheduled` / `.on_open` / `.follow_symlinks` keys.
+- **US4** per-root detection and reconciliation config —
+  `crates/app/settings/src/root_config.rs` holds per-root `ReconcileMode`
+  (`flag_missing` default, `auto_reconcile` opt-in) and the `detection.live` /
+  `.scheduled` / `.on_open` / `.follow_symlinks` keys. All three triggers are
+  consumed by `apps/desktop/src-tauri/src/frame_watcher.rs`: `detection.live` at
+  `:252` starts a real `notify` watcher via `start_artifact_watcher`,
+  `detection.scheduled` at `:204` spawns a periodic reconcile that doubles as the
+  polling fallback when live is off (`:59-60`), and `detection.on_open` at `:378`.
+  The registry is installed at `apps/desktop/src-tauri/src/lib.rs:772` and attached
+  or detached per root through `inventory_watcher_attach` / `_detach`
+  (`commands/inventory_frame.rs:125`/`:145`), so no watch is held on an idle root.
+  Config surface `inventory_root_config_get` / `_set` (`:84`/`:102`), UI
+  `apps/desktop/src/features/inventory/RootDetectionConfig.tsx:138`/`:160`/`:181`
+  with `__tests__/RootDetectionConfig.test.tsx`, live-event coverage
+  `apps/desktop/src-tauri/tests/frame_watcher_live_event.rs`. Landed in
+  `4d5916f9c` (PR #1636).
 - **US5** missing-frame awareness for calibration matches —
   `crates/app/core/tests/calibration_missing_flag_integration.rs`.
-
-**Not built**: the detection *triggers* US2 and US4 describe. `detection.live`,
-`detection.scheduled` and `detection.on_open` are stored and validated but have no
-consumer outside `root_config.rs`; nothing starts a frame-tree watcher or a
-scheduled sweep, so reconciliation only happens when the user asks for it. The
-`notify`-based watcher in `crates/workflow/artifacts/src/watcher.rs` belongs to
-spec 012 (artifact observation) and does not cover frame inventory.
 
 **Input**: User description: "Per-frame (per-file) inventory with live session membership. Complete PlateVault's per-frame inventory so raw sub-frame cleanup is possible and sessions stay honest about what is on disk."
 

--- a/specs/049-source-view-generation/data-model.md
+++ b/specs/049-source-view-generation/data-model.md
@@ -1,7 +1,8 @@
 # Data Model: Source View Generation
 
 **Spec**: `specs/049-source-view-generation/spec.md`
-**Status**: Planned
+**Status**: Implemented (post-hoc record, corrected 2026-08-24) — see `spec.md`'s
+status header for the per-user-story evidence.
 
 This feature is the **generation** counterpart of spec 026 and **reuses** its
 entities. It adds no new durable table. The reused entities and the delta are

--- a/specs/049-source-view-generation/spec.md
+++ b/specs/049-source-view-generation/spec.md
@@ -4,7 +4,20 @@
 
 **Created**: 2026-07-04
 
-**Status**: Clarified (all open questions resolved 2026-07-04)
+**Status**: Implemented (post-hoc record, verified 2026-08-24; open questions were
+resolved 2026-07-04). All four user stories ship: US1 `sourceview_generate`
+(`apps/desktop/src-tauri/src/commands/prepared_views.rs:130`, registered at
+`bootstrap/specta.rs:447`, covered by
+`crates/app/core/tests/source_view_generation_us1.rs`); US2 profile-driven layout
+via `workflow_profiles::seed::resolve_source_view_layout`
+(`crates/app/projects/src/source_view_generate/generate.rs:78`); US3
+`preparedview_regenerate` (`specta.rs:445`,
+`crates/app/core/tests/source_view_generation_us3_regenerate.rs`); US4
+`sourceview_verify` (`prepared_views.rs:151`,
+`crates/app/core/tests/source_view_verify_us4.rs`). Destination model shipped as
+`sourceview_destination_get` / `_set` (`prepared_views.rs:169`/`:188`), and
+`crates/e2e-tests/tests/source_view_journeys.rs` exercises the surface
+end-to-end.
 
 **Input**: User description: "Restore source-view generation: the app generates a
 processing-tool-ready (WBPP/PixInsight-first) project input directory on disk —

--- a/specs/051-tauri-shell-integration/spec.md
+++ b/specs/051-tauri-shell-integration/spec.md
@@ -4,7 +4,36 @@
 
 **Created**: 2026-07-05
 
-**Status**: Draft
+**Status**: Partial (verified 2026-08-24 against `origin/main` a52c637f2). Nine of
+ten user stories ship; US9 does not. The five shell-integration plugins are
+non-optional dependencies at `apps/desktop/src-tauri/Cargo.toml:59-67`.
+
+Shipped:
+
+- **US1** single instance — `tauri-plugin-single-instance`, initialised at
+  `apps/desktop/src-tauri/src/lib.rs:179`.
+- **US2** favourited targets as real data — `target_favourites_list` / `_add` /
+  `_remove` registered at `bootstrap/specta.rs:133-134` and `:243-244`, backed by
+  `crates/persistence/targets/src/repositories/target_favourites.rs`.
+- **US3** per-type cleanup overrides as canonical data — `cleanupTypeOverrides`
+  settings key with its own validation rule
+  (`crates/app/settings/src/descriptors.rs:548`, `:767`).
+- **US4** window size and position — `tauri-plugin-window-state`, initialised at
+  `lib.rs:235`.
+- **US5** native menu bar — `apps/desktop/src-tauri/src/bootstrap/menu.rs`.
+- **US6** native window chrome follows the theme —
+  `apps/desktop/src/data/theme.ts:313` calls `getCurrentWindow().setTheme(mode)`
+  (`decorations: false` at `tauri.conf.json:30`).
+- **US7** shareable diagnostics log file — `tauri-plugin-log`.
+- **US8** OS notification on long-task completion — `tauri-plugin-notification`,
+  initialised at `src/bootstrap/notify.rs:18`.
+- **US10** signed in-app updates — `tauri-plugin-updater` (builder at
+  `lib.rs:60-64`) plus `tauri-plugin-process` for the relaunch step.
+
+**Not built — US9** ("behaves like a native app, not a browser tab, in release
+builds"): no reload (F5 / Cmd+R), devtools-shortcut or `contextmenu` suppression
+exists anywhere under `apps/desktop/src`. Do not read the status above as covering
+it.
 
 **Input**: User description: "Adopt a decided set of Tauri shell integrations
 (single-instance guard, window-state persistence, native theme sync, a


### PR DESCRIPTION
## What this is

Ten instances of one defect class: a spec's `Status` field, or a present-tense
Overview claim, asserting work is outstanding when `origin/main` a52c637f2 shows
it shipped. This direction hides progress — two beads were filed today for work
already done, one claiming 37 files undone when it was 5 and complete.

Specs only. No `specs/*/tasks.md` was touched (task state lives in beads). Nothing
under `docs/journeys/` or `docs/product/journeys/` was touched.

## NO HOOK CHECKED THIS CHANGE

`.pre-commit-config.yaml` excludes `specs/` wholesale, so the repo gate is
**vacuous** on this diff. Reported honestly rather than cited as green:

```
$ bash scripts/precommit-verify.sh $(git diff --name-only)
pre-commit hooks that actually ran on these 12 path(s): 0
VACUOUS RUN: no hook checked any of the 12 path(s) given.
EXIT=1
```

`uvx slopvac` was run as a substitute and is **not** a gate here either: the
touched files carry pre-existing baselines of 111, 105, 54 and 48 errors, so the
linter is plainly not enforced on `specs/`. Per-file deltas from this change are
+1 to +10, every one a `prose-format.no-unicode-dash` on em dashes that match the
surrounding house style. `specs/026/research.md` was the only file this change
took from clean to dirty, and that was fixed — it is back to 0 errors.

## Verdicts — every instance re-verified against `origin/main`, not trusted

Re-verification changed **two** verdicts (a third, 048, was corrected in round 2).

| Spec | Filed as | Verdict | What changed |
|---|---|---|---|
| 016 `spec.md:9` | Draft, 4 items "Pending implementation" | **real, full** | Status → Implemented; the four pending items rewritten as shipped with per-item citations |
| 044 `spec.md:7` | Draft, 4 false present-tense claims | **real, US-level** | Status → Implemented (bounded); Context & Motivation put in past tense |
| 047 `spec.md:7` | Draft | **real, US-level** | Status → Implemented (bounded) |
| 037-ipc `spec.md:7` | Draft, half stale | **partial — Draft kept** | Background repointed, work rescoped to 24 wrappers in 2 modules |
| 037-e2e `spec.md:7` | Draft, "Layer 2 not shipped" | **bead wrong — full ship** | Status → Implemented; Overview past-tensed; wrong-path finding recorded |
| 015 `plan.md:4` | Draft vs `spec.md` Implemented | **real** | `plan.md` flipped to agree |
| 049 `spec.md:7`, `data-model.md:4` | Clarified / Planned | **real, full** | Both → Implemented, per-US evidence |
| 051 `spec.md:7` | Draft | **PARTIAL** | Status → Partial, naming US9 as not built |
| 026 `research.md:4` | NOT IMPLEMENTED | **real** | → IMPLEMENTED, matching its three siblings |
| 041 `spec.md:28` | Implemented 59/59, zero "approv" | **real — content, not status** | FR-006a/b/c added and dated |
| 048 `spec.md:7` | Draft, 3 false Overview claims | **real, full** | Status → Implemented (was Partial in r1 — see Round 2); Overview past-tensed |

### The three corrections

**037-e2e — the filing bead's evidence was wrong, though not for the reason first
given.** `astro-plan-dsga8` called Layer 2 unshipped by checking `apps/desktop/e2e`.
That path **did** exist and was deleted (see Round 2), so the audit cited a dead
path rather than an imaginary one. Layer 2 itself ships as the `thirtyfour` Rust
journey suite. Marked Implemented, with the deleted-path history recorded in the
spec.

**051 — Partial, not Implemented.** Nine of ten user stories ship. US9 ("behaves
like a native app, not a browser tab, in release builds") does not: no reload
(F5 / Cmd+R), devtools-shortcut or `contextmenu` suppression exists anywhere under
`apps/desktop/src`. Flipping this to Implemented would have converted an
understatement into an overclaim.

### Bounds stated rather than glossed

044 and 047 carry an explicit bound in their Status headers: user-story surfaces
were located, **per-FR verification was not performed**, so individual FRs are
unconfirmed rather than closed. PR #1744's review caught a newly-ticked box that
was itself false; the fix for that is to say what the evidence covers.

037-ipc keeps **Draft on purpose**. `commands.ts` was deleted (1673 lines) at
`54b56d284`, but 24 hand-written wrappers remain — 15 in `sessionsGroupsIpc.ts`,
9 in `calibrationHandoffIpc.ts` — so the spec's own Independent Test still fails.
The Background is repointed and the work rescoped rather than the status flipped.
Two further `invoke(` sites are explicitly excluded as non-wrappers:
`dev/ContractsPage.tsx:142` is the deliberate dynamic replay this migration must
preserve, and `data/logSubscription.ts:52` is a comment.

041 runs the other way — a completeness claim omitting shipped behaviour, so it
needed content. FR-006a/b/c cover the approval precondition, the
`plan.approval_required` refusal, the `plan.approval.stale` token check, and the
`plans::auto_apply` exception. They are dated 2026-08-24 so the 59/59 count is not
read as covering them. Modelled on spec 025 FR-001/FR-011, which states the same
gate correctly; 025 was not edited.

## Left alone deliberately

Specs 013 and 035 (stale-looking because they are records), spec 018:273/:276
(correctly recording absent paths), spec 040's grown counts, spec 033's
date-stamped gate counts, spec 010's superseded planning docs, and the two specs
sharing number 037.

Not fixed here, out of class — spec 016's "Mockup-done" bullets cite
`src/data/settings.ts` and `SettingsPage.tsx::SourceProtectionSection`, both
deleted, and spec 037-e2e's `research.md` cites `apps/desktop/e2e/helpers/*.ts`.
Those are stale-citation repointing, the job PR #1746 did for spec 048, and are
filed rather than swept in.

Tracks-Bead: astro-plan-5u4wl
Merge-Bead: astro-plan-rmoxf

---

# Round 2 — three review defects fixed

All three verified independently against `origin/main` before changing anything.

## 1. Spec 048 ships. Partial did not hold.

I marked 048 Partial claiming `detection.live` / `.scheduled` / `.on_open` had no
consumer outside `root_config.rs`. All three have one:
`apps/desktop/src-tauri/src/frame_watcher.rs` reads `detection.live` at `:252`
(starts a real `notify` watcher via `start_artifact_watcher`), `.scheduled` at
`:204` (periodic reconcile, also the polling fallback when live is off, `:59-60`),
and `.on_open` at `:378`. Registry at `lib.rs:772`; per-root attach/detach at
`commands/inventory_frame.rs:125`/`:145`; UI at
`features/inventory/RootDetectionConfig.tsx:138`/`:160`/`:181` with a colocated
test; live-event coverage at `src-tauri/tests/frame_watcher_live_event.rs`. Landed
`4d5916f9c` (#1636), confirmed an ancestor of `origin/main`. **Now Implemented.**

Two reviewer citations were slightly off and I used what I verified: the UI is under
`features/inventory/`, not `features/settings/`, and the commands are at `:125`/`:145`
(watcher) and `:84`/`:102` (config), not `:109`/`:131`/`:149`.

**Root cause of my error**: I proved a negative from a grep truncated by `head -10`;
`frame_watcher.rs` was below the cut. Calling something Partial when it fully ships
understates it — the same defect class this PR exists to correct, in the opposite
direction from the trap I was warned about. The consequent claim that the watcher
"belongs to spec 012 and does not cover frame inventory" was also wrong and is gone.

**`astro-plan-jlqf8` is INVALID** — its premise was this defect. Commented with the
evidence; not closed (outside my authority).

## 2. "apps/desktop/e2e has never existed" was false

`git log --all --diff-filter=A -- apps/desktop/e2e` exits 0. Added 2026-06-19/20
across `329c6d11d`, `db56e34ee`, `695f668b6`, `e3793a598`, holding
`playwright.real-backend.config.ts`, `real-backend/*.spec.ts`, `helpers/` and a
`README.md`; removed across `e3793a598`, `7a4f70446` (2026-06-20, standardized
real-UI E2E on `tauri-plugin-webdriver` and retired wdio) and `a504a7fce`
(2026-07-11). So `astro-plan-dsga8` cited a **deleted** path, not an imaginary one —
materially different and far more forgivable. Corrected in the spec and in
`astro-plan-a8tlf`.

## 3. The three-OS claim was overstated, and two populations were conflated

Default behaviour, not aspiration (`e2e.yml:14-35`):

| Trigger | What runs |
|---|---|
| every `pull_request` / `merge_group` | Tier-1 real-UI **smoke subset**, `ubuntu-latest` only |
| push to `main` | Tier-2 full matrix, `ubuntu-latest` (4 shards) + `windows-latest` (3 shards) |
| `macos-latest` | **opt-in only** — `workflow_dispatch` with `run_macos=true`, default `false` (`:163-168`, gated `:303`) |

macOS was skipped on this PR's own run, so "runs on ubuntu, windows and macos" was
not what happens. Windows is deliberately off PRs as the slow, historically flaky leg.

The three populations are now separated in the spec:

- **Layer 1** — `ci.yml`'s `integration` matrix ("Unit + integration (L1+L2)").
- **Layer 2** — the `thirtyfour` Rust suite: **30** tests across 14 files in
  `crates/e2e-tests/tests/`, all `#[ignore]`d in-source so
  `cargo test --workspace` never runs them; they run only via `e2e.yml` against the
  built `desktop_shell` under the `e2e` feature.
- **Mock-mode UI regression — neither layer** — **38** Playwright `.spec.ts` under
  `tests/e2e/`, run by `ci.yml`'s `ui-e2e` ("UI mock-mode (Playwright) — run") on
  `ubuntu-latest`, frontend-gated. These drive **in-process mocks**, not a real
  backend. Citing their file count as Layer 2 evidence was wrong.

The CI tier names do not match this document's layer names; `contracts/coverage-matrix.md`
carries that mapping note.

## Holding from round 1, per review

051 stays **Partial** (US9 absent on both TS and Rust sides — the reviewer's own
searches confirmed). 037-ipc stays **Draft** (24 wrappers). 041's FR-006a/b/c stand,
including the three-way distinction between `plan.approval_required`,
`plan.approval.stale` and content staleness. 044/047 keep their explicit
"per-FR verification not performed" bounds, ruled honest rather than a defect.

## Gate — still NO HOOK CHECKED THIS CHANGE

```
$ bash scripts/precommit-verify.sh $(git diff --name-only)
VACUOUS RUN: no hook checked any of the 2 path(s) given.
EXIT=1
```

Vacuous by design: `.pre-commit-config.yaml:16` excludes `specs/` wholesale, which
the reviewer confirmed. `uvx slopvac` is not a gate here either — deltas on the two
touched files are `+6` and `+7` against their `origin/main` baselines of 25 and 25,
all `prose-format.no-unicode-dash` on em dashes matching house style.
