### PR TITLE
fix(projects): route the plan-gated Prepare edge to a reviewable plan

### DIFF
--- a/apps/desktop/messages/en-GB.json
+++ b/apps/desktop/messages/en-GB.json
@@ -1521,6 +1521,7 @@
   "projects_wizard_toast_view_project": "View project",
   "projects_wizard_toast_created_folders": "Project \"{name}\" created — project folders created on disk.",
   "projects_wizard_toast_folders_failed": "Project \"{name}\" created, but folder creation failed. The folder plan remains available for review.",
+  "projects_source_views_review_title": "Review source view plan",
   "projects_source_views_removal_toast": "Removal plan created. Review and apply plan to complete removal.",
   "projects_source_views_removal_failed": "Could not create removal plan: {message}",
   "projects_source_views_regen_unresolved": " ({count} unresolved references — review plan before applying)",

--- a/apps/desktop/messages/pt-BR.json
+++ b/apps/desktop/messages/pt-BR.json
@@ -1462,6 +1462,7 @@
   "projects_wizard_toast_view_project": "Ver projeto",
   "projects_wizard_toast_created_folders": "Projeto \"{name}\" criado — pastas do projeto criadas no disco.",
   "projects_wizard_toast_folders_failed": "Projeto \"{name}\" criado, mas a criação das pastas falhou. O plano de pastas permanece disponível para revisão.",
+  "projects_source_views_review_title": "Revisar plano de visualização de origem",
   "projects_source_views_removal_toast": "Plano de remoção criado. Revise e aplique o plano para concluir a remoção.",
   "projects_source_views_removal_failed": "Não foi possível criar o plano de remoção: {message}",
   "projects_source_views_regen_unresolved": " ({count} referências não resolvidas — revise o plano antes de aplicar)",

--- a/apps/desktop/src/features/projects/ProjectDetail.archive-plan.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.archive-plan.test.tsx
@@ -20,6 +20,7 @@
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -118,6 +119,20 @@ const mockProject: ProjectDetailDto = {
   updatedAt: '2026-06-10T00:00:00Z',
 };
 
