### PR TITLE
docs(specs): point the 26 superseded-030 spec banners at spec 032

### DIFF
--- a/specs/001-astro-library-manager/spec.md
+++ b/specs/001-astro-library-manager/spec.md
@@ -1,8 +1,11 @@
 # Feature Specification: Astro Library Manager
 
-> **See Spec 030**: Implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for UI patterns, lifecycle states, source folder types, and data model changes.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
+> Lifecycle states, source folder types, and data model concepts are owned by
+> the dependent backend specs (002, 005-019, 023-026), not by spec 030.
 
 **Feature Branch**: `001-astro-library-manager`  
 **Created**: 2026-05-02  

--- a/specs/002-data-lifecycle-state-model/spec.md
+++ b/specs/002-data-lifecycle-state-model/spec.md
@@ -10,9 +10,10 @@
 > and FR-012 are partly historical — the state names remain valid but the owning flow has moved to
 > the Inbox ingest gate.
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `002-data-lifecycle-state-model`  
 **Created**: 2026-05-09  

--- a/specs/003-first-run-source-setup/spec.md
+++ b/specs/003-first-run-source-setup/spec.md
@@ -5,9 +5,11 @@
 > Under 035 there is no catalog download at first run; if a catalog/resolver step remains it becomes a
 > lightweight SIMBAD-reachability check. All other first-run setup steps are unaffected.
 
-> **UI Revised**: The UI design in this spec has been revised by
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md).
-> When implementing, follow spec 030 for layout, navigation, and component patterns.
+> **UI Revised**: The UI design in this spec was revised by
+> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md), which is
+> superseded as of 2026-06-11. UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns.
 
 **Feature Branch**: `003-first-run-source-setup`  
 **Created**: 2026-05-09  

--- a/specs/004-native-filesystem-controls/spec.md
+++ b/specs/004-native-filesystem-controls/spec.md
@@ -1,8 +1,10 @@
 # Feature Specification: Native Filesystem Controls
 
-> **UI Revised**: The UI design in this spec has been revised by
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md).
-> When implementing, follow spec 030 for layout, navigation, and component patterns.
+> **UI Revised**: The UI design in this spec was revised by
+> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md), which is
+> superseded as of 2026-06-11. UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns.
 
 **Feature Branch**: `004-native-filesystem-controls`  
 **Created**: 2026-05-09  

--- a/specs/005-inbox-mixed-folder-split/spec.md
+++ b/specs/005-inbox-mixed-folder-split/spec.md
@@ -10,9 +10,11 @@
 > The mixed-vs-single detection intent here remains the conceptual origin; the
 > implementation lives in 041.
 
-> **UI Revised**: The UI design in this spec has been revised by
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md).
-> When implementing, follow spec 030 for layout, navigation, and component patterns.
+> **UI Revised**: The UI design in this spec was revised by
+> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md), which is
+> superseded as of 2026-06-11. UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns.
 
 **Feature Branch**: `005-inbox-mixed-folder-split`  
 **Created**: 2026-05-09  

--- a/specs/006-inventory-library-lifecycle/spec.md
+++ b/specs/006-inventory-library-lifecycle/spec.md
@@ -36,9 +36,10 @@
 > pick persisted via the confirm-request extension (spec-008 FR-022).
 > No InventorySession state or projection shape changes. See the Iterations log.
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `006-inventory-library-lifecycle`  
 **Created**: 2026-05-09  

--- a/specs/007-calibration-matching-rules/spec.md
+++ b/specs/007-calibration-matching-rules/spec.md
@@ -1,8 +1,9 @@
 # Feature Specification: Calibration Matching Rules
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `007-calibration-matching-rules`
 **Created**: 2026-05-09

--- a/specs/008-project-create-onboard-edit/spec.md
+++ b/specs/008-project-create-onboard-edit/spec.md
@@ -1,8 +1,9 @@
 # Feature Specification: Project Create, Onboard, And Edit
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `008-project-create-onboard-edit`  
 **Created**: 2026-05-09  

