### PR TITLE
fix: warn before starting a second processing-tool run on Windows and macOS

### DIFF
--- a/.claude/rules/21-astro-monorepo.md
+++ b/.claude/rules/21-astro-monorepo.md
@@ -86,9 +86,15 @@ in `crates/app/core/src/tool_launch.rs` record `pid`, `launched_at`,
 `project_id`, and `tool_id`; `pid` is nullable because macOS `open -a` does not
 return one. `completed_at` is written by artifact observation
 (`crates/app/lifecycle/src/artifact/launches.rs`), not by the launch path. A
-prior `spawned` launch with a null `completed_at` and a live PID triggers the
-re-launch warning. Tests inject
-`workflow_profiles::launch::FakeSpawner` instead of spawning binaries. See
+prior `spawned` launch with a null `completed_at` triggers the re-launch warning
+when `workflow_profiles::launch::prior_launch_is_alive` confirms the tool is
+still running: by PID when one was recorded, otherwise by asking macOS Launch
+Services whether an application with the profile's `bundle_id` is running. Both
+are point-in-time queries made only when the user attempts a re-launch; nothing
+is polled or awaited. Tests inject
+`workflow_profiles::launch::FakeSpawner` instead of spawning binaries; liveness
+itself is covered against real processes in
+`crates/workflow/profiles/tests/liveness.rs`. See
 [`specs/011-processing-tool-launch/research.md`](../../specs/011-processing-tool-launch/research.md).
 
 The workspace Cargo manifest defines a `dev-tools` feature (default off) that

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,6 +3665,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4040,6 +4049,16 @@ dependencies = [
  "block2 0.6.2",
  "libc",
  "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
  "objc2-core-foundation",
 ]
 