+/** The plan-gated Prepare refusal mounts the source-view generate dialog,
+ *  which reads the settings query. */
+function renderPane() {
+  return render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <ProjectDetailContent projectId="proj-001" />
+    </QueryClientProvider>,
+  );
+}
+
 function setupStore(project: Partial<ProjectDetailDto> = {}) {
   vi.mocked(store.useProjectDetail).mockReturnValue({
     data: { ...mockProject, ...project },
@@ -145,7 +160,7 @@ describe('ProjectDetail archive plan generation (spec 017 US2/WP-B)', () => {
       protectedItemCount: 0,
     });
 
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     fireEvent.click(screen.getByTestId('transition-btn-archived'));
 
     // Still plan-gated: the exact info toast fires (no silent lifecycle flip).
@@ -187,7 +202,7 @@ describe('ProjectDetail archive plan generation (spec 017 US2/WP-B)', () => {
         "No files are linked to this project's sources — nothing to archive",
     });
 
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     fireEvent.click(screen.getByTestId('transition-btn-archived'));
 
     await waitFor(() => {
@@ -207,7 +222,7 @@ describe('ProjectDetail archive plan generation (spec 017 US2/WP-B)', () => {
       error: { code: 'plan.required', message: 'Plan required' },
     });
 
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     fireEvent.click(screen.getByTestId('transition-btn-prepared'));
 
     await waitFor(() => {
@@ -231,7 +246,7 @@ describe('ProjectDetail archive plan generation (spec 017 US2/WP-B)', () => {
     });
     mockGenerateArchivePlan.mockRejectedValue(new Error('db failure'));
 
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     fireEvent.click(screen.getByTestId('transition-btn-archived'));
 
     await waitFor(() => {

--- a/apps/desktop/src/features/projects/ProjectDetail.lifecycle.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.lifecycle.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock Tauri invoke
@@ -81,6 +82,20 @@ import * as store from './store';
 import { addToast } from '@/shared/toast';
 import type { ProjectDetailDto } from '@/bindings/index';
 
+/** The plan-gated Prepare refusal mounts the source-view generate dialog,
+ *  which reads the settings query. */
+function renderPane() {
+  return render(
+    <QueryClientProvider
+      client={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
+      <ProjectDetailContent projectId="proj-001" />
+    </QueryClientProvider>,
+  );
+}
+
 const mockProject: ProjectDetailDto = {
   id: 'proj-001',
   name: 'NGC 7000',
@@ -110,7 +125,7 @@ describe('ProjectDetail lifecycle transitions (spec 009 US3-3)', () => {
 
   it('renders lifecycle actions for ready state', () => {
     setupStore({ lifecycle: 'ready' });
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     // Per-project actions live in the detail action bar (single source of truth).
     expect(screen.getByTestId('lifecycle-actions')).toBeInTheDocument();
     // Should have a "Prepare" button (ready → prepared)
@@ -128,7 +143,7 @@ describe('ProjectDetail lifecycle transitions (spec 009 US3-3)', () => {
       newState: 'completed',
     });
 
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     fireEvent.click(screen.getByTestId('transition-btn-completed'));
 
     await waitFor(() => {
@@ -150,7 +165,7 @@ describe('ProjectDetail lifecycle transitions (spec 009 US3-3)', () => {
       error: { code: 'plan.required', message: 'Plan required' },
     });
 
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     fireEvent.click(screen.getByTestId('transition-btn-prepared'));
 
     await waitFor(() => {
@@ -172,7 +187,7 @@ describe('ProjectDetail lifecycle transitions (spec 009 US3-3)', () => {
       },
     });
 
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     fireEvent.click(screen.getByTestId('transition-btn-processing'));
 
     await waitFor(() => {
@@ -184,7 +199,7 @@ describe('ProjectDetail lifecycle transitions (spec 009 US3-3)', () => {
 
   it('renders the blocked banner when lifecycle=blocked', () => {
     setupStore({ lifecycle: 'blocked' });
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(screen.getByTestId('blocked-resolve-btn')).toBeInTheDocument();
   });
@@ -198,7 +213,7 @@ describe('ProjectDetail lifecycle transitions (spec 009 US3-3)', () => {
       newState: 'ready',
     });
 
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     fireEvent.click(screen.getByTestId('blocked-resolve-btn'));
 
     await waitFor(() => {
@@ -213,7 +228,7 @@ describe('ProjectDetail lifecycle transitions (spec 009 US3-3)', () => {
 
   it('does not render lifecycle transition buttons when lifecycle=setup_incomplete', () => {
     setupStore({ lifecycle: 'setup_incomplete' });
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     // The action bar still hosts always-present actions (Reveal / Open in tool),
     // but no lifecycle transition buttons exist for setup_incomplete.
     expect(screen.queryByTestId(/^transition-btn-/)).not.toBeInTheDocument();
@@ -226,7 +241,7 @@ describe('ProjectDetail lifecycle transitions (spec 009 US3-3)', () => {
 
   it('renders unarchive actions for archived state', () => {
     setupStore({ lifecycle: 'archived' });
-    render(<ProjectDetailContent projectId="proj-001" />);
+    renderPane();
     expect(screen.getByTestId('transition-btn-ready')).toBeInTheDocument();
     expect(screen.getByTestId('transition-btn-processing')).toBeInTheDocument();
   });

--- a/apps/desktop/src/features/projects/ProjectDetail.prepare-plan.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.prepare-plan.test.tsx
@@ -1,0 +1,172 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * ProjectDetail Prepare-edge plan wiring (astro-plan-krqge).
+ *
+ * `ready → prepared` is plan-gated and the backend refuses it with
+ * `plan.required`. The pane answered with an info toast only — no route to the
+ * source-view generation plan the edge requires — so the project stayed `ready`
+ * with nothing linked. Mirrors the Archive edge: refusal → generate → review.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+    useNavigate: () => vi.fn(),
+    Link: (await import('@/test/router-link-stub')).LinkStub,
+  };
+});
+
+vi.mock('./store', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./store')>();
+  return {
+    ...original,
+    useProjectDetail: vi.fn(),
+    useSessionNames: vi.fn(() => new Map()),
+    callTransitionLifecycle: vi.fn(),
+    callReinferChannels: vi.fn(),
+    callDismissChannelDrift: vi.fn(),
+    useProjectHistory: vi.fn(() => ({
+      data: [],
+      loading: false,
+      error: undefined,
+    })),
+  };
+});
+
+vi.mock('@/shared/toast', () => ({
+  addToast: vi.fn(),
+}));
+
+const { mockGenerateSourceView } = vi.hoisted(() => ({
+  mockGenerateSourceView: vi.fn(),
+}));
+
+vi.mock('./source-views', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./source-views')>();
+  return { ...actual, generateSourceView: mockGenerateSourceView };
+});
+
+vi.mock('@/features/archive/store', () => ({
+  useGenerateArchivePlan: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock('@/features/plans/PlanReviewOverlay', () => ({
+  PlanReviewOverlay: ({
+    planId,
+    open,
+    title,
+  }: {
+    planId: string | null;
+    open: boolean;
+    title: string;
+  }) =>
+    open ? (
+      <div data-testid="plan-review-stub" data-title={title}>
+        {planId}
+      </div>
+    ) : null,
+}));
+
+import { ProjectDetailContent } from './ProjectDetail';
+import * as store from './store';
+import type { ProjectDetailDto } from '@/bindings/index';
+
+const readyProject: ProjectDetailDto = {
+  id: 'proj-001',
+  name: 'JV Archive Prepared',
+  tool: 'PixInsight',
+  lifecycle: 'ready',
+  path: 'projects/JV_Archive_Prepared',
+  notes: null,
+  channelDrift: { hasNewSources: false, suggestedAction: 'dismiss' },
+  sources: [],
+  channels: [],
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-10T00:00:00Z',
+};
+
+function renderPane() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ProjectDetailContent projectId="proj-001" />
+    </QueryClientProvider>,
+  );
+}
+
+function refusePlanRequired() {
+  vi.mocked(store.useProjectDetail).mockReturnValue({
+    data: readyProject,
+    loading: false,
+    error: undefined,
+  });
+  vi.mocked(store.callTransitionLifecycle).mockResolvedValue({
+    status: 'error',
+    contractVersion: '2.0.0',
+    requestId: 'req-1',
+    error: {
+      code: 'plan.required',
+      message:
+        'edge (project, ready -> prepared) requires an approved FilesystemPlan',
+    },
+  });
+}
+
+describe('ProjectDetail Prepare plan gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('offers the source-view generation route when Prepare is refused with plan.required', async () => {
+    refusePlanRequired();
+
+    renderPane();
+    fireEvent.click(screen.getByTestId('transition-btn-prepared'));
+
+    expect(
+      await screen.findByTestId('generate-source-view-dialog'),
+    ).toBeInTheDocument();
+  });
+
+  it('opens the plan review surface with the generated source-view plan id', async () => {
+    refusePlanRequired();
+    mockGenerateSourceView.mockResolvedValue({
+      planId: 'plan-view-prepare',
+      warnings: [],
+      usedCopyFallback: false,
+    });
+
+    renderPane();
+    fireEvent.click(screen.getByTestId('transition-btn-prepared'));
+    fireEvent.click(await screen.findByTestId('generate-source-view-submit'));
+
+    await waitFor(() => {
+      expect(mockGenerateSourceView).toHaveBeenCalledWith({
+        projectId: 'proj-001',
+        copyOptIn: false,
+      });
+    });
+    const review = await screen.findByTestId('plan-review-stub');
+    expect(review).toHaveTextContent('plan-view-prepare');
+    expect(review).toHaveAttribute('data-title', 'Review source view plan');
+  });
+});

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -57,6 +57,7 @@ import { BlockedBanner, deriveBlockedReason } from './BlockedBanner';
 import type { BlockedReason } from './BlockedBanner';
 import { lifecycleFooterActions } from './lifecycle-actions';
 import { PlanReviewOverlay } from '@/features/plans/PlanReviewOverlay';
+import { GenerateSourceViewDialog } from './GenerateSourceViewDialog';
 // spec 011: tool launch CTA
 import {
   toolIdFromProjectTool,
@@ -100,14 +101,18 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
     lifecycle,
     channelWorking,
     transitionWorking,
-    archiveReviewPlanId,
-    setArchiveReviewPlanId,
+    reviewPlanId,
+    setReviewPlanId,
+    reviewPlanKind,
     archiveEmptyReason,
     setArchiveEmptyReason,
+    prepareGenerateOpen,
+    setPrepareGenerateOpen,
     handleReinfer,
     handleDismissDrift,
     handleTransition,
-    handleArchivePlanApplied,
+    handlePrepareViewPlanCreated,
+    handleReviewPlanApplied,
     handleResolveBlocked,
     handleReveal,
   } = useProjectDetailActions(projectId, project);
@@ -447,21 +452,37 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
         <EditProjectPane project={project} onClose={() => setEditOpen(false)} />
       </Modal>
 
-      {/* ── Archive plan review overlay (spec 017 US2/WP-B) ──────────────────
-          Opens automatically when the plan-gated Archive transition refuses
-          with plan.required; shares the same review → approve → apply kit as
-          the cleanup flow. */}
+      {/* ── Source-view generation dialog for the plan-gated Prepare edge ────
+          Opens when ready → prepared refuses with plan.required; the created
+          plan goes to the same review overlay the Archive edge uses. */}
+      {prepareGenerateOpen && (
+        <GenerateSourceViewDialog
+          projectId={projectId}
+          open
+          onClose={() => setPrepareGenerateOpen(false)}
+          onPlanCreated={handlePrepareViewPlanCreated}
+        />
+      )}
+
+      {/* ── Plan review overlay (spec 017 US2/WP-B) ──────────────────────────
+          Opens automatically when a plan-gated transition refuses with
+          plan.required and its generator produces a plan; shares the same
+          review → approve → apply kit as the cleanup flow. */}
       <PlanReviewOverlay
-        planId={archiveReviewPlanId}
-        open={archiveReviewPlanId !== null}
+        planId={reviewPlanId}
+        open={reviewPlanId !== null}
         onClose={() => {
-          setArchiveReviewPlanId(null);
+          setReviewPlanId(null);
           setArchiveEmptyReason(null);
         }}
-        title={m.archive_generate_review_title()}
+        title={
+          reviewPlanKind === 'archive'
+            ? m.archive_generate_review_title()
+            : m.projects_source_views_review_title()
+        }
         emptyReason={archiveEmptyReason}
-        onApplied={handleArchivePlanApplied}
-        onRetryCreated={setArchiveReviewPlanId}
+        onApplied={handleReviewPlanApplied}
+        onRetryCreated={setReviewPlanId}
       />
     </DetailPanel>
   );

--- a/apps/desktop/src/features/projects/SourceViewsSection.plan-review.test.tsx
+++ b/apps/desktop/src/features/projects/SourceViewsSection.plan-review.test.tsx
@@ -1,0 +1,159 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * SourceViewsSection plan-review routing (astro-plan-krqge).
+ *
+ * `sourceview.generate` only persists a `prepared_view_generation` plan — the
+ * links are materialised when that plan is approved and applied. The section
+ * was mounted without the optional `onPlanCreated` callback, so every created
+ * plan was orphaned: no review surface, no links, and an archive plan with
+ * zero items forever after.
+ *
+ * Asserts the user-visible outcome: generating (or regenerating) opens the
+ * shared plan review surface carrying the created plan id.
+ */
+
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockList, mockGenerate, mockRegenerate } = vi.hoisted(() => ({
+  mockList: vi.fn(),
+  mockGenerate: vi.fn(),
+  mockRegenerate: vi.fn(),
+}));
+
+vi.mock('./source-views', async () => {
+  const actual =
+    await vi.importActual<typeof import('./source-views')>('./source-views');
+  return {
+    ...actual,
+    listPreparedViews: mockList,
+    generateSourceView: mockGenerate,
+    regeneratePreparedView: mockRegenerate,
+  };
+});
+
+vi.mock('./ViewAuditHistory', () => ({
+  ViewAuditHistory: () => null,
+}));
+
+vi.mock('@/shared/toast', () => ({
+  addToast: vi.fn(),
+}));
+
+vi.mock('@/features/plans/PlanReviewOverlay', () => ({
+  PlanReviewOverlay: ({
+    planId,
+    open,
+  }: {
+    planId: string | null;
+    open: boolean;
+  }) => (open ? <div data-testid="plan-review-stub">{planId}</div> : null),
+}));
+
+import { SourceViewsSection } from './SourceViewsSection';
+import type { PreparedViewSummary } from './source-views';
+
+function renderSection() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <SourceViewsSection projectId="proj-1" />
+    </QueryClientProvider>,
+  );
+}
+
+const removedView: PreparedViewSummary = {
+  id: 'view-removed',
+  projectId: 'proj-1',
+  kind: 'symlink',
+  state: 'removed',
+  createdAt: '2026-01-01T00:00:00Z',
+  itemCount: 1,
+  items: [
+    {
+      id: 'item-1',
+      inventoryItemId: 'inv-1',
+      viewRelativePath: '/dest/light.fits',
+      materialization: 'symlink',
+      lastObservedState: 'missing',
+    },
+  ],
+};
+
+describe('SourceViewsSection plan review routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens the plan review surface with the generated plan id', async () => {
+    mockList.mockResolvedValue({ views: [] });
+    mockGenerate.mockResolvedValue({
+      planId: 'plan-view-1',
+      warnings: [],
+      usedCopyFallback: false,
+    });
+
+    renderSection();
+
+    fireEvent.click(await screen.findByTestId('generate-source-view-btn'));
+    fireEvent.click(await screen.findByTestId('generate-source-view-submit'));
+
+    await waitFor(() => {
+      expect(mockGenerate).toHaveBeenCalledWith({
+        projectId: 'proj-1',
+        copyOptIn: false,
+      });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('plan-review-stub')).toHaveTextContent(
+        'plan-view-1',
+      );
+    });
+  });
+
+  it('opens the plan review surface with the regeneration plan id', async () => {
+    mockList.mockResolvedValue({ views: [removedView] });
+    mockRegenerate.mockResolvedValue({
+      planId: 'plan-regen-1',
+      unresolvedItemCount: 0,
+    });
+
+    renderSection();
+
+    fireEvent.click(await screen.findByTestId('regenerate-view-view-removed'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('plan-review-stub')).toHaveTextContent(
+        'plan-regen-1',
+      );
+    });
+  });
+
+  it('keeps the review surface closed when generation fails', async () => {
+    mockList.mockResolvedValue({ views: [] });
+    mockGenerate.mockRejectedValue(new Error('no_selection'));
+
+    renderSection();
+
+    fireEvent.click(await screen.findByTestId('generate-source-view-btn'));
+    fireEvent.click(await screen.findByTestId('generate-source-view-submit'));
+
+    const dialog = await screen.findByTestId('generate-source-view-dialog');
+    await waitFor(() => {
+      expect(within(dialog).getByText(/no_selection/)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('plan-review-stub')).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/features/projects/SourceViewsSection.tsx
+++ b/apps/desktop/src/features/projects/SourceViewsSection.tsx
@@ -43,14 +43,13 @@ import type {
 } from './source-views';
 import { errMessage } from '@/lib/errors';
 import { GenerateSourceViewDialog } from './GenerateSourceViewDialog';
+import { PlanReviewOverlay } from '@/features/plans/PlanReviewOverlay';
 import { ViewAuditHistory } from './ViewAuditHistory';
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
 export interface SourceViewsSectionProps {
   projectId: string;
-  /** Called with planId after a plan is created so the parent can navigate. */
-  onPlanCreated?: (planId: string) => void;
   /** Whether the collapsible section starts open. Default true. */
   defaultOpen?: boolean;
 }
@@ -59,7 +58,6 @@ export interface SourceViewsSectionProps {
 
 export function SourceViewsSection({
   projectId,
-  onPlanCreated,
   defaultOpen = true,
 }: SourceViewsSectionProps) {
   const [views, setViews] = useState<PreparedViewSummary[]>([]);
@@ -70,13 +68,11 @@ export function SourceViewsSection({
   const [verifyResults, setVerifyResults] = useState<
     Record<string, SourceViewVerifyResponse>
   >({});
-
-  function handleGenerated(planId: string) {
-    onPlanCreated?.(planId);
-    // Refresh the list so a newly-applied view (once the caller approves +
-    // applies the plan) will show up on next load; nothing to reload yet
-    // since the plan hasn't been applied.
-  }
+  // Every action here produces a plan that only takes effect once it is
+  // reviewed, approved and applied; without this overlay the plan is created
+  // and then orphaned, so no links are ever materialised.
+  const [reviewPlanId, setReviewPlanId] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
   const generateButton = (
     <Btn
@@ -111,7 +107,7 @@ export function SourceViewsSection({
     return () => {
       cancelled = true;
     };
-  }, [projectId]);
+  }, [projectId, reloadKey]);
 
   // ── Handlers ────────────────────────────────────────────────────────────────
 
@@ -125,10 +121,10 @@ export function SourceViewsSection({
         message: m.projects_source_views_removal_toast(),
         action: {
           label: m.projects_source_views_view_plan_btn(),
-          onClick: () => onPlanCreated?.(planId),
+          onClick: () => setReviewPlanId(planId),
         },
       });
-      onPlanCreated?.(planId);
+      setReviewPlanId(planId);
     } catch (err: unknown) {
       addToast({
         variant: 'warn',
@@ -157,10 +153,10 @@ export function SourceViewsSection({
         message: m.projects_source_views_regen_toast({ warning }),
         action: {
           label: m.projects_source_views_view_plan_btn(),
-          onClick: () => onPlanCreated?.(planId),
+          onClick: () => setReviewPlanId(planId),
         },
       });
-      onPlanCreated?.(planId);
+      setReviewPlanId(planId);
     } catch (err: unknown) {
       addToast({
         variant: 'warn',
@@ -197,7 +193,20 @@ export function SourceViewsSection({
       projectId={projectId}
       open={generateOpen}
       onClose={() => setGenerateOpen(false)}
-      onPlanCreated={handleGenerated}
+      onPlanCreated={setReviewPlanId}
+    />
+  );
+
+  // Mounted only while a plan is under review — the overlay reads a query
+  // client at render time even when closed.
+  const overlay = reviewPlanId !== null && (
+    <PlanReviewOverlay
+      planId={reviewPlanId}
+      open={reviewPlanId !== null}
+      onClose={() => setReviewPlanId(null)}
+      title={m.projects_source_views_review_title()}
+      onApplied={() => setReloadKey((key) => key + 1)}
+      onRetryCreated={setReviewPlanId}
     />
   );
 
@@ -210,6 +219,7 @@ export function SourceViewsSection({
       >
         <p className="pv-text-sm pv-text-muted">{m.common_loading()}</p>
         {dialog}
+        {overlay}
       </Section>
     );
   }
@@ -225,6 +235,7 @@ export function SourceViewsSection({
           {m.projects_source_views_load_error({ error })}
         </Banner>
         {dialog}
+        {overlay}
       </Section>
     );
   }
@@ -240,6 +251,7 @@ export function SourceViewsSection({
           {m.projects_source_views_empty()}
         </p>
         {dialog}
+        {overlay}
       </Section>
     );
   }
@@ -251,6 +263,7 @@ export function SourceViewsSection({
       right={generateButton}
     >
       {dialog}
+      {overlay}
       <ul className="pv-source-views__list">
         {views.map((view) => (
           <li
@@ -372,7 +385,7 @@ export function SourceViewsSection({
 
               {/* T019: audit-history surface — this view's removal/regeneration
                   plans, reusing the shared plan review overlay for full detail. */}
-              <ViewAuditHistory viewId={view.id} onViewPlan={onPlanCreated} />
+              <ViewAuditHistory viewId={view.id} onViewPlan={setReviewPlanId} />
             </div>
 
             <div className="pv-source-views__actions">

--- a/apps/desktop/src/features/projects/useProjectDetailActions.ts
+++ b/apps/desktop/src/features/projects/useProjectDetailActions.ts
@@ -41,9 +41,16 @@ export function useProjectDetailActions(
   // transition is plan-gated; this is the UI entry point that actually
   // creates the reviewable plan the toast below points the user to.
   const generateArchivePlan = useGenerateArchivePlan();
-  const [archiveReviewPlanId, setArchiveReviewPlanId] = useState<string | null>(
-    null,
-  );
+  const [reviewPlanId, setReviewPlanId] = useState<string | null>(null);
+  // Which generator produced `reviewPlanId` — the shared overlay is titled per
+  // flow, and only the archive generator reports an `emptyReason`.
+  const [reviewPlanKind, setReviewPlanKind] = useState<
+    'archive' | 'source_view'
+  >('archive');
+  // ready → prepared is plan-gated on a source-view generation plan, and
+  // generating one needs the user's copy opt-in, so the refusal opens the
+  // existing generate dialog rather than generating unattended.
+  const [prepareGenerateOpen, setPrepareGenerateOpen] = useState(false);
   // #603: diagnostic sentence for a 0-item archive plan, surfaced by
   // `archive.plan.generate` alongside the plan id — the review overlay has
   // no other way to explain WHY a plan came back empty.
@@ -127,6 +134,8 @@ export function useProjectDetailActions(
         });
         if (nextState === 'archived') {
           void handleGenerateArchivePlan();
+        } else if (nextState === 'prepared') {
+          setPrepareGenerateOpen(true);
         }
       } else if (resp.status === 'error') {
         addToast({
@@ -160,7 +169,8 @@ export function useProjectDetailActions(
         variant: 'info',
       });
       setArchiveEmptyReason(res.emptyReason ?? null);
-      setArchiveReviewPlanId(res.planId);
+      setReviewPlanKind('archive');
+      setReviewPlanId(res.planId);
     } catch {
       addToast({
         message: m.archive_generate_failed(),
@@ -169,10 +179,22 @@ export function useProjectDetailActions(
     }
   };
 
-  /** After the archive plan applies, the project's lifecycle flips server-side
+  /**
+   * Route a source-view generation plan into the shared review overlay — the
+   * plan-gated `ready → prepared` edge is closed by applying that plan, the
+   * same way applying an origin=archive plan is the only path to `archived`.
+   */
+  const handlePrepareViewPlanCreated = (planId: string) => {
+    setPrepareGenerateOpen(false);
+    setArchiveEmptyReason(null);
+    setReviewPlanKind('source_view');
+    setReviewPlanId(planId);
+  };
+
+  /** After a review plan applies, the project's lifecycle flips server-side
    * (C5 — applying an origin=archive plan is the one legitimate path to
    * `archived`); refresh the detail query so the UI reflects it. */
-  const handleArchivePlanApplied = () => {
+  const handleReviewPlanApplied = () => {
     void sharedQueryClient.invalidateQueries({
       queryKey: queryKeys.projects.detail(projectId),
     });
@@ -201,14 +223,18 @@ export function useProjectDetailActions(
     lifecycle,
     channelWorking,
     transitionWorking,
-    archiveReviewPlanId,
-    setArchiveReviewPlanId,
+    reviewPlanId,
+    setReviewPlanId,
+    reviewPlanKind,
     archiveEmptyReason,
     setArchiveEmptyReason,
+    prepareGenerateOpen,
+    setPrepareGenerateOpen,
     handleReinfer,
     handleDismissDrift,
     handleTransition,
-    handleArchivePlanApplied,
+    handlePrepareViewPlanCreated,
+    handleReviewPlanApplied,
     handleResolveBlocked,
     handleReveal,
   };

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -215,9 +215,9 @@ use apply::{spawn_executor_run, SpawnExecutorParams};
 use callbacks::{audit_item_cancelled, PlanApplyCallbacks};
 use finalizers::{
     finalize_archive_lifecycle, finalize_calibration_master_archive,
-    finalize_calibration_master_restore, finalize_project_create_manifest,
-    finalize_restore_lifecycle, finalize_view_generation, finalize_view_regeneration,
-    finalize_view_removal,
+    finalize_calibration_master_restore, finalize_prepared_lifecycle,
+    finalize_project_create_manifest, finalize_restore_lifecycle, finalize_view_generation,
+    finalize_view_regeneration, finalize_view_removal,
 };
 use paths::{
     check_overlap_and_register, compute_plan_path_set, item_row_to_executor_item,

--- a/crates/app/core/src/plan_apply/finalizers.rs
+++ b/crates/app/core/src/plan_apply/finalizers.rs
@@ -395,6 +395,79 @@ pub(super) async fn finalize_restore_lifecycle(
     }
 }
 
+/// Terminal step of a clean `origin = prepared_view_generation` apply: drive the
+/// owning project `ready → prepared`. This is the closure of the requires-plan
+/// gate on that edge (spec 009 research §Which edges trigger filesystem work:
+/// side effect "PreparedSource artifact creation", gating "approved plan
+/// required") — the artifact the edge requires has just been materialised, and
+/// `apply_transition` refuses the edge unconditionally, so without this closure
+/// no project can ever reach `prepared`.
+///
+/// Only `ready → prepared` is legal into `prepared` for a project
+/// (`domain_core::lifecycle::project::is_allowed`); an already-`prepared`
+/// project is a no-op, so re-applying a second generation plan is harmless.
+///
+/// Best-effort: the links already exist on disk, so a failure here must NOT
+/// fail the apply. Every failure is logged for an external watchdog (§II).
+#[expect(
+    clippy::cognitive_complexity,
+    reason = "prepared finalize: lifecycle transition per project entity with per-step logging"
+)]
+pub(super) async fn finalize_prepared_lifecycle(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    project_id: &str,
+) {
+    use crate::lifecycle::lifecycle_use_case::{transition_lifecycle, TransitionCommand};
+    use domain_core::ids::EntityId;
+    use domain_core::lifecycle::data_asset::EntityType;
+    use persistence_lifecycle::repositories::lifecycle::SqliteLifecycleRepository;
+    use persistence_plans::repositories::projects as projects_repo;
+
+    let uuid = match uuid::Uuid::parse_str(project_id) {
+        Ok(u) => u,
+        Err(e) => {
+            tracing::error!(%project_id, error=%e, "prepared lifecycle closure: project id is not a uuid");
+            return;
+        }
+    };
+
+    let current = match projects_repo::get_project(pool, project_id).await {
+        Ok(p) => p.lifecycle,
+        Err(e) => {
+            tracing::error!(%project_id, error=%e, "prepared lifecycle closure: project not found");
+            return;
+        }
+    };
+
+    if current == "prepared" {
+        return;
+    }
+
+    if current != "ready" {
+        tracing::warn!(
+            %project_id, from_state = %current,
+            "prepared lifecycle closure: source view applied outside 'ready'; leaving lifecycle unchanged"
+        );
+        return;
+    }
+
+    let repo = SqliteLifecycleRepository::new(pool.clone(), bus.clone());
+    let cmd = TransitionCommand {
+        entity_id: EntityId::from_uuid(uuid),
+        entity_type: EntityType::Project,
+        from_state: current,
+        to_state: "prepared".to_owned(),
+        trigger: "sourceview.plan.applied".to_owned(),
+        actor: "user".to_owned(),
+        request_id: EntityId::new(),
+    };
+
+    if let Err(e) = transition_lifecycle(&repo, bus, cmd).await {
+        tracing::error!(%project_id, error=%e, "prepared lifecycle closure: transition to prepared failed");
+    }
+}
+
 // ── Calibration master archive lifecycle closure (#886) ──────────────────────
 
 /// Terminal step of a successful `origin = calibration_master_archive` plan

--- a/crates/app/core/src/plan_apply/terminal.rs
+++ b/crates/app/core/src/plan_apply/terminal.rs
@@ -9,11 +9,11 @@
 use super::{
     apply_repo, audit_item_cancelled, deterministic_entity_id, finalize_archive_lifecycle,
     finalize_calibration_master_archive, finalize_calibration_master_restore,
-    finalize_project_create_manifest, finalize_restore_lifecycle, finalize_view_generation,
-    finalize_view_regeneration, finalize_view_removal, json, new_id, AuditLogEntry, EntityType,
-    EventBus, OpEventEmitter, OperationEventType, OperationStatus, Outcome, PlanApplyingCompleted,
-    PlanApplyingPaused, Severity, Source, SqlitePool, TerminalCounts, Timestamp,
-    TOPIC_PLAN_APPLYING_COMPLETED, TOPIC_PLAN_APPLYING_PAUSED,
+    finalize_prepared_lifecycle, finalize_project_create_manifest, finalize_restore_lifecycle,
+    finalize_view_generation, finalize_view_regeneration, finalize_view_removal, json, new_id,
+    AuditLogEntry, EntityType, EventBus, OpEventEmitter, OperationEventType, OperationStatus,
+    Outcome, PlanApplyingCompleted, PlanApplyingPaused, Severity, Source, SqlitePool,
+    TerminalCounts, Timestamp, TOPIC_PLAN_APPLYING_COMPLETED, TOPIC_PLAN_APPLYING_PAUSED,
 };
 
 use super::apply::cumulative_counts;
@@ -131,6 +131,9 @@ pub(super) async fn handle_completed(
             "prepared_view_generation" => {
                 if let Some(project_id) = plan_project_id {
                     finalize_view_generation(pool, plan_id, project_id).await;
+                    if terminal == "applied" {
+                        finalize_prepared_lifecycle(pool, bus, project_id).await;
+                    }
                 }
             }
             "prepared_view_removal" => {

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -2999,3 +2999,135 @@ async fn a_pause_after_a_skip_counts_the_rows_not_the_lagging_plan_counter() {
 
     active_runs().remove("p-pause-skip");
 }
+
+// ── astro-plan-krqge: prepared lifecycle closure ─────────────────────────────
+
+async fn insert_ready_project(db: &Database, project_id: &str) {
+    use persistence_plans::repositories::projects as projects_repo;
+
+    projects_repo::insert_project(
+        db.pool(),
+        &projects_repo::InsertProject {
+            id: project_id,
+            name: "JV Archive Prepared",
+            tool: "PixInsight",
+            lifecycle: "ready",
+            path: "projects/JV_Archive_Prepared",
+            notes: None,
+            canonical_target_id: None,
+            is_mosaic: false,
+        },
+    )
+    .await
+    .unwrap();
+}
+
+/// A clean `prepared_view_generation` apply closes the requires-plan gate on
+/// `ready → prepared`: `apply_transition` refuses that edge unconditionally, so
+/// without this closure the project can never leave `ready` and stays unlinked.
+#[tokio::test]
+async fn completed_view_generation_apply_prepares_the_project() {
+    use persistence_plans::repositories::projects as projects_repo;
+
+    let (db, bus) = setup().await;
+    let plan_id = "p-krqge-prepared";
+    let run_id = "run-krqge-prepared";
+    let project_id = Uuid::new_v4().to_string();
+    insert_ready_project(&db, &project_id).await;
+    insert_approved_plan_with_items(&db, plan_id, 1).await;
+    apply_repo::cas_approved_to_applying(db.pool(), plan_id, run_id, "test-token", 1, 1)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE plan_items SET item_state = 'succeeded' WHERE plan_id = ?")
+        .bind(plan_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+    // The terminal state is derived from the plan row's cumulative counters
+    // (`cumulative_counts`), not from item states.
+    sqlx::query("UPDATE plans SET items_applied = 1, items_failed = 0 WHERE id = ?")
+        .bind(plan_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    terminal::handle_completed(
+        db.pool(),
+        &bus,
+        plan_id,
+        run_id,
+        "prepared_view_generation",
+        Some(&project_id),
+        None,
+        TerminalCounts { succeeded: 1, failed: 0, skipped: 0, cancelled: 0 },
+    )
+    .await;
+
+    let project = projects_repo::get_project(db.pool(), &project_id).await.unwrap();
+    assert_eq!(
+        project.lifecycle, "prepared",
+        "applying the source-view plan must drive the project to prepared"
+    );
+
+    let entries = list_audit_entries(
+        db.pool(),
+        &AuditLogFilter { entity_id: Some(project_id.clone()), ..AuditLogFilter::default() },
+    )
+    .await
+    .unwrap();
+    assert!(
+        entries.iter().any(|e| e.trigger == "sourceview.plan.applied"),
+        "the lifecycle closure must leave a durable audit record: {entries:?}"
+    );
+}
+
+/// A `partially_applied` terminal leaves the lifecycle alone — only a clean
+/// apply materialises every planned link (mirrors the archive closure, which
+/// runs on `applied` only).
+#[tokio::test]
+async fn partially_applied_view_generation_leaves_lifecycle_ready() {
+    use persistence_plans::repositories::projects as projects_repo;
+
+    let (db, bus) = setup().await;
+    let plan_id = "p-krqge-partial";
+    let run_id = "run-krqge-partial";
+    let project_id = Uuid::new_v4().to_string();
+    insert_ready_project(&db, &project_id).await;
+    insert_approved_plan_with_items(&db, plan_id, 2).await;
+    apply_repo::cas_approved_to_applying(db.pool(), plan_id, run_id, "test-token", 2, 2)
+        .await
+        .unwrap();
+    sqlx::query("UPDATE plan_items SET item_state = 'succeeded' WHERE id = ?")
+        .bind(format!("{plan_id}-item-0"))
+        .execute(db.pool())
+        .await
+        .unwrap();
+    sqlx::query("UPDATE plan_items SET item_state = 'failed' WHERE id = ?")
+        .bind(format!("{plan_id}-item-1"))
+        .execute(db.pool())
+        .await
+        .unwrap();
+    sqlx::query("UPDATE plans SET items_applied = 1, items_failed = 1 WHERE id = ?")
+        .bind(plan_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    terminal::handle_completed(
+        db.pool(),
+        &bus,
+        plan_id,
+        run_id,
+        "prepared_view_generation",
+        Some(&project_id),
+        None,
+        TerminalCounts { succeeded: 1, failed: 1, skipped: 0, cancelled: 0 },
+    )
+    .await;
+
+    let project = projects_repo::get_project(db.pool(), &project_id).await.unwrap();
+    assert_eq!(
+        project.lifecycle, "ready",
+        "a partial apply must not claim the project is prepared"
+    );
+}

--- a/scripts/eslint-alm-baseline.txt
+++ b/scripts/eslint-alm-baseline.txt
@@ -41,12 +41,12 @@ src/features/projects/CalibrationMatchPanel.tsx	127	alm/require-root-testid
 src/features/projects/ManifestsAccordion.tsx	125	alm/require-root-testid
 src/features/projects/ProjectBottomDetail.tsx	53	alm/require-root-testid
 src/features/projects/ProjectChannelsSection.tsx	36	alm/require-root-testid
-src/features/projects/ProjectDetail.tsx	138	alm/require-root-testid
+src/features/projects/ProjectDetail.tsx	143	alm/require-root-testid
 src/features/projects/ProjectSourcesSection.tsx	96	alm/require-root-testid
 src/features/projects/ProjectsPage.tsx	224	alm/require-root-testid
 src/features/projects/ProjectsTable.tsx	281	alm/require-root-testid
 src/features/projects/SessionSourcePicker.tsx	117	alm/require-root-testid
-src/features/projects/SourceViewsSection.tsx	206	alm/require-root-testid
+src/features/projects/SourceViewsSection.tsx	215	alm/require-root-testid
 src/features/projects/ToolLaunchesAccordion.tsx	209	alm/require-root-testid
 src/features/projects/edit/ChannelDriftBanner.tsx	31	alm/require-root-testid
 src/features/projects/edit/EditProjectPane.tsx	156	alm/require-root-testid


### PR DESCRIPTION
## What

`ready → prepared` ("Prepare") is refused server-side with `plan.required` on
every attempt, and the pane answered with a dead-end info toast — no generator,
no review surface, no route for the user to satisfy the gate. Separately,
`SourceViewsSection` was mounted without its `onPlanCreated` callback, so the
`prepared_view_generation` plan that `sourceview.generate` creates was orphaned:
never reviewed, never applied, no links materialised, and therefore every
archive plan empty ("No files are linked to this project's sources"). Journey
J07 could not get past step 1.

## Changes

- Prepare's `plan.required` refusal now opens the existing source-view generate
  dialog and routes the created plan into the shared `PlanReviewOverlay` — the
  same refusal → generate → review shape the Archive edge already had. The copy
  opt-in stays a user choice, so the dialog is used rather than an unattended
  generate call.
- `SourceViewsSection` owns a review overlay, so generate / remove / regenerate
  all reach approve + apply instead of creating a plan and dropping it. The dead
  optional `onPlanCreated` prop is gone (it had no producer).
- Applying a clean `prepared_view_generation` plan drives the owning project
  `ready → prepared` (`finalize_prepared_lifecycle`), mirroring
  `finalize_archive_lifecycle`. The plan gate in `apply_transition` is
  unconditional, so plan apply is the only path across the edge — exactly as it
  is the only path to `archived`. A `partially_applied` terminal leaves the
  lifecycle unchanged.

## Tests

All confirmed failing with the fix reverted, per test:

| Test | Revert result |
| --- | --- |
| `ProjectDetail.prepare-plan.test.tsx` — Prepare refusal offers the generation route | fails (dialog absent) |
| `ProjectDetail.prepare-plan.test.tsx` — review overlay opens with the plan id and source-view title | fails (no overlay) |
| `SourceViewsSection.plan-review.test.tsx` — generate opens the review surface | fails (no overlay) |
| `SourceViewsSection.plan-review.test.tsx` — regenerate opens the review surface | fails (no overlay) |
| `completed_view_generation_apply_prepares_the_project` | fails (`lifecycle` stays `ready`) |
| `partially_applied_view_generation_leaves_lifecycle_ready` | passes pre-fix (disclosed guard); fails when the `applied` gate is removed |
| `SourceViewsSection.plan-review.test.tsx` — failed generation keeps the surface closed | passes pre-fix (disclosed boundary case) |

Gates run: `vitest run` (273 files / 2423 tests, exit 0), `tsc --noEmit` and
`tsc -p tsconfig.e2e.json --noEmit`, `pnpm lint` (biome + eslint baseline + i18n
catalog + locale drift + mock baseline, exit 0), `cargo test -p app_core` (578
tests), `cargo clippy -p app_core --all-targets`, `cargo fmt --check`.

## Notes

- Two existing `ProjectDetail` test files gained a `QueryClientProvider`: the
  refusal now mounts a dialog that reads the settings query.
- `scripts/eslint-alm-baseline.txt` records root-testid violations by line
  number; both shifted.
- `sourceview.generate` writes no audit row, and neither does any other plan
  generator in this repo (`archive_generator`, `cleanup_generator`) — plan
  generation is not an audited action; the `plan` row is the durable record and
  the audit trail starts at plan apply.
- Sibling plan-gated edges that still dead-end are filed separately, not fixed
  here: `prepared → ready` (no generator exists anywhere) and
  `archived → ready` / `archived → processing` (the restore generator needs
  `archivedViaPlanId` and is reachable only from the Archive page).

Tracks-Bead: astro-plan-krqge
Merge-Bead: astro-plan-4loso
Closes-Bead: astro-plan-krqge