--- a/specs/009-project-lifecycle-model/spec.md
+++ b/specs/009-project-lifecycle-model/spec.md
@@ -12,9 +12,10 @@
 > prepared` PreparedSource creation is now **per-framing** (a Q20 source view per
 > framing). See the Iterations log below. Spec 008 owns the framing data model.
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `009-project-lifecycle-model`  
 **Created**: 2026-05-09  

--- a/specs/010-guided-first-project-flow/spec.md
+++ b/specs/010-guided-first-project-flow/spec.md
@@ -1,8 +1,10 @@
 # Feature Specification: Guided First Project Flow
 
-> **UI Revised**: The UI design in this spec has been revised by
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md).
-> When implementing, follow spec 030 for layout, navigation, and component patterns.
+> **UI Revised**: The UI design in this spec was revised by
+> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md), which is
+> superseded as of 2026-06-11. UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns.
 
 **Feature Branch**: `010-guided-first-project-flow`
 **Created**: 2026-05-09

--- a/specs/011-processing-tool-launch/spec.md
+++ b/specs/011-processing-tool-launch/spec.md
@@ -1,8 +1,9 @@
 # Feature Specification: Processing Tool Launch
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `011-processing-tool-launch`
 **Created**: 2026-05-09

--- a/specs/012-processing-artifact-observation/spec.md
+++ b/specs/012-processing-artifact-observation/spec.md
@@ -1,8 +1,9 @@
 # Feature Specification: Processing Artifact Observation
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `012-processing-artifact-observation`  
 **Created**: 2026-05-09  

--- a/specs/013-target-lookup-from-fits-object/spec.md
+++ b/specs/013-target-lookup-from-fits-object/spec.md
@@ -7,9 +7,10 @@
 > **target-identity model** here (canonical target, `CatalogRef`, aliases, dedup) is **retained and
 > reused** by spec 035.
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `013-target-lookup-from-fits-object`  
 **Created**: 2026-05-09  

--- a/specs/014-catalog-index-licensing/spec.md
+++ b/specs/014-catalog-index-licensing/spec.md
@@ -7,9 +7,10 @@
 > are now resolved on demand against SIMBAD with a bundled seed index + local cache (spec 035). The
 > **license-attribution** model here (CDS/OpenNGC CC-BY attribution) remains relevant.
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `014-catalog-index-licensing`  
 **Created**: 2026-05-09  

--- a/specs/015-token-pattern-builder/spec.md
+++ b/specs/015-token-pattern-builder/spec.md
@@ -1,8 +1,9 @@
 # Feature Specification: Token Pattern Builder
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `015-token-pattern-builder`  
 **Created**: 2026-05-09  

--- a/specs/016-source-protection-defaults/spec.md
+++ b/specs/016-source-protection-defaults/spec.md
@@ -1,8 +1,9 @@
 # Feature Specification: Source Protection Defaults
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `016-source-protection-defaults`  
 **Created**: 2026-05-09  

--- a/specs/017-cleanup-archive-review-plans/spec.md
+++ b/specs/017-cleanup-archive-review-plans/spec.md
@@ -1,8 +1,9 @@
 # Feature Specification: Cleanup And Archive Review Plans
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `017-cleanup-archive-review-plans`  
 **Created**: 2026-05-09  

--- a/specs/018-settings-configuration-model/spec.md
+++ b/specs/018-settings-configuration-model/spec.md
@@ -5,9 +5,10 @@
 > the catalog settings surface becomes the SIMBAD resolver settings (endpoint, enable/disable, cache).
 > All other settings are unaffected.
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `018-settings-configuration-model`  
 **Created**: 2026-05-09  

--- a/specs/019-bottom-log-viewer/spec.md
+++ b/specs/019-bottom-log-viewer/spec.md
@@ -1,8 +1,10 @@
 # Feature Specification: Bottom Log Viewer
 
-> **UI Revised**: The UI design in this spec has been revised by
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md).
-> When implementing, follow spec 030 for layout, navigation, and component patterns.
+> **UI Revised**: The UI design in this spec was revised by
+> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md), which is
+> superseded as of 2026-06-11. UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns.
 
 **Feature Branch**: `019-bottom-log-viewer`  
 **Created**: 2026-05-09  

--- a/specs/021-developer-contract-diagnostics/spec.md
+++ b/specs/021-developer-contract-diagnostics/spec.md
@@ -1,8 +1,11 @@
 # Feature Specification: Developer Contract Diagnostics
 
-> **See Spec 030**: Implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for UI patterns, lifecycle states, source folder types, and data model changes.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
+> Lifecycle states, source folder types, and data model concepts are owned by
+> the dependent backend specs (002, 005-019, 023-026), not by spec 030.
 
 **Feature Branch**: `021-developer-contract-diagnostics`  
 **Created**: 2026-05-09  

--- a/specs/022-mantine-prototype-design-system/spec.md
+++ b/specs/022-mantine-prototype-design-system/spec.md
@@ -1,8 +1,10 @@
 # Feature Specification: Desktop Prototype Design System
 
-> **UI Revised**: The UI design in this spec has been revised by
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md).
-> When implementing, follow spec 030 for layout, navigation, and component patterns.
+> **UI Revised**: The UI design in this spec was revised by
+> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md), which is
+> superseded as of 2026-06-11. UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns.
 
 **Feature Branch**: `022-mantine-prototype-design-system`
 **Created**: 2026-05-09

--- a/specs/023-target-identity-history-notes/spec.md
+++ b/specs/023-target-identity-history-notes/spec.md
@@ -19,9 +19,10 @@
 > (FR-009 dropped + SC-002 nav reversal are sanctioned scope changes; FR-005/FR-007 observing-plan refs
 > remain deferred / out of scope).
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `023-target-identity-history-notes`  
 **Created**: 2026-05-09  

--- a/specs/024-project-manifests-and-notes/spec.md
+++ b/specs/024-project-manifests-and-notes/spec.md
@@ -1,8 +1,9 @@
 # Feature Specification: Project Manifests And Notes
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `024-project-manifests-and-notes`  
 **Created**: 2026-05-09  

--- a/specs/025-filesystem-plan-application/spec.md
+++ b/specs/025-filesystem-plan-application/spec.md
@@ -1,8 +1,9 @@
 # Feature Specification: Filesystem Plan Application
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `025-filesystem-plan-application`  
 **Created**: 2026-05-09  

--- a/specs/026-generated-project-source-view-removal/spec.md
+++ b/specs/026-generated-project-source-view-removal/spec.md
@@ -1,8 +1,9 @@
 # Feature Specification: Generated Project Source View Removal
 
-> **See Spec 030**: UI implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for layout, navigation, and component patterns.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
 
 **Feature Branch**: `026-generated-project-source-view-removal`  
 **Created**: 2026-05-09  

--- a/specs/029-tauri-backend-wiring/spec.md
+++ b/specs/029-tauri-backend-wiring/spec.md
@@ -1,8 +1,11 @@
 # Feature Specification: Tauri Backend Wiring
 
-> **See Spec 030**: Implementation of this feature must follow
-> [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
-> for UI patterns, lifecycle states, source folder types, and data model changes.
+> **See Spec 032**: UI implementation of this feature must follow
+> [Spec 032 — Design V4](../032-design-v4-implementation/spec.md), the current UI
+> truth, for layout, navigation, and component patterns. Spec 030 (UI Audit &
+> Revision), cited here previously, is superseded as of 2026-06-11.
+> Lifecycle states, source folder types, and data model concepts are owned by
+> the dependent backend specs (002, 005-019, 023-026), not by spec 030.
 
 **Feature Branch**: `029-tauri-backend-wiring`
 


### PR DESCRIPTION
## What

Twenty-six `specs/*/spec.md` banners instructed the reader to follow **spec 030
(UI Audit & Revision)**, which has carried `Status: Superseded (2026-06-11)`
since spec 032 delivered the UI/component work. All 26 now point at
[Spec 032 — Design V4](../../specs/032-design-v4-implementation/spec.md) in one
consistent wording, and each records that 030 is superseded.

## What supersedes 030, and how it was confirmed

Three independent reads at `origin/main`:

- `specs/030-ui-audit-revision/spec.md:7-9` — its own Status line names
  "Spec 032 — Design V4 (the current UI truth, reached via Spec 031 Design V3)".
- `specs/SPEC_STATUS.md:77-79` — 030 `🔴 Superseded`, 031 `✅ Closed` and
  "superseded by 032", 032 `✅ Implemented` with an empty notes cell.
  `specs/SPEC_STATUS.md:75` also states "UI design is owned by 032".
- `specs/032-design-v4-implementation/spec.md:6` — `Status: Implemented
  (post-hoc record)`. `git grep -in 'supersed' -- 'specs/*/spec.md'` returns no
  line marking 032 superseded, so the replacement pointer has not itself moved.

