### PR TITLE
docs(mcp-bridge): document the TAURI_CONFIG build so execute_js can return

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -54,8 +54,12 @@ if (import.meta.env.VITE_DEV_TOOLS === 'true') {
 }
 
 // Feature 037 US3: expose a real IPC invoke bridge for the WebdriverIO E2E
-// journeys. `withGlobalTauri` is off, so `window.__TAURI__` is unavailable in the
-// webview; this gives the journeys a way to assert UI -> real-backend round-trips
+// journeys. `withGlobalTauri` is absent from `tauri.conf.json` and the E2E build
+// does not merge the `tauri.dev.conf.json` overlay that sets it, so
+// `window.__TAURI__` is unavailable in the E2E webview — but it IS present under
+// that overlay (docs/development/mcp-bridge.md), so its absence is a property of
+// this build path, not of the app.
+// This gives the journeys a way to assert UI -> real-backend round-trips
 // (e.g. `roots_list`) over the *real* IPC path. VITE_E2E is statically falsy in
 // production builds, so this branch and the ipc chunk reference are tree-shaken
 // out (mirrors the VITE_DEV_TOOLS gate above and the VITE_E2E path override).

--- a/docs/development/mcp-bridge.md
+++ b/docs/development/mcp-bridge.md
@@ -30,6 +30,52 @@ PV_MCP_BRIDGE_ENABLE=1 pnpm tauri dev --config src-tauri/tauri.dev.conf.json --f
 The `tauri.dev.conf.json` overlay also enables `withGlobalTauri`, which
 `webview_execute_js` needs to reach command handlers.
 
+### Build the binary without the Tauri CLI
+
+`generate_context!` compiles `withGlobalTauri` in rather than reading it at
+startup: it embeds the global API script only when the config it sees has the
+flag set (`tauri-codegen/src/context.rs`, `config.app.with_global_tauri`). That
+config comes from three places:
+
+- `apps/desktop/src-tauri/tauri.conf.json`
+- the per-platform overlays, such as `tauri.windows.conf.json`
+- the `TAURI_CONFIG` environment variable, merged over both
+
+`tauri.dev.conf.json` is none of those. The `--config` flag of the Tauri CLI is
+what puts its contents into `TAURI_CONFIG`.
+
+So a plain `cargo build -p desktop_shell --features dev-tools` produces a binary
+with **no** `window.__TAURI__`. The bridge still starts and still answers
+`get_window_info`, but every `webview_execute_js` call times out, because the
+result-return the plugin injects goes through `window.__TAURI__`. Merge the
+overlay explicitly to get a drivable binary:
+
+```sh
+cd apps/desktop/src-tauri
+TAURI_CONFIG="$(cat tauri.dev.conf.json)" \
+  cargo build -p desktop_shell --features dev-tools
+```
+
+```powershell
+cd apps\desktop\src-tauri
+$env:TAURI_CONFIG = Get-Content -Raw tauri.dev.conf.json
+cargo build -p desktop_shell --features dev-tools
+```
+
+`TAURI_CONFIG` is a `rerun-if-env-changed` input, so switching it in or out
+rebuilds `desktop_shell` rather than reusing the previous binary. Before you
+launch, confirm that the build picked the overlay up. The global API script is a
+literal in the binary:
+
+```sh
+grep -ac __TAURI_IIFE__ target/debug/desktop_shell   # 1 with the overlay, 0 without
+```
+
+A debug binary loads the UI from `devUrl` (`http://localhost:5173`), so Vite must
+stay up for as long as the app does. On Windows, `Start-Process` over SSH reaps
+both Vite and the app when the SSH session closes, so launch each under
+`schtasks` or another session-persistent launcher.
+
 ### Windows host, WSL client
 
 `scripts\win-native-dev.ps1 -McpBridge` launches the same overlay and sets the

--- a/scripts/check-dev-surface-absent.sh
+++ b/scripts/check-dev-surface-absent.sh
@@ -10,6 +10,7 @@
 #   2. the resolved default feature graph of `desktop_shell` pulls neither
 #      feature and neither gated plugin crate
 #   3. no shipped capability file grants a permission from a gated plugin
+#   4. no config the build reads by filename sets `withGlobalTauri`
 #
 # Exit 0 requires a positive determination from every check. Each one first
 # asserts that its input exists and that its query returned a record it can