@@ -6363,6 +6382,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8129,11 +8162,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -8143,6 +8188,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8191,7 +8245,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -8258,6 +8323,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8405,6 +8480,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -8620,6 +8704,7 @@ dependencies = [
  "fs_pathsafe",
  "itertools",
  "project_structure",
+ "sysinfo",
  "tempfile",
  "winreg 0.56.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,6 +135,11 @@ percent-encoding = "2"
 semver = "1"
 strum = { version = "0.27", features = ["derive"] }
 strum_macros = "0.27"
+# Process liveness for the re-launch guard. Only the `system` feature is enabled:
+# the disk/network/component collectors are unused and pull extra platform code.
+# A safe cross-platform API is a hard requirement here — the workspace forbids
+# `unsafe_code`, so `kill(pid, 0)` and `OpenProcess` are not reachable directly.
+sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # dev-dependencies (referenced via [dev-dependencies] in consuming crates):
 proptest = "1"

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -51,7 +51,9 @@ use sqlx::SqlitePool;
 use workflow_profiles::{
     args::{render, RenderContext},
     discover::discover_all,
-    launch::{pid_is_alive, verify_cwd_containment, LaunchError, ProcessSpawner, SpawnRequest},
+    launch::{
+        prior_launch_is_alive, verify_cwd_containment, LaunchError, ProcessSpawner, SpawnRequest,
+    },
     seed,
 };
 
@@ -457,13 +459,22 @@ pub async fn launch(
             Err(resp) => return Ok(resp),
         };
 
+    // bundle_id from Settings (override) or seeded default
+    let bundle_id_key = format!("tools.{}.bundle_id", req.tool_id);
+    let bundle_id = read_string_setting(pool, &bundle_id_key)
+        .await
+        .or_else(|| config.profile.bundle_id.map(ToOwned::to_owned));
+
     // ── Step 5: re-launch guard ───────────────────────────────────────────────
     if !req.force {
         if let Ok(Some(prior)) =
             tl_repo::get_latest_launch(pool, &req.project_id, &req.tool_id).await
         {
             if prior.outcome == "spawned" && prior.completed_at.is_none() {
-                let alive = prior.pid.and_then(|p| u32::try_from(p).ok()).is_some_and(pid_is_alive);
+                let alive = prior_launch_is_alive(
+                    prior.pid.and_then(|p| u32::try_from(p).ok()),
+                    bundle_id.as_deref(),
+                );
                 if alive {
                     return Ok(ToolLaunchResponse {
                         status: ToolLaunchStatus::PriorInstanceAlive,
@@ -494,12 +505,6 @@ pub async fn launch(
         Err(e) => return Ok(error_response("args.operand_not_absolute", e)),
     };
     let args_hash = compute_args_hash(&config.executable_path, &argv);
-
-    // bundle_id from Settings (override) or seeded default
-    let bundle_id_key = format!("tools.{}.bundle_id", req.tool_id);
-    let bundle_id = read_string_setting(pool, &bundle_id_key)
-        .await
-        .or_else(|| config.profile.bundle_id.map(ToOwned::to_owned));
 
     // ── Steps 7-9: spawn, persist, emit audit ────────────────────────────────
     spawn_and_record(
@@ -961,19 +966,15 @@ mod tests {
         assert_eq!(row.outcome, "spawned");
     }
 
-    #[tokio::test]
-    async fn launch_prior_instance_alive_without_force() {
+    /// Seed an unfinished prior launch for `pixinsight` and return the response
+    /// to a second, unforced launch of the same tool.
+    async fn relaunch_over_prior(pid: Option<u32>, force: bool) -> ToolLaunchResponse {
         let db = setup_db().await;
         let project_id = make_project(&db).await;
         let bus = make_bus(db.pool().clone());
         insert_root(&db, &abs("/mnt/library")).await;
         set_tool_path(&db, "pixinsight", "/usr/bin/pixinsight").await;
 
-        // Insert a "spawned" row with a pid that the test process can never have as its own child.
-        // pid_is_alive uses kill(pid, 0); on Linux PID 1 is always alive (init/systemd).
-        // However we can't reliably test "alive" in unit tests without spawning. Instead, we
-        // test the guard by inserting a completed row (completed_at non-null) which should NOT
-        // trigger the guard.
         let launch_id = new_id();
         let audit_id = new_id();
         tl_repo::insert_tool_launch(
@@ -982,7 +983,7 @@ mod tests {
                 id: &launch_id,
                 project_id: &project_id,
                 tool_id: "pixinsight",
-                pid: None, // No PID → pid_is_alive returns false
+                pid,
                 working_dir: Some("/mnt/library/test_project"),
                 args_hash: Some("abc"),
                 outcome: "spawned",
@@ -992,15 +993,41 @@ mod tests {
         .await
         .unwrap();
 
-        // Without a real alive PID, guard should NOT trigger; second launch should succeed.
-        let spawner2 = FakeSpawner::ok();
-        let req2 = ToolLaunchRequest {
+        let spawner = FakeSpawner::ok();
+        let req = ToolLaunchRequest {
             project_id: project_id.clone(),
             tool_id: "pixinsight".to_owned(),
-            force: false,
+            force,
         };
-        let resp2 = launch(db.pool(), &bus, &spawner2, req2).await.unwrap();
-        assert_eq!(resp2.status, ToolLaunchStatus::Success);
+        launch(db.pool(), &bus, &spawner, req).await.unwrap()
+    }
+
+    /// astro-plan-7wu52: the guard must fire on every platform, not only Linux.
+    /// The recorded pid is this test process, so the prior instance really is
+    /// alive wherever the test runs.
+    #[tokio::test]
+    async fn launch_is_refused_while_the_prior_instance_is_alive() {
+        let own_pid = std::process::id();
+        let resp = relaunch_over_prior(Some(own_pid), false).await;
+        assert_eq!(resp.status, ToolLaunchStatus::PriorInstanceAlive);
+        assert!(resp.prior_instance_alive);
+        assert!(resp.launch_id.is_none(), "no second launch is recorded");
+    }
+
+    /// `force=true` is the "Open another instance" button and skips the guard.
+    #[tokio::test]
+    async fn forced_launch_proceeds_over_a_live_prior_instance() {
+        let own_pid = std::process::id();
+        let resp = relaunch_over_prior(Some(own_pid), true).await;
+        assert_eq!(resp.status, ToolLaunchStatus::Success);
+    }
+
+    /// A launch row with no pid and a tool that is not installed cannot be shown
+    /// alive, so the guard stays out of the way.
+    #[tokio::test]
+    async fn launch_proceeds_when_the_prior_launch_recorded_no_identity() {
+        let resp = relaunch_over_prior(None, false).await;
+        assert_eq!(resp.status, ToolLaunchStatus::Success);
     }
 
     #[tokio::test]

--- a/crates/workflow/profiles/Cargo.toml
+++ b/crates/workflow/profiles/Cargo.toml
@@ -20,6 +20,7 @@ fs_pathsafe = { path = "../../fs/pathsafe" }
 # spec 042 (T203): first-wins dedup of discovery results by tool id
 # (replaces the hand-rolled `HashSet`-insert filter).
 itertools = { workspace = true }
+sysinfo = { workspace = true }
 
 [dev-dependencies]
 # Containment fixtures build platform-absolute roots via `test_support`, which the

--- a/crates/workflow/profiles/src/launch.rs
+++ b/crates/workflow/profiles/src/launch.rs
@@ -15,8 +15,7 @@
 //! - **Linux**: `process_group(0)` for session detach.
 //!
 //! No `unsafe` code: `process_group(0)` is a stable safe API since Rust 1.64.
-//! PID liveness uses `std::fs::metadata("/proc/<pid>")` on Linux and a
-//! best-effort path on other Unix platforms (no libc).
+//! Liveness for the re-launch guard is answered by [`prior_launch_is_alive`].
 
 use std::path::Path;
 
@@ -205,30 +204,71 @@ fn spawn_platform(_req: SpawnRequest) -> Result<SpawnResult, LaunchError> {
     Err(LaunchError::SpawnFailed("unsupported platform".to_owned()))
 }
 
-// ── pid_is_alive ──────────────────────────────────────────────────────────────
+// ── Liveness ──────────────────────────────────────────────────────────────────
 
-/// Best-effort check: return `true` when the OS still has a process with `pid`.
+/// Return `true` when the OS still has a live process with `pid`.
 ///
-/// Uses `/proc/<pid>` presence on Linux; `kill -0` is not available without
-/// `unsafe` code, so we fall back to a conservative `false` on other platforms.
-/// The re-launch guard treats `false` as "no prior instance" (safe to launch).
+/// One implementation on every platform: an earlier `/proc/<pid>` check was
+/// `#[cfg(target_os = "linux")]` with a hardcoded `false` elsewhere, which made
+/// the re-launch guard inert on the two platforms the product ships to
+/// (astro-plan-7wu52). `sysinfo` carries the per-platform code behind a safe
+/// API, which the workspace-wide `forbid(unsafe_code)` requires.
+///
+/// An unreaped child has exited and is reported dead. The explicit `Zombie`
+/// status is only ever observed on Linux: macOS drops a zombie from the process
+/// map outright, and Windows has no such state.
 #[must_use]
 pub fn pid_is_alive(pid: u32) -> bool {
-    pid_is_alive_impl(pid)
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessStatus, ProcessesToUpdate};
+
+    let pid = Pid::from_u32(pid);
+    let mut sys = sysinfo::System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        true,
+        ProcessRefreshKind::nothing(),
+    );
+    sys.process(pid).is_some_and(|p| p.status() != ProcessStatus::Zombie)
 }
 
-#[cfg(target_os = "linux")]
-fn pid_is_alive_impl(pid: u32) -> bool {
-    // `/proc/<pid>` exists as long as the process is alive on Linux.
-    std::path::Path::new(&format!("/proc/{pid}")).exists()
+/// Return `true` when macOS Launch Services currently has a running application
+/// with `bundle_id`.
+///
+/// Answers liveness for the `open -b` launch arm, which returns no PID at all
+/// (`spawn_platform` above), so `pid_is_alive` has nothing to check for every
+/// seeded profile on macOS.
+///
+/// This is a point-in-time query, not supervision (constitution III): no child
+/// handle is retained, nothing is polled or awaited, and no signal can be sent.
+/// It is called only when the user attempts a re-launch.
+///
+/// The answer is coarser than the guard's `(project, tool)` scope — it reports
+/// that *an* instance of the tool is running, not that it is the one this
+/// project started. Callers ask only after establishing that their own prior
+/// launch for that pair never completed, and the resulting warning is advisory,
+/// so the coarser answer is preferred over skipping the check.
+///
+/// `/usr/bin/lsappinfo` is absent off macOS, where bundle identifiers do not
+/// exist; the spawn failure is the correct `false`.
+#[must_use]
+pub fn bundle_is_running(bundle_id: &str) -> bool {
+    std::process::Command::new("/usr/bin/lsappinfo")
+        .args(["find", &format!("bundleid={bundle_id}")])
+        .output()
+        .is_ok_and(|out| !out.stdout.trim_ascii().is_empty())
 }
 
-#[cfg(not(target_os = "linux"))]
-fn pid_is_alive_impl(_pid: u32) -> bool {
-    // Conservative: assume not alive on platforms we cannot check safely.
-    // The re-launch guard only fires when this returns `true`, so false negatives
-    // cause the guard to be silently skipped — acceptable for v1.
-    false
+/// Answer the re-launch guard's liveness question from whichever identity the
+/// prior launch managed to record.
+///
+/// A recorded PID is the precise signal and wins outright; `bundle_id` is the
+/// fallback for the macOS `open -b` arm, which records none.
+#[must_use]
+pub fn prior_launch_is_alive(pid: Option<u32>, bundle_id: Option<&str>) -> bool {
+    match pid {
+        Some(pid) => pid_is_alive(pid),
+        None => cfg!(target_os = "macos") && bundle_id.is_some_and(bundle_is_running),
+    }
 }
 
 // ── Verify working-dir containment ────────────────────────────────────────────

--- a/crates/workflow/profiles/tests/liveness.rs
+++ b/crates/workflow/profiles/tests/liveness.rs
@@ -1,0 +1,154 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Real-process liveness for the re-launch guard (astro-plan-7wu52).
+//!
+//! Every assertion here is made against a process the OS genuinely has or
+//! genuinely does not have. A test that only asserted `pid_is_alive` returns
+//! `false` would have passed against the hardcoded-`false` implementation this
+//! file exists to prevent, so the alive direction is what carries the proof.
+
+use workflow_profiles::launch::{bundle_is_running, pid_is_alive, prior_launch_is_alive};
+
+/// The test process itself is unarguably alive on every platform.
+///
+/// This is the assertion the previous `#[cfg(target_os = "linux")]`
+/// implementation failed on macOS and Windows.
+#[test]
+fn the_running_test_process_is_alive() {
+    assert!(pid_is_alive(std::process::id()), "the process making this call is running");
+}
+
+/// A child that has exited and been reaped is gone.
+#[test]
+fn a_reaped_child_is_not_alive() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let record = dir.path().join("record.txt");
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_spawn-stub"))
+        .arg(&record)
+        .spawn()
+        .expect("spawn stub");
+    let pid = child.id();
+    child.wait().expect("reap stub");
+    assert!(!pid_is_alive(pid), "a reaped child leaves no live process");
+}
+
+/// An unreaped child has exited and must read as dead, not as a running tool.
+///
+/// Unix-only because a zombie is a Unix process state; Windows has no
+/// equivalent, so there is nothing to assert there.
+#[cfg(unix)]
+#[test]
+fn an_unreaped_child_is_not_alive() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let record = dir.path().join("record.txt");
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_spawn-stub"))
+        .arg(&record)
+        .spawn()
+        .expect("spawn stub");
+    let pid = child.id();
+
+    // Wait for the stub to publish its record, which it does immediately before
+    // exiting, then leave the child unreaped.
+    for _ in 0..200 {
+        if record.exists() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    assert!(record.exists(), "stub published its record");
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    assert!(!pid_is_alive(pid), "an exited-but-unreaped child is not a running tool");
+    child.wait().expect("reap stub");
+}
+
+/// A pid far above the OS maximum can never belong to a process.
+#[test]
+fn an_impossible_pid_is_not_alive() {
+    assert!(!pid_is_alive(u32::MAX - 1));
+}
+
+/// A recorded pid decides the answer, so a stale bundle id cannot override it.
+#[test]
+fn a_live_pid_wins_over_the_bundle_id_fallback() {
+    assert!(prior_launch_is_alive(Some(std::process::id()), None));
+    assert!(prior_launch_is_alive(Some(std::process::id()), Some("com.example.absent")));
+}
+
+/// A launch that recorded neither identity cannot be shown alive.
+#[test]
+fn no_recorded_identity_is_not_alive() {
+    assert!(!prior_launch_is_alive(None, None));
+}
+
+/// An application that is not installed is not running.
+///
+/// Passes off macOS for a different reason — `lsappinfo` does not exist there —
+/// which is the intended answer on a platform without bundle identifiers.
+#[test]
+fn an_unknown_bundle_id_is_not_running() {
+    assert!(!bundle_is_running("com.example.definitely-not-installed"));
+}
+
+/// An application started the way production starts one — `open -b <bundle_id>`,
+/// the arm that records no pid — is reported running, and stops being reported
+/// once it quits.
+///
+/// `TextEdit` ships with every macOS install. When the developer already has it
+/// open the round trip would close their editor, so that case asserts only the
+/// positive direction and leaves the application alone.
+///
+/// Requires a GUI login session, so this runs on a developer machine and on the
+/// dispatch-only macOS CI chain, never on the Linux runner that gates pull
+/// requests.
+#[cfg(target_os = "macos")]
+#[test]
+fn an_application_launched_by_bundle_id_is_reported_running() {
+    const BUNDLE_ID: &str = "com.apple.TextEdit";
+
+    fn wait_for(want: bool) -> bool {
+        for _ in 0..100 {
+            if bundle_is_running(BUNDLE_ID) == want {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        false
+    }
+
+    if bundle_is_running(BUNDLE_ID) {
+        assert!(prior_launch_is_alive(None, Some(BUNDLE_ID)), "an open TextEdit reads as alive");
+        return;
+    }
+
+    let opened = std::process::Command::new("/usr/bin/open")
+        .args(["-g", "-b", BUNDLE_ID])
+        .status()
+        .expect("run open");
+    assert!(opened.success(), "open -b {BUNDLE_ID} succeeded");
+
+    let running = wait_for(true);
+
+    let quit = std::process::Command::new("/usr/bin/osascript")
+        .args(["-e", &format!(r#"tell application id "{BUNDLE_ID}" to quit"#)])
+        .status();
+
+    assert!(running, "Launch Services reports TextEdit while it is open");
+    assert!(quit.is_ok_and(|s| s.success()), "TextEdit quit cleanly");
+    assert!(wait_for(false), "Launch Services stops reporting TextEdit once it quits");
+}
+
+/// The guard reaches the bundle-id fallback when the launch recorded no pid,
+/// which is every `open -b` launch on macOS.
+#[cfg(target_os = "macos")]
+#[test]
+fn a_pidless_launch_falls_back_to_the_bundle_id() {
+    // Finder is the one application that is always running in a GUI session.
+    assert_eq!(
+        prior_launch_is_alive(None, Some("com.apple.finder")),
+        bundle_is_running("com.apple.finder"),
+        "the pid-less path delegates to the bundle-id query"
+    );
+    assert!(bundle_is_running("com.apple.finder"), "Finder runs in every GUI session");
+}

--- a/specs/011-processing-tool-launch/tasks.md
+++ b/specs/011-processing-tool-launch/tasks.md
@@ -81,7 +81,7 @@ counterparts (contract-backed, audited) are tracked as fresh tasks.
   recorded `pid` is still alive (best-effort `kill 0`), present a modal
   with exactly two buttons: **"Open another instance"** (dispatches
   `force=true`) and **"Cancel"** (aborts) (A3).
-  _Evidence: `ProjectDetail.tsx` — `relaunch-modal` test-id with "Open another instance" / "Cancel" buttons; `launch.rs::pid_is_alive` uses `/proc/<pid>` on Linux_
+  _Evidence: `ProjectDetail.tsx` — `relaunch-modal` test-id with "Open another instance" / "Cancel" buttons; `launch.rs::prior_launch_is_alive` (PID via `sysinfo`, macOS bundle id via `lsappinfo`), covered in `profiles/tests/liveness.rs`_
 
 - [x] **T012b**. Implement cwd library-root containment check in the launch
   use case (R-CwdContain, FR-010): canonicalize `working_dir`; verify it
@@ -218,9 +218,12 @@ T019 (needs T007) ─► T020 ─► T021 ─► T022                         �
 - **args_hash uses SHA-256** not BLAKE3: BLAKE3 is not in the workspace deps; SHA-256
   via `sha2` (already present) is used instead. The field is opaque for correlation
   only. Decision documented in this tasks.md.
-- **pid_is_alive on macOS/Windows**: uses `/proc/<pid>` on Linux only; returns `false`
-  (safe conservative) on other platforms to avoid `unsafe` code (workspace `forbid`).
-  Re-launch guard still works: `false` means guard does not fire, which is safe.
+- **pid_is_alive on macOS/Windows**: RESOLVED (astro-plan-7wu52). The original
+  `/proc/<pid>`-on-Linux-only implementation returned a hardcoded `false` on the two
+  platforms the product ships to, so the T012 guard could never fire there — the
+  "guard still works, `false` is safe" reasoning recorded here was wrong. Liveness is
+  now one `sysinfo`-backed implementation on all platforms, with a macOS Launch
+  Services bundle-id query for the `open -b` arm that records no PID at all.
 - **source-view folder column**: `project.path` is the project root in v1; spec 026
   owns the source-view folder column. `resolve_working_folder` passes `None` until
   spec 026 wires it.


### PR DESCRIPTION
## Summary

- The warning shown before starting a second processing-tool run over one that
  is still in progress never appeared on Windows or macOS. It now does.
- On macOS the app usually has no process id for a tool it launched through
  Launch Services, so the check asks macOS whether the application is running
  instead. Nothing is polled or supervised — the question is asked once, when
  you click Launch again.

Work bead `astro-plan-7wu52`. Merge bead `astro-plan-a7fcq`.

## The defect

`workflow_profiles::launch::pid_is_alive` was `#[cfg(target_os = "linux")]` over
`/proc/<pid>`, with a `#[cfg(not(target_os = "linux"))]` arm returning a
hardcoded `false`. The re-launch guard in `crates/app/core/src/tool_launch.rs`
gated on `prior.pid.is_some_and(pid_is_alive)`.

The warning that stops a user starting a second PixInsight or Siril run over an
in-progress one therefore could not fire on Windows or macOS — the only two
platforms the product ships to. It worked on Linux, which no user runs.

No test and no journey asserted the warning. The one test that carried its name,
`launch_prior_instance_alive_without_force`, asserted the guard does *not* fire,
and its own comment conceded "we can't reliably test 'alive' in unit tests
without spawning".

## What the guard is for

Per `specs/011-processing-tool-launch/research.md` (R4) and spec.md acceptance
scenario 3, it is an advisory interstitial, not a lock: when the latest launch
for a `(project, tool)` pair has `completed_at = NULL` and the tool still looks
alive, the user is offered "Open another instance" and "Cancel". Its whole value
is on the desktop, and on the desktop it was inert. Implementing it was chosen
over removing it: the design is sound and cheap to honour, and the alternative
leaves a user who double-clicks Launch with two PixInsight instances competing
over the same source-view folder and no signal that they did so.

## Liveness

One implementation on every platform, via `sysinfo`. The whole `cfg` split is
gone, so the path Windows and macOS take is the path the Linux runner exercises
on every pull request.

macOS needed more than a working `pid_is_alive`. The `open -b <bundle_id>` arm —
which every seeded profile with a bundle id takes on macOS — returns no PID at
all, so the guard failed at `is_some()` before liveness was consulted.
`prior_launch_is_alive` therefore prefers a recorded PID and falls back to
`lsappinfo find bundleid=<id>`, a Launch Services query.

**Why that is not supervision.** Constitution III and
`.claude/rules/21-astro-monorepo.md` forbid the app supervising or killing a
processing tool. Supervision means retaining a handle to the child, waiting on
or polling it, and being able to signal it. This does none of those: it is a
single question asked of the OS at the moment the user clicks Launch again,
answered from state the OS already keeps, with no handle retained between calls
and no ability to affect the process. The app remains unable to observe the
tool's exit — `completed_at` still comes from artifact observation (spec 012),
not from here.

The bundle-id answer is coarser than the guard's `(project, tool)` scope: it
reports that an instance of the tool is running, not that it is the one this
project started. It is only asked after the caller has established that its own
prior launch for that pair never completed, and the outcome is a dismissable
warning, so the coarser answer is preferred over skipping the check. This is
recorded on `bundle_is_running`.

## Why a dependency rather than a hand-roll

`kill(pid, 0)` and `OpenProcess` are both unreachable: the workspace sets
`unsafe_code = "forbid"`. `rustix` is already in the tree with a safe API but
covers Unix only. Shelling out to `tasklist` on Windows would add no dependency
and would rebuild the three-way platform branch this PR exists to delete, on the
one platform that could not be tested from here.

`sysinfo` is pinned to `default-features = false, features = ["system"]`, the
smallest unit that includes process listing. It adds `windows`, `ntapi`, and
`objc2-io-kit` to the lockfile; `windows` is Windows-only build weight and is the
real cost of this choice.

## Tests

`crates/workflow/profiles/tests/liveness.rs` (new, 9 tests) plus three rewritten
guard tests in `tool_launch.rs`. Every assertion is against a process the OS
genuinely has or genuinely does not have — the test process itself, or a real
`spawn-stub` child spawned and reaped. `FakeSpawner` is not used for liveness:
a fake that reports liveness would assert only that the fixture was configured.

A test asserting `pid_is_alive` returns `false` would have passed against the
defect, so each test was confirmed failing against a reverted or mutated
implementation:

| Mutation | Tests that failed |
|---|---|
| `pid_is_alive` reverted to the pre-fix `false`-off-Linux behaviour | `the_running_test_process_is_alive`, `a_live_pid_wins_over_the_bundle_id_fallback`, `launch_is_refused_while_the_prior_instance_is_alive` |
| `pid_is_alive` forced to `true` | `an_impossible_pid_is_not_alive`, `a_reaped_child_is_not_alive`, `an_unreaped_child_is_not_alive` |
| `bundle_is_running` forced to `false` | `a_pidless_launch_falls_back_to_the_bundle_id`, `an_application_launched_by_bundle_id_is_reported_running` |
| bundle-id fallback dropped from `prior_launch_is_alive` | `no_recorded_identity_is_not_alive` |

No test survived all four mutations.

### What is not verified

- **Windows.** Not exercised at all. `sysinfo`'s Windows process enumeration is
  taken on the crate's authority; the Windows CI job runs only on pushes to
  `main`, and the Windows host was held by other work. The PID path is the same
  code the Linux runner exercises, which is the strongest claim available here
  and is weaker than a run on Windows.
- **macOS bundle-id tests on CI.** The two macOS-only tests need a GUI login
  session. They pass locally on Darwin 25.3.0; the macOS CI chain is
  dispatch-only, so the Linux runner that gates pull requests skips them.
- **Zombie handling off Linux.** `ProcessStatus::Zombie` is only ever observed on
  Linux — macOS drops a zombie from the process map outright and Windows has no
  such state. The answer ("dead") is the same on all three; the mechanism is not.
- The re-launch warning still has no journey coverage. Not addressed here:
  `docs/journeys/` is owned by #1756.

## Platform-`cfg` census

Every `cfg` / `cfg!` under `crates/` naming a platform predicate
(`target_os`, `target_family`, `target_env`, `target_vendor`, `windows`, `unix`,
`macos`, `linux`): **135 lines across 39 files**. A deliberately looser pattern
returned the identical 135, so no exception is hiding behind the convention. The
pattern was checked against `launch.rs:226` — the known defect — before the count
was trusted. `cfg_attr` platform sites: 0.

Of those, **6** have a body that could be read as a constant:

| Site | Verdict |
|---|---|
| `workflow/profiles/src/launch.rs:226` | **the defect**, fixed here |
| `workflow/profiles/src/discover.rs:339` — `vec![]` off the three supported targets | deliberate: no known install locations to search |
| `fs/inventory/src/drive_scope.rs:55` — `volume_id` → `None` off unix and windows | deliberate: no such platform ships |
| `app/projects/src/source_view_generate/generate.rs:413` — long-path warning skipped off Windows | deliberate: `MAX_PATH` is a Windows constraint |
| `app/core/src/first_run/mod.rs:160` | false positive of the heuristic — the `None` is a shared `if`/`else` tail. This is the site of `astro-plan-zjf88` (root-overlap case-folding only on Windows), fixed concurrently in #1758, not touched here |
| `fs/pathsafe/src/lib.rs:66` | false positive — the `false` is the shared tail after a Windows-only reparse-point check |

**No lint or shared primitive is warranted.** A rule flagging "platform `cfg`
branch returning a constant" would fire on 5 sites to catch 1. The two real
defects in this class share no mechanism — one is a missing platform
implementation, the other an inverted case-sensitivity assumption — so there is
nothing to extract. The durable measure is the one taken here: the site no longer
branches on platform at all.

## Also corrected

- `specs/011-processing-tool-launch/tasks.md` recorded the limitation with the
  reasoning "Re-launch guard still works: `false` means guard does not fire,
  which is safe." That was wrong and is now marked resolved.
- `.claude/rules/21-astro-monorepo.md` described the guard as firing on "a live
  PID", which was never true off Linux.

## Verification

All commands run in `~/tmp/worktrees/platevault/fix-pidalive-relaunch-guard`
with `CARGO_TARGET_DIR=~/tmp/cargo-target/pidalive`, on macOS (Darwin 25.3.0),
after merging `origin/main` at `83bfd4718`.

| Command | Exit |
|---|---|
| `cargo test -p workflow_profiles -p app_core` | 0 — 30 test binaries, 0 failures |
| `cargo clippy -p workflow_profiles -p app_core --all-targets` | 0 — no warnings |
| `cargo fmt --all -- --check` | 0 |
| `pre-commit run --files <committed files>` | 0 — 10 hooks, 0 failures |

`core.hooksPath` on this machine is redirected to git-defender, so the repository
pre-commit hook does not run on commit; it was run explicitly, hence the row
above.

## Spec Context

Spec 011 (processing tool launch), T012 re-launch warning.