Every rewritten relative link was checked to resolve on disk.

## Banner count — the bead's 20 was an undercount of 7 files

The bead counted **files** matching the literal `See Spec 030`:

```
git grep -l '**See Spec 030**' origin/main -- 'specs/*/spec.md'   # 20 files
```

Counting files that link to 030's spec.md at all finds seven more:

```
git grep -l '030-ui-audit-revision/spec.md' origin/main -- 'specs/*/spec.md'   # 27 files
```

Every one of the 27 carries exactly one banner and one link occurrence, so
files, banners, and occurrences coincide at 27. The extra seven (003, 004, 005,
010, 019, 020, 022) use a `**UI Revised**` banner instead of `**See Spec 030**`;
six of them carry the identical instruction in different words. **26 files are
changed here**; 020 is left (below).

## Instruction versus historical record

Three banner forms existed:

- **Form A1 — pure instruction (17 files):** "*UI implementation of this feature
  must follow [Spec 030] for layout, navigation, and component patterns.*"
  002, 006, 007, 008, 009, 011, 012, 013, 014, 015, 016, 017, 018, 023, 024,
  025, 026. Rewritten.
- **Form A2 — pure instruction (3 files):** same, plus "*for UI patterns,
  lifecycle states, source folder types, and data model changes*" — 001, 021,
  029. Rewritten, and given a second sentence because 030's own Status assigns
  those non-UI concepts to the dependent backend specs (002, 005-019, 023-026),
  not to 032.