@@ -78,6 +79,28 @@ if [ "${#CAPABILITIES[@]}" -eq 0 ]; then
   fail "no capability file matches $CAPABILITY_GLOB, so no grant was read"
 elif grep -lE "\"($GATED_PERMISSIONS)" "${CAPABILITIES[@]}" | grep -q .; then
   fail "a shipped capability file grants a gated plugin permission"
+fi
+
+# --- 4. config: no filename-addressed config sets withGlobalTauri ---
+# `withGlobalTauri` exposes every command handler to page JavaScript. It is
+# compiled in by `generate_context!` from `tauri.conf.json` plus the
+# per-platform overlays plus the `TAURI_CONFIG` env var, so a build that passes
+# neither `--config` nor `TAURI_CONFIG` can only pick it up from these files.
+# `tauri.dev.conf.json` is deliberately not among them: no build reads it by
+# name (see docs/development/mcp-bridge.md).
+SHIPPED_CONFIG_BASE=apps/desktop/src-tauri/tauri.conf.json
+# Brace expansion ignores `nullglob`, so filter to what exists.
+SHIPPED_CONFIGS=()
+for candidate in \
+  "$SHIPPED_CONFIG_BASE" \
+  apps/desktop/src-tauri/tauri.{macos,linux,windows,android,ios}.conf.json{,5} \
+  apps/desktop/src-tauri/Tauri{,.macos,.linux,.windows,.android,.ios}.toml; do
+  [ -f "$candidate" ] && SHIPPED_CONFIGS+=("$candidate")
+done
+if [ ! -f "$SHIPPED_CONFIG_BASE" ]; then
+  fail "$SHIPPED_CONFIG_BASE is missing, so no shipped config was read"
+elif grep -lEi '"?with_?global_?tauri"?' "${SHIPPED_CONFIGS[@]}" | grep -q .; then
+  fail "a config the build reads by filename sets withGlobalTauri"
 fi
 
 if [ "$FAILED" -ne 0 ]; then


### PR DESCRIPTION
## What

`withGlobalTauri` is already `true` in `apps/desktop/src-tauri/tauri.dev.conf.json`,
but no build reads that file by name. `tauri-codegen` embeds the global API
script at compile time from `tauri.conf.json`, the per-platform overlays, and
the `TAURI_CONFIG` environment variable; the `--config` flag of the Tauri CLI is
the only thing that puts the dev overlay into `TAURI_CONFIG`. So a plain
`cargo build -p desktop_shell --features dev-tools` yields a binary with no
`window.__TAURI__`, the bridge answers `get_window_info`, and every
`webview_execute_js` call times out. The Windows journey host hit exactly that.

- `docs/development/mcp-bridge.md`: the `TAURI_CONFIG` recipe for a built
  binary, the binary-literal check that tells the two builds apart, and the
  `devUrl` / Vite-lifetime constraint that also bit the host.
- `scripts/check-dev-surface-absent.sh`: a fourth assertion, so
  `withGlobalTauri` cannot reach a config the release build reads by filename.
- `apps/desktop/src/main.tsx`: the comment asserted the flag is off, without
  saying that only the base and E2E configs lack it.

## Verification

| Check | Result |
|---|---|
| `cargo build -p desktop_shell` (default features) | exit 0; `grep -ac __TAURI_IIFE__` = 0 |
| `TAURI_CONFIG="$(cat tauri.dev.conf.json)" cargo build -p desktop_shell --features dev-tools` | exit 0; `grep -ac __TAURI_IIFE__` = 1 |
| `execute_js` against the running app | `typeof window.__TAURI__` = `object`; `1+1` returned `2` |
| Real interaction | clicking the wizard `2. Theme` step moved the heading from `Choose your language` to `Choose how PlateVault looks` |
| `bash scripts/check-dev-surface-absent.sh` | exit 0; exit 1 with `withGlobalTauri` injected into `tauri.conf.json` |
| `shellcheck scripts/check-dev-surface-absent.sh` | exit 0 |
| `biome check apps/desktop/src/main.tsx` | exit 0 |

The observed run used a macOS debug binary against Vite on `localhost:5173`,
with the real backend and an isolated SQLite database.

Release path proof: the shipped `tauri.conf.json` carries no `withGlobalTauri`,
no per-platform overlay exists, and a default-feature binary contains zero
occurrences of the global API script literal. The new gate assertion fails when
that stops being true.

Tracks-Bead: astro-plan-0vvzm
Closes-Bead: astro-plan-0vvzm
Merge-Bead: astro-plan-k4sqy