- **Form B — record plus instruction (6 files):** "*The UI design in this spec
  has been revised by [Spec 030]. When implementing, follow spec 030 …*" —
  003, 004, 005, 010, 019, 022. Sentence one is a true historical record: 030
  did revise those designs. Sentence two is the same defective instruction.
  The record is kept, moved to past tense and marked superseded; only the
  imperative half is repointed.

## Left unchanged

- **`specs/020-router-url-state/spec.md`** — its banner reads "*The UI design in
  this spec **follows** [Spec 030] **and the merged design-v4 implementation**.
  Routes, navigation, and layout match the shipped app shell.*" That is a
  descriptive record of what this spec conforms to, not an instruction to the
  reader, and it already names design-v4 as the merged implementation. Repointing
  it would rewrite a true record.
- **`specs/027-frontend-implementation/spec.md`** — already correct; its banner
  is the wording this change matches.
- Every `specs/*/tasks.md` — a repo guard refuses those writes, and
  `astro-plan-44tb` owns the stale task paper that also cites 030 as live.
- `docs/journeys/`, `docs/product/journeys/` — out of scope.

## NO HOOK CHECKED THIS CHANGE

`.pre-commit-config.yaml` excludes the spec tree wholesale.
`scripts/precommit-verify.sh` on all 26 paths reported:

```
pre-commit hooks that actually ran on these 26 path(s): 0
VACUOUS RUN: no hook checked any of the 26 path(s) given.
```

All ten configured hooks reported "no files to check". **No automated gate
verified this change.** The evidence for it is the three-source confirmation of
030's supersession above, the resolve-check on every rewritten link, and a
post-fix grep showing zero remaining `follow spec 030` / `**See Spec 030**`
instructions in `specs/*/spec.md`. No test was added; this is prose only.

## Concurrency

`astro-plan-2mfx6` is concurrently building a path-existence check for the spec
tree and `astro-plan-qos8v` is repointing stale identifiers. This PR touches the
banner block in the first 25 lines of these 26 files: 001, 002, 003, 004, 005,
006, 007, 008, 009, 010, 011, 012, 013, 014, 015, 016, 017, 018, 019, 021, 022,
023, 024, 025, 026, 029 (all `spec.md`). It adds one new relative link per file,
`../032-design-v4-implementation/spec.md`, which exists.

## Not resolved here

- `astro-plan-44tb` — the `tasks.md` paper citing 030 as live. Different file
  set, different fix, and spec task files are guard-protected.
- `astro-plan-2mfx6`, `astro-plan-qos8v` — separate units.

Tracks-Bead: astro-plan-2lw7g
Closes-Bead: astro-plan-2lw7g
Merge-Bead: astro-plan-s1ltj
